### PR TITLE
fix: tighten log_date validation in saveDailyLog

### DIFF
--- a/src/app/actions/__tests__/saveDailyLog.test.ts
+++ b/src/app/actions/__tests__/saveDailyLog.test.ts
@@ -466,6 +466,80 @@ describe("saveDailyLog — 連続保存シナリオ（体重→macro）", () => 
   });
 });
 
+describe("saveDailyLog — log_date バリデーション", () => {
+  // 正常系
+  test("通常の日付 → ok: true", async () => {
+    makeClientMock(null);
+    const result = await saveDailyLog({ log_date: "2026-03-13", weight: 70.0 });
+    expect(result.ok).toBe(true);
+  });
+
+  test("うるう年 2月29日 (2024) → ok: true", async () => {
+    makeClientMock(null);
+    const result = await saveDailyLog({ log_date: "2024-02-29", weight: 70.0 });
+    expect(result.ok).toBe(true);
+  });
+
+  test("月末 1月31日 → ok: true", async () => {
+    makeClientMock(null);
+    const result = await saveDailyLog({ log_date: "2026-01-31", weight: 70.0 });
+    expect(result.ok).toBe(true);
+  });
+
+  test("月末 4月30日 → ok: true", async () => {
+    makeClientMock(null);
+    const result = await saveDailyLog({ log_date: "2026-04-30", weight: 70.0 });
+    expect(result.ok).toBe(true);
+  });
+
+  // 異常系: フォーマット不正
+  test("スラッシュ区切り (2026/03/13) → ok: false", async () => {
+    const result = await saveDailyLog({ log_date: "2026/03/13", weight: 70.0 });
+    expect(result.ok).toBe(false);
+  });
+
+  test("空文字 → ok: false", async () => {
+    const result = await saveDailyLog({ log_date: "", weight: 70.0 });
+    expect(result.ok).toBe(false);
+  });
+
+  test("数字のみ (20260313) → ok: false", async () => {
+    const result = await saveDailyLog({ log_date: "20260313", weight: 70.0 });
+    expect(result.ok).toBe(false);
+  });
+
+  test("任意文字列 ('abc') → ok: false", async () => {
+    const result = await saveDailyLog({ log_date: "abc", weight: 70.0 });
+    expect(result.ok).toBe(false);
+  });
+
+  // 異常系: 実在しない日付
+  test("非うるう年 2月29日 (2026) → ok: false", async () => {
+    const result = await saveDailyLog({ log_date: "2026-02-29", weight: 70.0 });
+    expect(result.ok).toBe(false);
+  });
+
+  test("存在しない日 4月31日 → ok: false", async () => {
+    const result = await saveDailyLog({ log_date: "2026-04-31", weight: 70.0 });
+    expect(result.ok).toBe(false);
+  });
+
+  test("存在しない月 13月 → ok: false", async () => {
+    const result = await saveDailyLog({ log_date: "2026-13-01", weight: 70.0 });
+    expect(result.ok).toBe(false);
+  });
+
+  test("0月 → ok: false", async () => {
+    const result = await saveDailyLog({ log_date: "2026-00-01", weight: 70.0 });
+    expect(result.ok).toBe(false);
+  });
+
+  test("0日 → ok: false", async () => {
+    const result = await saveDailyLog({ log_date: "2026-01-00", weight: 70.0 });
+    expect(result.ok).toBe(false);
+  });
+});
+
 describe("saveDailyLog — Phase 2.5 バリデーション", () => {
   test("sleep_hours が 25 → ok: false", async () => {
     const result = await saveDailyLog({ log_date: "2026-03-13", sleep_hours: 25 });

--- a/src/app/actions/saveDailyLog.ts
+++ b/src/app/actions/saveDailyLog.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { isValidTrainingType, isValidWorkMode } from "@/lib/utils/trainingType";
 import { buildUpdatePayload } from "./buildUpdatePayload";
+import { parseLocalDateStr } from "@/lib/utils/date";
 
 /**
  * フィールドの意味:
@@ -46,16 +47,13 @@ export type SaveDailyLogResult =
   | { ok: true }
   | { ok: false; message: string };
 
-/** ISO 8601 日付文字列 (YYYY-MM-DD) かどうか */
-function isValidDate(s: string): boolean {
-  return /^\d{4}-\d{2}-\d{2}$/.test(s) && !isNaN(Date.parse(s));
-}
-
 export async function saveDailyLog(
   input: SaveDailyLogInput
 ): Promise<SaveDailyLogResult> {
   // --- サーバー側バリデーション ---
-  if (!isValidDate(input.log_date)) {
+  // parseLocalDateStr は形式・月範囲・実在日付をローカル解釈で厳密検証する。
+  // Date.parse は環境依存・実在日未検証のため使用しない。
+  if (parseLocalDateStr(input.log_date) === null) {
     return { ok: false, message: "日付の形式が正しくありません" };
   }
 


### PR DESCRIPTION
## 概要

`saveDailyLog` の日付バリデーションを `Date.parse` 依存から除去し、既存の `parseLocalDateStr` による厳密なローカル日付検証に統一する。

## 変更内容

### `src/app/actions/saveDailyLog.ts`

```diff
- /** ISO 8601 日付文字列 (YYYY-MM-DD) かどうか */
- function isValidDate(s: string): boolean {
-   return /^\d{4}-\d{2}-\d{2}$/.test(s) && !isNaN(Date.parse(s));
- }
  ...
- if (!isValidDate(input.log_date)) {
+ // parseLocalDateStr は形式・月範囲・実在日付をローカル解釈で厳密検証する。
+ // Date.parse は環境依存・実在日未検証のため使用しない。
+ if (parseLocalDateStr(input.log_date) === null) {
```

`parseLocalDateStr` は `src/lib/utils/date.ts` に既存の関数で、以下を全て検証する:
- `YYYY-MM-DD` 形式チェック
- 月が 1〜12 の範囲
- **実在する年月日**（`2026-02-29` や `2026-04-31` を弾く）
- `new Date(y, m-1, d)` によるローカル解釈（UTC 依存なし）

## 日付バリデーション方針

| 検証項目 | 変更前 (`Date.parse`) | 変更後 (`parseLocalDateStr`) |
|---|---|---|
| フォーマット (`YYYY-MM-DD`) | regex で検証 | 同等 |
| 実在する年月日 | **未検証** (`Date.parse` は `2026-02-31` などを通す場合がある) | **厳密に検証** |
| ローカル日付解釈 | 環境依存 | `new Date(y, m-1, d)` でローカル固定 |
| 再利用性 | ad hoc 関数 | date.ts の共通 utility を使用 |

## テスト (`src/app/actions/__tests__/saveDailyLog.test.ts`)

`saveDailyLog — log_date バリデーション` describe ブロックを新設（13件追加）:

**正常系**
- 通常の日付 `2026-03-13` → ok: true
- うるう年 `2024-02-29` → ok: true
- 月末 `2026-01-31` → ok: true
- 月末 `2026-04-30` → ok: true

**異常系: フォーマット不正**
- スラッシュ区切り `2026/03/13` → ok: false
- 空文字 → ok: false
- 数字のみ `20260313` → ok: false
- 任意文字列 `abc` → ok: false

**異常系: 実在しない日付**
- 非うるう年 2月29日 `2026-02-29` → ok: false
- 存在しない日 `2026-04-31` → ok: false
- 存在しない月 `2026-13-01` → ok: false
- 0月 `2026-00-01` → ok: false
- 0日 `2026-01-00` → ok: false

全 572 件パス (`node_modules/.bin/jest --no-coverage`)、`npx tsc --noEmit` エラーなし。

## 影響範囲

- `saveDailyLog` の日付不正入力に対するエラーメッセージは変更なし（「日付の形式が正しくありません」）
- 正常な `YYYY-MM-DD` 入力の挙動は変わらない
- `parseLocalDateStr` 自体は変更なし（既存テスト `date.test.ts` も全通過）

## 残課題（別 Issue 対応）

- CSV インポート時の日付バリデーションは `csvParser.ts` 内で別途 regex + normalize 処理をしており、こちらは今回スコープ外。別途レビューが必要であれば Issue 化する。

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)