### PR TITLE
refactor: make saveDailyLog atomic

### DIFF
--- a/src/app/actions/__tests__/saveDailyLog.test.ts
+++ b/src/app/actions/__tests__/saveDailyLog.test.ts
@@ -23,47 +23,36 @@ const mockCreateClient = createClient as jest.MockedFunction<typeof createClient
 
 // ── Supabase クライアントモックヘルパー ─────────────────────────────────────
 
-type CapturedCalls = { insert?: unknown; update?: unknown };
+/** saveDailyLog の RPC 呼び出し引数をキャプチャする型 */
+type RpcCapture = {
+  name?: string;
+  p_log_date?: string;
+  p_fields?: Record<string, unknown>;
+};
 
 /**
- * saveDailyLog が内部で呼ぶ Supabase チェーンをシミュレートするモック。
+ * saveDailyLog が内部で呼ぶ supabase.rpc() をモックする。
  *
- * from() は2回呼ばれる:
- *   1回目: .select("log_date").eq().maybeSingle() — 既存レコード確認
- *   2回目: .update(payload).eq() または .insert(payload)
+ * save_daily_log_partial RPC に渡された引数を capture に記録するので、
+ * テスト側で p_log_date / p_fields の内容を検証できる。
  *
- * captured に呼び出し時の引数を書き込むので、テスト側で検証できる。
+ * @param rpcError - RPC が返すエラー（省略時は null = 成功）
  */
-function makeClientMock(
-  existingRecord: { log_date: string } | null,
-  captured: CapturedCalls = {}
-) {
-  const eqForUpdate = jest.fn().mockResolvedValue({ error: null });
-  const updateFn = jest.fn().mockImplementation((payload: unknown) => {
-    captured.update = payload;
-    return { eq: eqForUpdate };
-  });
-  const insertFn = jest.fn().mockImplementation((payload: unknown) => {
-    captured.insert = payload;
-    return Promise.resolve({ error: null });
-  });
-  const maybeSingleFn = jest
-    .fn()
-    .mockResolvedValue({ data: existingRecord, error: null });
-  const eqForSelect = jest
-    .fn()
-    .mockReturnValue({ maybeSingle: maybeSingleFn });
-  const selectFn = jest.fn().mockReturnValue({ eq: eqForSelect });
+function makeRpcMock(rpcError?: { message: string }): RpcCapture {
+  const capture: RpcCapture = {};
 
   mockCreateClient.mockReturnValueOnce({
-    from: jest.fn().mockReturnValue({
-      select: selectFn,
-      update: updateFn,
-      insert: insertFn,
-    }),
+    rpc: jest.fn().mockImplementation(
+      (name: string, args: { p_log_date: string; p_fields: Record<string, unknown> }) => {
+        capture.name      = name;
+        capture.p_log_date = args.p_log_date;
+        capture.p_fields  = args.p_fields;
+        return Promise.resolve({ error: rpcError ?? null });
+      }
+    ),
   } as unknown as ReturnType<typeof createClient>);
 
-  return captured;
+  return capture;
 }
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -314,23 +303,29 @@ describe("buildUpdatePayload — null による明示的クリア", () => {
 });
 
 // ════════════════════════════════════════════════════════════════════════════
-// 2. saveDailyLog action — Supabase モックを使った結合テスト
+// 2. saveDailyLog action — Supabase RPC モックを使った結合テスト
+//
+// read-then-write (select → insert/update 分岐) を廃止し、
+// save_daily_log_partial RPC の 1 呼び出しで atomic upsert を実現している。
+// テストは RPC への引数 (p_log_date, p_fields) を検証する。
 // ════════════════════════════════════════════════════════════════════════════
 
-describe("saveDailyLog — insert / partial update の分岐", () => {
-  // ケース1: 既存レコードなし → insert が呼ばれ、渡したフィールドのみ含まれる
-  test("新規日付 → insert が呼ばれる", async () => {
-    const captured = makeClientMock(null);
+describe("saveDailyLog — atomic upsert (RPC 呼び出し検証)", () => {
+  test("weight のみ → RPC が save_daily_log_partial で呼ばれ p_fields に weight が含まれる", async () => {
+    const capture = makeRpcMock();
     const result = await saveDailyLog({ log_date: "2026-03-13", weight: 70.5 });
 
     expect(result.ok).toBe(true);
-    expect(captured.insert).toEqual({ log_date: "2026-03-13", weight: 70.5 });
-    expect(captured.update).toBeUndefined();
+    expect(capture.name).toBe("save_daily_log_partial");
+    expect(capture.p_log_date).toBe("2026-03-13");
+    expect(capture.p_fields?.weight).toBe(70.5);
+    // 未指定フィールドは p_fields に含まれない
+    expect("calories" in (capture.p_fields ?? {})).toBe(false);
+    expect("protein"  in (capture.p_fields ?? {})).toBe(false);
   });
 
-  // ケース2: 既存レコードあり → update が呼ばれ、渡したフィールドのみ含まれる
-  test("既存日付 → update が呼ばれる", async () => {
-    const captured = makeClientMock({ log_date: "2026-03-13" });
+  test("macro のみ → p_fields に calories/protein が含まれ weight は含まれない", async () => {
+    const capture = makeRpcMock();
     const result = await saveDailyLog({
       log_date: "2026-03-13",
       calories: 2000,
@@ -338,50 +333,59 @@ describe("saveDailyLog — insert / partial update の分岐", () => {
     });
 
     expect(result.ok).toBe(true);
-    expect(captured.update).toEqual({ calories: 2000, protein: 150 });
-    expect(captured.insert).toBeUndefined();
+    expect(capture.p_fields?.calories).toBe(2000);
+    expect(capture.p_fields?.protein).toBe(150);
+    expect("weight" in (capture.p_fields ?? {})).toBe(false);
   });
 
-  // ケース3: 全フィールド undefined → エラー（no-op ではなくエラー扱い）
+  // 全フィールド undefined → DB アクセスなしでエラー
   //
   // 設計判断: 全フィールド undefined の送信は「保存するデータがない」エラーとする。
   //   - no-op 成功にすると、フォームの空送信や実装バグが検出できなくなる
-  //   - サーバー側のガードとして明示的に弾き、DB アクセスも行わない
+  //   - サーバー側のガードとして明示的に弾き、RPC も呼ばない
   //   - UI 側 (MealLogger の hasContent チェック) で通常は防がれるため、
   //     このパスはプログラミングエラー検出が主目的
   test("全フィールド undefined → ok: false (保存するデータがありません)", async () => {
-    // このケースは Supabase に届く前に弾かれるのでモック不要
     const result = await saveDailyLog({ log_date: "2026-03-13" });
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.message).toBe("保存するデータがありません");
     }
   });
+
+  test("RPC がエラーを返す → ok: false", async () => {
+    makeRpcMock({ message: "DB error" });
+    const result = await saveDailyLog({ log_date: "2026-03-13", weight: 70.5 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("保存に失敗しました");
+    }
+  });
 });
 
 describe("saveDailyLog — 連続保存シナリオ（体重→macro）", () => {
   /**
-   * 主要ユースケース:
-   *   1回目: 朝に体重だけ保存 → insert
-   *   2回目: 夜に食事 macro を保存 → update (weight はペイロードに含まれない)
+   * RPC ベースでの partial update 意味論の確認。
    *
-   * weight がペイロードに含まれないことで、DB 上の weight が維持されることを保証する。
-   * (実際の DB 値の維持は Supabase 側の動作に委ねられるが、
-   *  update payload に weight が入らないことをここで保証する)
+   * 旧: 1回目 insert / 2回目 update と分岐していた。
+   * 新: 両回とも同じ RPC を呼ぶ。p_fields に「送ったフィールドのみ」が含まれることで
+   *     DB 側の ON CONFLICT CASE WHEN により未指定フィールドが保持される。
+   *
+   * テストが担保すること:
+   *   - 2回目の p_fields に weight が含まれないこと（RPC が weight を触らない = 保持）
    */
-  test("1回目で weight 保存、2回目で macro 保存しても weight がペイロードに含まれない", async () => {
-    // --- 1回目: 新規日付に weight のみ保存 ---
-    const captured1 = makeClientMock(null);
+  test("weight 保存後に macro のみ保存: 2回目 p_fields に weight が含まれない", async () => {
+    // --- 1回目: weight のみ ---
+    const capture1 = makeRpcMock();
     const result1 = await saveDailyLog({ log_date: "2026-03-13", weight: 70.5 });
 
     expect(result1.ok).toBe(true);
-    expect(captured1.insert).toEqual({ log_date: "2026-03-13", weight: 70.5 });
-    // macro 系・タグ・note は insert にも含まれない
-    expect("calories" in (captured1.insert as object)).toBe(false);
-    expect("protein"  in (captured1.insert as object)).toBe(false);
+    expect(capture1.p_fields?.weight).toBe(70.5);
+    expect("calories" in (capture1.p_fields ?? {})).toBe(false);
+    expect("protein"  in (capture1.p_fields ?? {})).toBe(false);
 
-    // --- 2回目: 同日付に macro のみ追記 ---
-    const captured2 = makeClientMock({ log_date: "2026-03-13" });
+    // --- 2回目: macro のみ ---
+    const capture2 = makeRpcMock();
     const result2 = await saveDailyLog({
       log_date: "2026-03-13",
       calories: 2000,
@@ -391,62 +395,73 @@ describe("saveDailyLog — 連続保存シナリオ（体重→macro）", () => 
     });
 
     expect(result2.ok).toBe(true);
-    // update が呼ばれ、macro 4項目だけを含む
-    expect(captured2.update).toEqual({
-      calories: 2000,
-      protein: 150,
-      fat: 60,
-      carbs: 200,
-    });
-    // weight はペイロードに含まれない → DB 上の weight=70.5 は保持される
-    expect("weight" in (captured2.update as object)).toBe(false);
-    expect("note"   in (captured2.update as object)).toBe(false);
-    expect("is_cheat_day" in (captured2.update as object)).toBe(false);
-    expect(captured2.insert).toBeUndefined();
+    // macro 4 項目のみ p_fields に含まれる
+    expect(capture2.p_fields?.calories).toBe(2000);
+    expect(capture2.p_fields?.protein).toBe(150);
+    expect(capture2.p_fields?.fat).toBe(60);
+    expect(capture2.p_fields?.carbs).toBe(200);
+    // weight は p_fields になし → RPC は weight を触らない → DB 値は保持される
+    expect("weight"       in (capture2.p_fields ?? {})).toBe(false);
+    expect("note"         in (capture2.p_fields ?? {})).toBe(false);
+    expect("is_cheat_day" in (capture2.p_fields ?? {})).toBe(false);
   });
 
-  test("タグのみ更新しても macro・weight が保持される", async () => {
-    const captured = makeClientMock({ log_date: "2026-03-13" });
+  test("タグのみ保存: p_fields に is_cheat_day のみ、weight・macro は含まれない", async () => {
+    const capture = makeRpcMock();
     const result = await saveDailyLog({
       log_date: "2026-03-13",
       is_cheat_day: true,
     });
 
     expect(result.ok).toBe(true);
-    expect(captured.update).toEqual({ is_cheat_day: true });
-    expect("weight"   in (captured.update as object)).toBe(false);
-    expect("calories" in (captured.update as object)).toBe(false);
+    expect(capture.p_fields?.is_cheat_day).toBe(true);
+    expect("weight"   in (capture.p_fields ?? {})).toBe(false);
+    expect("calories" in (capture.p_fields ?? {})).toBe(false);
   });
 
-  test("note のみ更新しても他フィールドが保持される", async () => {
-    const captured = makeClientMock({ log_date: "2026-03-13" });
+  test("note のみ保存: p_fields に note のみ、他フィールドは含まれない", async () => {
+    const capture = makeRpcMock();
     const result = await saveDailyLog({
       log_date: "2026-03-13",
       note: "体調良好",
     });
 
     expect(result.ok).toBe(true);
-    expect(captured.update).toEqual({ note: "体調良好" });
-    expect("weight"      in (captured.update as object)).toBe(false);
-    expect("calories"    in (captured.update as object)).toBe(false);
-    expect("is_cheat_day" in (captured.update as object)).toBe(false);
+    expect(capture.p_fields?.note).toBe("体調良好");
+    expect("weight"       in (capture.p_fields ?? {})).toBe(false);
+    expect("calories"     in (capture.p_fields ?? {})).toBe(false);
+    expect("is_cheat_day" in (capture.p_fields ?? {})).toBe(false);
   });
 
-  test("training_type 保存時に leg_flag が同時に insert される", async () => {
-    const captured = makeClientMock(null);
+  test("training_type 保存時に leg_flag が p_fields に同時に含まれる", async () => {
+    const capture = makeRpcMock();
     const result = await saveDailyLog({
       log_date: "2026-03-13",
       training_type: "quads",
     });
 
     expect(result.ok).toBe(true);
-    const inserted = captured.insert as Record<string, unknown>;
-    expect(inserted.training_type).toBe("quads");
-    expect(inserted.leg_flag).toBe(true);
+    expect(capture.p_fields?.training_type).toBe("quads");
+    // leg_flag は buildUpdatePayload が training_type から導出して追加する
+    expect(capture.p_fields?.leg_flag).toBe(true);
   });
 
-  test("sleep_hours・had_bowel_movement・work_mode の単体保存", async () => {
-    const captured = makeClientMock({ log_date: "2026-03-13" });
+  test("training_type: null → leg_flag も null で p_fields に含まれる（明示クリア）", async () => {
+    const capture = makeRpcMock();
+    const result = await saveDailyLog({
+      log_date: "2026-03-13",
+      training_type: null,
+    });
+
+    expect(result.ok).toBe(true);
+    expect("training_type" in (capture.p_fields ?? {})).toBe(true);
+    expect(capture.p_fields?.training_type).toBeNull();
+    expect("leg_flag" in (capture.p_fields ?? {})).toBe(true);
+    expect(capture.p_fields?.leg_flag).toBeNull();
+  });
+
+  test("sleep_hours・had_bowel_movement・work_mode のみ保存: 他フィールドは含まれない", async () => {
+    const capture = makeRpcMock();
     const result = await saveDailyLog({
       log_date: "2026-03-13",
       sleep_hours: 7.0,
@@ -455,39 +470,49 @@ describe("saveDailyLog — 連続保存シナリオ（体重→macro）", () => 
     });
 
     expect(result.ok).toBe(true);
-    expect(captured.update).toEqual({
-      sleep_hours: 7.0,
-      had_bowel_movement: true,
-      work_mode: "office",
+    expect(capture.p_fields?.sleep_hours).toBe(7.0);
+    expect(capture.p_fields?.had_bowel_movement).toBe(true);
+    expect(capture.p_fields?.work_mode).toBe("office");
+    expect("weight"        in (capture.p_fields ?? {})).toBe(false);
+    expect("training_type" in (capture.p_fields ?? {})).toBe(false);
+    expect("leg_flag"      in (capture.p_fields ?? {})).toBe(false);
+  });
+
+  test("had_bowel_movement: null → p_fields にキーが含まれ値が null（明示クリア=未記録）", async () => {
+    const capture = makeRpcMock();
+    const result = await saveDailyLog({
+      log_date: "2026-03-13",
+      had_bowel_movement: null,
     });
-    expect("weight" in (captured.update as object)).toBe(false);
-    expect("training_type" in (captured.update as object)).toBe(false);
-    expect("leg_flag" in (captured.update as object)).toBe(false);
+
+    expect(result.ok).toBe(true);
+    expect("had_bowel_movement" in (capture.p_fields ?? {})).toBe(true);
+    expect(capture.p_fields?.had_bowel_movement).toBeNull();
   });
 });
 
 describe("saveDailyLog — log_date バリデーション", () => {
   // 正常系
   test("通常の日付 → ok: true", async () => {
-    makeClientMock(null);
+    makeRpcMock();
     const result = await saveDailyLog({ log_date: "2026-03-13", weight: 70.0 });
     expect(result.ok).toBe(true);
   });
 
   test("うるう年 2月29日 (2024) → ok: true", async () => {
-    makeClientMock(null);
+    makeRpcMock();
     const result = await saveDailyLog({ log_date: "2024-02-29", weight: 70.0 });
     expect(result.ok).toBe(true);
   });
 
   test("月末 1月31日 → ok: true", async () => {
-    makeClientMock(null);
+    makeRpcMock();
     const result = await saveDailyLog({ log_date: "2026-01-31", weight: 70.0 });
     expect(result.ok).toBe(true);
   });
 
   test("月末 4月30日 → ok: true", async () => {
-    makeClientMock(null);
+    makeRpcMock();
     const result = await saveDailyLog({ log_date: "2026-04-30", weight: 70.0 });
     expect(result.ok).toBe(true);
   });
@@ -552,10 +577,10 @@ describe("saveDailyLog — Phase 2.5 バリデーション", () => {
   });
 
   test("sleep_hours が 0 → ok: true (境界値)", async () => {
-    const captured = makeClientMock(null);
+    const capture = makeRpcMock();
     const result = await saveDailyLog({ log_date: "2026-03-13", sleep_hours: 0 });
     expect(result.ok).toBe(true);
-    expect((captured.insert as Record<string, unknown>).sleep_hours).toBe(0);
+    expect(capture.p_fields?.sleep_hours).toBe(0);
   });
 
   test("training_type が不正な値 → ok: false", async () => {

--- a/src/app/actions/saveDailyLog.ts
+++ b/src/app/actions/saveDailyLog.ts
@@ -106,39 +106,19 @@ export async function saveDailyLog(
     return { ok: false, message: "保存するデータがありません" };
   }
 
-  // --- Supabase: 既存レコードを確認して insert / partial update ---
+  // --- Supabase: RPC で atomic upsert ---
+  // save_daily_log_partial は INSERT ... ON CONFLICT DO UPDATE で
+  // read-then-write を廃し、1 回の DB 呼び出しで partial upsert を完結させる。
+  // payload の JSONB キー存在が undefined/null/値の 3 状態を担保する。
   const supabase = createClient();
 
-  const { data: existing, error: fetchError } = await supabase
-    .from("daily_logs")
-    .select("log_date")
-    .eq("log_date", input.log_date)
-    .maybeSingle();
-
-  if (fetchError) {
-    console.error("[saveDailyLog] fetch error:", fetchError.message);
-    return { ok: false, message: "保存に失敗しました: " + fetchError.message };
-  }
-
-  let saveError: { message: string } | null;
-
-  if (existing) {
-    // 既存レコードあり: 送られたフィールドのみ上書き（partial update）
-    const { error } = await supabase
-      .from("daily_logs")
-      .update(payload)
-      .eq("log_date", input.log_date);
-    saveError = error;
-  } else {
-    // 新規レコード: insert
-    const { error } = await supabase
-      .from("daily_logs")
-      .insert({ log_date: input.log_date, ...payload });
-    saveError = error;
-  }
+  const { error: saveError } = await supabase.rpc("save_daily_log_partial", {
+    p_log_date: input.log_date,
+    p_fields:   payload,
+  });
 
   if (saveError) {
-    console.error("[saveDailyLog] save error:", saveError.message, "| payload keys:", Object.keys(payload));
+    console.error("[saveDailyLog] rpc error:", saveError.message, "| payload keys:", Object.keys(payload));
     return { ok: false, message: "保存に失敗しました: " + saveError.message };
   }
 

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -334,7 +334,15 @@ export type Database = {
       };
     };
     Views: Record<string, never>;
-    Functions: Record<string, never>;
+    Functions: {
+      save_daily_log_partial: {
+        Args: {
+          p_log_date: string;
+          p_fields: Record<string, unknown>;
+        };
+        Returns: undefined;
+      };
+    };
     Enums: Record<string, never>;
     CompositeTypes: Record<string, never>;
   };

--- a/supabase/migrations/20260315000001_create_save_daily_log_partial_rpc.sql
+++ b/supabase/migrations/20260315000001_create_save_daily_log_partial_rpc.sql
@@ -1,0 +1,111 @@
+-- save_daily_log_partial: 部分更新対応の atomic upsert RPC
+--
+-- 目的:
+--   saveDailyLog の read-then-write (select → insert/update 分岐) を廃止し、
+--   1 回の DB 呼び出しで insert-or-partial-update を完結させる。
+--
+-- 部分更新の意味論:
+--   p_fields JSONB のキー存在で 3 状態を表現する。
+--   - キーなし          : 未更新（既存値を保持）
+--   - キーあり, 値 null : 明示クリア（null を書き込む）
+--   - キーあり, 値あり  : 上書き
+--
+--   JSONB の `?` 演算子がキー存在チェック、`->>'col'` が値取得（NULL if absent）。
+--   これにより undefined フィールドを既存値に保持する partial update が原子的に実現される。
+--
+-- 新規レコードのデフォルト値:
+--   NOT NULL DEFAULT FALSE の boolean 列 (is_cheat_day 等) は、
+--   INSERT 側で COALESCE(..., FALSE) を適用することで DB DEFAULT と整合させる。
+--   nullable 列はキーなしの場合 NULL が適用される（DB スキーマのデフォルト値）。
+--
+-- training_type / leg_flag:
+--   leg_flag の導出は TypeScript 側 (deriveLegFlag) で完結する。
+--   RPC は両フィールドをそのまま受け取り、ON CONFLICT 側でも個別に CASE 処理する。
+
+CREATE OR REPLACE FUNCTION save_daily_log_partial(
+  p_log_date DATE,
+  p_fields   JSONB
+) RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  INSERT INTO daily_logs (
+    log_date,
+    weight, calories, protein, fat, carbs, note,
+    is_cheat_day, is_refeed_day, is_eating_out, is_poor_sleep,
+    sleep_hours, had_bowel_movement,
+    training_type, work_mode, leg_flag
+  ) VALUES (
+    p_log_date,
+    -- nullable 列: キーなし → NULL (DB DEFAULT), キーあり → その値
+    (p_fields->>'weight')::NUMERIC,
+    (p_fields->>'calories')::NUMERIC,
+    (p_fields->>'protein')::NUMERIC,
+    (p_fields->>'fat')::NUMERIC,
+    (p_fields->>'carbs')::NUMERIC,
+    p_fields->>'note',
+    -- NOT NULL DEFAULT FALSE 列: キーなし → FALSE, キーあり → その値
+    COALESCE((p_fields->>'is_cheat_day')::BOOLEAN,  FALSE),
+    COALESCE((p_fields->>'is_refeed_day')::BOOLEAN, FALSE),
+    COALESCE((p_fields->>'is_eating_out')::BOOLEAN, FALSE),
+    COALESCE((p_fields->>'is_poor_sleep')::BOOLEAN, FALSE),
+    -- nullable 列 (続き)
+    (p_fields->>'sleep_hours')::NUMERIC,
+    (p_fields->>'had_bowel_movement')::BOOLEAN,
+    p_fields->>'training_type',
+    p_fields->>'work_mode',
+    (p_fields->>'leg_flag')::BOOLEAN
+  )
+  ON CONFLICT (log_date) DO UPDATE SET
+    -- CASE WHEN キー存在 THEN 新値 ELSE 既存値 END で partial update を実現
+    weight             = CASE WHEN p_fields ? 'weight'
+                              THEN (p_fields->>'weight')::NUMERIC
+                              ELSE daily_logs.weight             END,
+    calories           = CASE WHEN p_fields ? 'calories'
+                              THEN (p_fields->>'calories')::NUMERIC
+                              ELSE daily_logs.calories           END,
+    protein            = CASE WHEN p_fields ? 'protein'
+                              THEN (p_fields->>'protein')::NUMERIC
+                              ELSE daily_logs.protein            END,
+    fat                = CASE WHEN p_fields ? 'fat'
+                              THEN (p_fields->>'fat')::NUMERIC
+                              ELSE daily_logs.fat                END,
+    carbs              = CASE WHEN p_fields ? 'carbs'
+                              THEN (p_fields->>'carbs')::NUMERIC
+                              ELSE daily_logs.carbs              END,
+    note               = CASE WHEN p_fields ? 'note'
+                              THEN p_fields->>'note'
+                              ELSE daily_logs.note               END,
+    is_cheat_day       = CASE WHEN p_fields ? 'is_cheat_day'
+                              THEN (p_fields->>'is_cheat_day')::BOOLEAN
+                              ELSE daily_logs.is_cheat_day       END,
+    is_refeed_day      = CASE WHEN p_fields ? 'is_refeed_day'
+                              THEN (p_fields->>'is_refeed_day')::BOOLEAN
+                              ELSE daily_logs.is_refeed_day      END,
+    is_eating_out      = CASE WHEN p_fields ? 'is_eating_out'
+                              THEN (p_fields->>'is_eating_out')::BOOLEAN
+                              ELSE daily_logs.is_eating_out      END,
+    is_poor_sleep      = CASE WHEN p_fields ? 'is_poor_sleep'
+                              THEN (p_fields->>'is_poor_sleep')::BOOLEAN
+                              ELSE daily_logs.is_poor_sleep      END,
+    sleep_hours        = CASE WHEN p_fields ? 'sleep_hours'
+                              THEN (p_fields->>'sleep_hours')::NUMERIC
+                              ELSE daily_logs.sleep_hours        END,
+    had_bowel_movement = CASE WHEN p_fields ? 'had_bowel_movement'
+                              THEN (p_fields->>'had_bowel_movement')::BOOLEAN
+                              ELSE daily_logs.had_bowel_movement END,
+    training_type      = CASE WHEN p_fields ? 'training_type'
+                              THEN p_fields->>'training_type'
+                              ELSE daily_logs.training_type      END,
+    work_mode          = CASE WHEN p_fields ? 'work_mode'
+                              THEN p_fields->>'work_mode'
+                              ELSE daily_logs.work_mode          END,
+    leg_flag           = CASE WHEN p_fields ? 'leg_flag'
+                              THEN (p_fields->>'leg_flag')::BOOLEAN
+                              ELSE daily_logs.leg_flag           END;
+END;
+$$;
+
+COMMENT ON FUNCTION save_daily_log_partial(DATE, JSONB) IS
+  '日次ログの partial upsert。p_fields の JSONB キー存在で
+   未更新(キーなし) / 明示クリア(キーあり+null) / 上書き(キーあり+値) を表現する。';


### PR DESCRIPTION
## 概要

`saveDailyLog` の保存処理を `read → insert/update 分岐` の 2 段階構成から脱却させ、PostgreSQL RPC による 1 回の DB 呼び出しで完結する atomic upsert に置き換える。

## 変更内容

### `supabase/migrations/20260315000001_create_save_daily_log_partial_rpc.sql`

`save_daily_log_partial(p_log_date DATE, p_fields JSONB)` RPC を新設。

`INSERT ... ON CONFLICT (log_date) DO UPDATE` を使用:

| タイミング | 処理 |
|---|---|
| 新規 (INSERT) | nullable 列 → NULL / NOT NULL DEFAULT FALSE 列 → `COALESCE(..., FALSE)` |
| 既存 (ON CONFLICT DO UPDATE) | `CASE WHEN p_fields ? 'col' THEN 新値 ELSE 既存値 END` で partial update |

### `src/app/actions/saveDailyLog.ts`

```diff
- // select で既存チェック → insert または update に分岐
- const { data: existing } = await supabase.from("daily_logs").select(...).maybeSingle();
- if (existing) { supabase.from("daily_logs").update(payload).eq(...) }
- else          { supabase.from("daily_logs").insert({...}) }
+ // 1 回の RPC で atomic upsert
+ await supabase.rpc("save_daily_log_partial", { p_log_date, p_fields: payload });
```

### `src/lib/supabase/types.ts`

`Functions` に `save_daily_log_partial` の型定義を追加。

### `src/app/actions/__tests__/saveDailyLog.test.ts`

`makeClientMock`（`from().select()...` チェーンモック）を `makeRpcMock`（`rpc()` モック）に全面置き換え。RPC への引数（`p_log_date` / `p_fields` の内容）を直接検証するケースに刷新。

## 保存フローの見直し

```
旧: select(存在確認) → [insert | update] = 最小 2 RTT、競合余地あり
新: rpc(atomic upsert)                  = 1 RTT、競合なし
```

## partial update の意味論維持

JSONB のキー存在が 3 状態を表現する:

| TypeScript 側 | p_fields JSONB | DB 側の動作 |
|---|---|---|
| `undefined` | キーなし | `ELSE daily_logs.col` → 既存値保持 |
| `null` | キーあり、値 null | `THEN NULL` → null を書き込む |
| 値あり | キーあり、値あり | `THEN 値` → 上書き |

`buildUpdatePayload` が undefined を除去した payload を作り、そのまま `p_fields` として渡すことでこの意味論を維持。

## training_type / leg_flag の整合

`buildUpdatePayload` 側で `deriveLegFlag` による導出は変わらない。RPC は `training_type` と `leg_flag` を独立したフィールドとして受け取り、CASE WHEN で各々処理する。

## テスト

全 575 件パス (`node_modules/.bin/jest --no-coverage`)、`npx tsc --noEmit` エラーなし。

新規テストケース:
- `training_type: null` → `leg_flag` も null で p_fields に含まれる
- `had_bowel_movement: null` → p_fields にキーあり・値 null（明示クリア）
- RPC エラー時 → `ok: false` + メッセージ

## 影響範囲

- `saveDailyLog` 経由の保存フロー全般
- 戻り値仕様 (`{ ok: true } | { ok: false; message }`) は変わらない
- `buildUpdatePayload` は変更なし
- UI コンポーネント (`MealLogger` 等) への変更なし

## 残課題

- `supabase gen types` で types.ts を実スキーマから再生成（migration 適用後、`Functions` 定義が手動追記のため）
- 他の保存アクションの atomic 化は今回スコープ外

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)