### PR TITLE
docs: add KPI definition notes to analytics pages

### DIFF
--- a/src/components/dashboard/WeeklyReviewCard.tsx
+++ b/src/components/dashboard/WeeklyReviewCard.tsx
@@ -335,7 +335,7 @@ export function WeeklyReviewCard({ data, phase, enrichedAvailability }: Props) {
 
       {/* ── フッター ── */}
       <div className="flex items-center justify-between border-t border-slate-50 bg-slate-50 px-5 py-2 text-[11px] text-slate-400">
-        <span>体重は 7 日移動平均 / トレンドは 14 日線形回帰 / あくまで推定値です</span>
+        <span>体重は直近7暦日の移動平均 / トレンドは直近14暦日の線形回帰 / 栄養は直近7暦日の記録平均 / あくまで推定値です</span>
         <span className={`font-semibold ${qualityScoreColor(quality.score)}`}>
           品質 {quality.score}/100
         </span>

--- a/src/components/macro/MacroKpiCards.tsx
+++ b/src/components/macro/MacroKpiCards.tsx
@@ -62,9 +62,10 @@ export function MacroKpiCards({ kpi, targets, diff }: MacroKpiCardsProps) {
           <div className="mt-1">
             <WeekDelta curr={weekly.avgCalories} prev={prevWeekly.avgCalories} unit="kcal" />
           </div>
+          <p className="mt-1.5 text-xs text-slate-400">直近7記録日の平均</p>
           {/* TDEE 接続導線 */}
           {diff.calories !== null && (
-            <p className="mt-2 text-xs text-slate-400">
+            <p className="mt-1 text-xs text-slate-400">
               {diff.calories > 100
                 ? "目標を超過 — 収支は TDEE 画面で確認できます"
                 : diff.calories < -100
@@ -92,7 +93,7 @@ export function MacroKpiCards({ kpi, targets, diff }: MacroKpiCardsProps) {
               : "—"}
           </p>
           <p className={`mt-1 text-sm font-medium ${paceColor}`}>{paceLabel}</p>
-          <p className="mt-2 text-xs text-slate-400">直近7日 vs 前7日の平均体重比</p>
+          <p className="mt-2 text-xs text-slate-400">直近7記録日 vs 前7記録日 の平均体重比</p>
         </div>
       </div>
 
@@ -114,6 +115,7 @@ export function MacroKpiCards({ kpi, targets, diff }: MacroKpiCardsProps) {
             <div className="mt-1">
               <WeekDelta curr={actual} prev={prevActual} unit={unit} />
             </div>
+            <p className="mt-1.5 text-xs text-slate-400">直近7記録日の平均</p>
           </div>
         ))}
       </div>

--- a/src/components/tdee/TdeeKpiCard.tsx
+++ b/src/components/tdee/TdeeKpiCard.tsx
@@ -80,7 +80,7 @@ export function TdeeKpiCard({
             <span className="ml-1 text-base font-normal text-gray-400">kcal</span>
           </p>
           <p className="mt-1 text-xs text-gray-400">
-            Macro 画面の週平均摂取と同一定義
+            直近7記録日の平均（ML バッチ実行時は 7 暦日ローリング平均）
           </p>
         </div>
 
@@ -92,7 +92,7 @@ export function TdeeKpiCard({
             <span className="ml-1 text-base font-normal text-gray-400">kcal</span>
           </p>
           <p className="mt-1 text-xs text-gray-400">
-            体重推移を平滑化して逆算（短期ノイズを除去）
+            体重平滑化から逆算した推定値の直近7日平均（バッチ計算値）
             {theoreticalTdee !== null && (
               <> — 理論値 {Math.round(theoreticalTdee).toLocaleString()} kcal</>
             )}
@@ -146,8 +146,8 @@ export function TdeeKpiCard({
           </p>
           <p className="mt-1 text-xs text-gray-400">
             {measuredWeightChange !== null
-              ? "直近7日 vs 前7日の平均体重差"
-              : "前週の体重データが不足しています"}
+              ? "直近7記録日 vs 前7記録日 の平均体重差"
+              : "前週の体重データが不足しています（直近7記録日）"}
           </p>
         </div>
       </div>


### PR DESCRIPTION
## 概要

分析系ページの各 KPI に定義注記を追加し、数値の意味の誤読を防ぐ。

## 追加・修正した KPI 注記

### TdeeKpiCard（TDEE 画面）

| KPI | 変更前 | 変更後 |
|---|---|---|
| 平均摂取（直近7日）| "Macro 画面の週平均摂取と同一定義" | "直近7記録日の平均（ML バッチ実行時は 7 暦日ローリング平均）" |
| 実測 TDEE（7日平均）| "体重推移を平滑化して逆算（短期ノイズを除去）" | "体重平滑化から逆算した推定値の直近7日平均（バッチ計算値）" |
| 実測変化（体重推移）| "直近7日 vs 前7日の平均体重差" | "直近7記録日 vs 前7記録日 の平均体重差" |

### MacroKpiCards（栄養分析画面）

| KPI | 変更前 | 変更後 |
|---|---|---|
| 週平均カロリー | 注記なし | "直近7記録日の平均" を追加 |
| 週次体重変化 | "直近7日 vs 前7日の平均体重比" | "直近7記録日 vs 前7記録日 の平均体重比" |
| P / F / C カード | 注記なし | "直近7記録日の平均" を追加 |

### WeeklyReviewCard（ダッシュボード週次レビュー）

フッター: "体重は 7 日移動平均 / トレンドは 14 日線形回帰 / あくまで推定値です"
→ "体重は直近7暦日の移動平均 / トレンドは直近14暦日の線形回帰 / 栄養は直近7暦日の記録平均 / あくまで推定値です"

## 7暦日 / 7記録日 の表記整理

- **7暦日**: `calcReadiness` / `calcWeeklyReview` が使用（`dateRangeStr` による暦日ウィンドウ）
- **7記録日**: `calcMacroKpi` / TDEE ページ fallback が使用（`sorted.slice(-7)` による記録順）
- ML バッチ（enrich.py）の `avg_calories_7d` / `avg_tdee_7d` は 7暦日ローリング平均

各 KPI の実装と一致した表記を適用。

## fallback 文言の統一

- 「実測変化」の fallback: "前週の体重データが不足しています" → "前週の体重データが不足しています（直近7記録日）" に期間を追記
- ページ上部バナー（error / unavailable / stale）は既に整合しているため変更なし

## テスト

- `npx tsc --noEmit` エラーなし
- `npx jest --no-coverage` 556 tests PASS

## 影響範囲

UI の注記テキストのみ変更。計算ロジック・表示値・レイアウトへの変更なし。

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)