### PR TITLE
refactor: add feature registry as single source of truth for analysis pipeline

### DIFF
--- a/ml-pipeline/analyze.py
+++ b/ml-pipeline/analyze.py
@@ -8,7 +8,9 @@ analyze.py — XGBoost 因子分析バッチ
     current_weight を説明変数から除外してリーケージを防ぐ。
 
 ■ 特徴量:
-    旧版に合わせて cal_lag1 / rolling_cal_7 / p_lag1 / f_lag1 / c_lag1 の 5 特徴を使用。
+    feature_registry.py の FEATURE_REGISTRY (active=True) から動的取得する。
+    特徴量の追加・変更は feature_registry.py のみを編集すること。
+    FEATURE_COLS を analyze.py に直書きしない。
 
 ■ 出力:
     結果は analytics_cache.payload (JSONB) に保存する。
@@ -41,11 +43,18 @@ from datetime import datetime, timezone
 
 import pandas as pd
 
+from feature_registry import (
+    TargetType,
+    active_feature_cols,
+    active_feature_labels,
+    active_features,
+)
+
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger(__name__)
 
-# 旧版と同じ 5 特徴 (current_weight はリーケージのため除外)
-FEATURE_COLS = ["cal_lag1", "rolling_cal_7", "p_lag1", "f_lag1", "c_lag1"]
+# feature_registry.py から動的取得。直書きしない。
+FEATURE_COLS = active_feature_cols()
 
 # ── stability 定義 ────────────────────────────────────────────────────────────
 # N_BOOTSTRAP 回のリサンプリングで XGBoost を再学習し、各 feature の
@@ -61,21 +70,16 @@ FEATURE_COLS = ["cal_lag1", "rolling_cal_7", "p_lag1", "f_lag1", "c_lag1"]
 #   → stability = "unavailable"
 #     (importance は表示するが stability は提供しない)
 N_BOOTSTRAP = 20  # bootstrap 反復数。少なすぎると CV が不安定、多すぎると重い
-FEATURE_LABELS = {
-    # フロントエンド featureLabels.ts の FEATURE_LABEL_MAP と同期すること
-    "cal_lag1":      "摂取 kcal（当日）",
-    "rolling_cal_7": "摂取 kcal（週平均）",
-    "p_lag1":        "タンパク質（g）",
-    "f_lag1":        "脂質（g）",
-    "c_lag1":        "炭水化物（g）",
-}
 MIN_ROWS = 14
 
 
 # ── 純粋ロジック層 ─────────────────────────────────────────────────────────────
 
 
-def apply_feature_engineering(df: pd.DataFrame) -> pd.DataFrame:
+def apply_feature_engineering(
+    df: pd.DataFrame,
+    target_type: TargetType = TargetType.NEXT_DAY_CHANGE,
+) -> pd.DataFrame:
     """欠損除去・ソート・特徴量エンジニアリング・target 計算を適用した DataFrame を返す。
 
     run_importance() と compute_meta() の両方がこの関数を経由することで、
@@ -86,6 +90,12 @@ def apply_feature_engineering(df: pd.DataFrame) -> pd.DataFrame:
 
     入力 df を変更しない（内部で copy する）。
     xgboost / supabase を必要としない純粋変換。
+
+    Args:
+        df:          daily_logs の生 DataFrame。
+        target_type: 目的変数の種類。TargetType.NEXT_DAY_CHANGE のみ実装済み。
+                     新しい target_type は feature_registry.TargetType に追加してから
+                     ここに分岐を追加すること。
     """
     df = df.copy()
     df = df.dropna(subset=["weight", "calories", "protein", "fat", "carbs"])
@@ -97,21 +107,14 @@ def apply_feature_engineering(df: pd.DataFrame) -> pd.DataFrame:
     df["f_lag1"]        = df["fat"]
     df["c_lag1"]        = df["carbs"]
 
-    # ── 目的変数: 翌日体重変化量 = weight(t+1) - weight(t) ──────────────────
-    # 「翌日体重の絶対値」ではなく「翌日の変化量（増加=正、減少=負）」を予測する。
-    # これにより「炭水化物・脚トレ・睡眠などが翌日体重をどれだけ動かすか」という
-    # 解釈しやすい目的変数になる。current_weight は説明変数から除外済み（リーケージ回避）。
-    #
-    # ── 将来拡張メモ ─────────────────────────────────────────────────────────
-    # 今回は最も単純で解釈しやすい「翌日変化量」を採用する。
-    # 将来比較したい target 候補:
-    #   - 2日後変化量:       weight.shift(-2) - weight
-    #   - 3日移動平均との差: rolling(3).mean().shift(-1) - weight  ← 定義は要検討
-    # 足トレや高糖質の影響は翌日だけでなく 2 日程度残る可能性があるため、
-    # データが十分に蓄積されたタイミングで比較実験すること。
-    # 追加するには本関数に `target_type` 引数を設け、上記の計算式を分岐させる。
-    # ─────────────────────────────────────────────────────────────────────────
-    df["target"] = df["weight"].shift(-1) - df["weight"]
+    # ── 目的変数 ─────────────────────────────────────────────────────────────
+    if target_type == TargetType.NEXT_DAY_CHANGE:
+        # 翌日体重変化量 = weight(t+1) - weight(t)
+        # 「翌日体重の絶対値」ではなく「翌日の変化量（増加=正、減少=負）」を予測する。
+        # current_weight は説明変数から除外済み（リーケージ回避）。
+        df["target"] = df["weight"].shift(-1) - df["weight"]
+    else:
+        raise ValueError(f"未実装の target_type: {target_type!r}")
 
     return df
 
@@ -153,10 +156,11 @@ def run_importance(df: pd.DataFrame) -> dict[str, dict[str, float | str]]:
     raw = dict(zip(FEATURE_COLS, model.feature_importances_.tolist()))
 
     # ラベルと重要度（%）を合わせて返す
+    labels = active_feature_labels()
     total = sum(raw.values()) or 1.0
     return {
         col: {
-            "label": FEATURE_LABELS[col],
+            "label": labels[col],
             "importance": round(raw[col], 6),
             "pct": round(raw[col] / total * 100, 1),
         }
@@ -243,8 +247,34 @@ def compute_stability(
     return result
 
 
-def compute_meta(df: pd.DataFrame) -> dict[str, object]:
-    """分析前提情報（サンプル数・日付範囲・除外数）を計算して返す。
+def compute_feature_coverage(df: pd.DataFrame) -> dict[str, float]:
+    """アクティブな特徴量ごとのソース列の非欠損率を返す。
+
+    apply_feature_engineering() 前の生 DataFrame を渡すこと。
+    フィルタ後の df では全列が non-null になるため意味がない。
+
+    Returns:
+        {feature_name: coverage_rate} の辞書。coverage_rate は 0.0〜1.0 の float。
+        入力 df が空の場合は全特徴量が 0.0 になる。
+    """
+    n = len(df)
+    if n == 0:
+        return {f.name: 0.0 for f in active_features()}
+    result: dict[str, float] = {}
+    for feat in active_features():
+        if feat.source_col in df.columns:
+            coverage = float(df[feat.source_col].notna().sum()) / n
+        else:
+            coverage = 0.0
+        result[feat.name] = round(coverage, 4)
+    return result
+
+
+def compute_meta(
+    df: pd.DataFrame,
+    target_type: TargetType = TargetType.NEXT_DAY_CHANGE,
+) -> dict[str, object]:
+    """分析前提情報（サンプル数・日付範囲・除外数・特徴量情報）を計算して返す。
 
     apply_feature_engineering() 経由で run_importance() と同じ前処理を参照する。
     xgboost / supabase を必要としない純粋関数。
@@ -256,17 +286,23 @@ def compute_meta(df: pd.DataFrame) -> dict[str, object]:
         - date_to (str | None): 有効サンプルの最新日付。サンプルなしなら None
         - total_rows (int): 入力 df の行数（フィルタ前）
         - dropped_count (int): 欠損除外 + shift(-1) 末尾除外の合計
+        - feature_labels (dict[str, str]): {feature_name: label}。フロントの fallback 用。
+        - feature_coverage (dict[str, float]): {feature_name: 非欠損率 0.0〜1.0}
+        - target_type (str): 使用した目的変数の種類（TargetType の値）
     """
     total_rows = int(len(df))
-    df_proc = apply_feature_engineering(df)
+    df_proc = apply_feature_engineering(df, target_type=target_type)
     df_proc = df_proc.dropna(subset=FEATURE_COLS + ["target"])
     sample_count = int(len(df_proc))
     return {
-        "sample_count":  sample_count,
-        "date_from":     str(df_proc["log_date"].iloc[0])  if sample_count > 0 else None,
-        "date_to":       str(df_proc["log_date"].iloc[-1]) if sample_count > 0 else None,
-        "total_rows":    total_rows,
-        "dropped_count": total_rows - sample_count,
+        "sample_count":     sample_count,
+        "date_from":        str(df_proc["log_date"].iloc[0])  if sample_count > 0 else None,
+        "date_to":          str(df_proc["log_date"].iloc[-1]) if sample_count > 0 else None,
+        "total_rows":       total_rows,
+        "dropped_count":    total_rows - sample_count,
+        "feature_labels":   active_feature_labels(),
+        "feature_coverage": compute_feature_coverage(df),
+        "target_type":      target_type.value,
     }
 
 

--- a/ml-pipeline/feature_registry.py
+++ b/ml-pipeline/feature_registry.py
@@ -1,0 +1,260 @@
+"""
+feature_registry.py — 因子分析 特徴量定義の単一ソース
+
+このファイルが analyze.py・フロントエンド・将来の SHAP 移行すべての正本となる。
+
+■ 設計方針
+  - 特徴量の「名前 / 表示ラベル / 型 / nullable / ソース列 / encoder 方針 / 有効フラグ」を
+    FeatureDef に集約する。
+  - analyze.py は active_feature_cols() / active_feature_labels() を呼んで使う。
+    FEATURE_COLS / FEATURE_LABELS を直書きしない。
+  - フロントエンドは _meta.feature_labels (payload に含まれる) をフォールバックとして使える。
+    featureLabels.ts の FEATURE_LABEL_MAP が第一優先だが、未登録キーは payload 側を使用する。
+
+■ active フラグの意味
+  active=True  : 現在の XGBoost 学習で使用する
+  active=False : 将来の feature-set 比較候補。定義だけ登録済み。
+
+■ 新規特徴量の追加手順
+  1. ここに FeatureDef を追加する（active=False で先行登録可）
+  2. apply_feature_engineering() に列生成コードを追加する
+  3. active=True に変更する
+  4. featureLabels.ts の FEATURE_LABEL_MAP に同じラベルを追加する (任意)
+     ※ featureLabels.ts に追加しなくても _meta.feature_labels が fallback になるため
+       フロント表示は壊れない
+
+■ SHAP 移行時の想定
+  - analyze.py の run_importance() を SHAP に差し替える際、feature_registry の
+    encoder_hint を参照して前処理を決定する。
+  - FEATURE_REGISTRY の feature 定義は変えずに analyze.py 側だけ書き換えられる。
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+# ── 列挙型 ─────────────────────────────────────────────────────────────────────
+
+class FeatureDtype(str, Enum):
+    """特徴量の型カテゴリ。encoder 選択・欠損処理方針の決定に使用する。"""
+    NUMERIC  = "numeric"   # 連続値 (calories, weight, sleep_hours 等)
+    BOOLEAN  = "boolean"   # True/False (is_cheat_day, leg_flag 等)
+    CATEGORY = "category"  # 有限カテゴリ (training_type, work_mode 等)
+
+
+class EncoderHint(str, Enum):
+    """SHAP 移行時・特徴量エンジニアリング時の encoder 方針。
+
+    現状は XGBoost (tree-based) のため encoding 不要だが、
+    将来 linear / neural 系モデルを追加する場合に参照する。
+    """
+    PASSTHROUGH    = "passthrough"    # numeric: そのまま渡す
+    ORDINAL        = "ordinal"        # boolean: 0/1 に変換
+    ONE_HOT        = "one_hot"        # category: one-hot encoding
+    TARGET_ENCODE  = "target_encode"  # category: target encoding (高カーディナリティ向け)
+
+
+class TargetType(str, Enum):
+    """目的変数の種類。
+
+    現在は NEXT_DAY_CHANGE のみ実装。
+    将来の比較実験で追加する候補を Enum に先行登録しておく。
+
+    追加手順:
+      1. ここに値を追加する
+      2. apply_feature_engineering() に計算式を追加する
+      3. analyze.py の run_importance / compute_meta に target_type 引数を渡す
+    """
+    NEXT_DAY_CHANGE = "next_day_change"
+    # 将来候補 (実装前):
+    # TWO_DAY_CHANGE  = "two_day_change"   # weight.shift(-2) - weight
+
+
+# ── 特徴量定義型 ───────────────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class FeatureDef:
+    """特徴量1件の完全な定義。
+
+    フィールド:
+      name          : 特徴量エンジニアリング後の列名 (XGBoost / SHAP に渡す名前)
+      label         : 日本語表示ラベル (フロントエンドの fallback にもなる)
+      dtype         : 型カテゴリ (FeatureDtype)
+      nullable      : ソース列が NULL を許容するか
+      source_col    : daily_logs 上の元列名 (feature coverage 算出に使用)
+      encoder_hint  : SHAP 移行時・線形モデル追加時の encoder 方針 (EncoderHint)
+      active        : 現在の学習で使用するか
+                      False = 将来候補として定義済み、学習には含めない
+    """
+    name:         str
+    label:        str
+    dtype:        FeatureDtype
+    nullable:     bool
+    source_col:   str
+    encoder_hint: EncoderHint = EncoderHint.PASSTHROUGH
+    active:       bool        = True
+
+
+# ── 特徴量レジストリ ────────────────────────────────────────────────────────────
+
+FEATURE_REGISTRY: list[FeatureDef] = [
+    # ── 現在アクティブな特徴量 (analyze.py FEATURE_COLS と等価) ───────────────
+    FeatureDef(
+        name="cal_lag1",
+        label="摂取 kcal（当日）",
+        dtype=FeatureDtype.NUMERIC,
+        nullable=False,
+        source_col="calories",
+        encoder_hint=EncoderHint.PASSTHROUGH,
+        active=True,
+    ),
+    FeatureDef(
+        name="rolling_cal_7",
+        label="摂取 kcal（週平均）",
+        dtype=FeatureDtype.NUMERIC,
+        nullable=False,
+        source_col="calories",
+        encoder_hint=EncoderHint.PASSTHROUGH,
+        active=True,
+    ),
+    FeatureDef(
+        name="p_lag1",
+        label="タンパク質（g）",
+        dtype=FeatureDtype.NUMERIC,
+        nullable=False,
+        source_col="protein",
+        encoder_hint=EncoderHint.PASSTHROUGH,
+        active=True,
+    ),
+    FeatureDef(
+        name="f_lag1",
+        label="脂質（g）",
+        dtype=FeatureDtype.NUMERIC,
+        nullable=False,
+        source_col="fat",
+        encoder_hint=EncoderHint.PASSTHROUGH,
+        active=True,
+    ),
+    FeatureDef(
+        name="c_lag1",
+        label="炭水化物（g）",
+        dtype=FeatureDtype.NUMERIC,
+        nullable=False,
+        source_col="carbs",
+        encoder_hint=EncoderHint.PASSTHROUGH,
+        active=True,
+    ),
+
+    # ── 将来の特徴量候補 (active=False; データ蓄積後に着手) ──────────────────
+    FeatureDef(
+        name="sleep_hours",
+        label="睡眠時間（h）",
+        dtype=FeatureDtype.NUMERIC,
+        nullable=True,
+        source_col="sleep_hours",
+        encoder_hint=EncoderHint.PASSTHROUGH,
+        active=False,
+    ),
+    FeatureDef(
+        name="had_bowel_movement",
+        label="便通あり",
+        dtype=FeatureDtype.BOOLEAN,
+        nullable=True,
+        source_col="had_bowel_movement",
+        encoder_hint=EncoderHint.ORDINAL,
+        active=False,
+    ),
+    FeatureDef(
+        name="is_cheat_day",
+        label="チートデイ",
+        dtype=FeatureDtype.BOOLEAN,
+        nullable=False,
+        source_col="is_cheat_day",
+        encoder_hint=EncoderHint.ORDINAL,
+        active=False,
+    ),
+    FeatureDef(
+        name="is_refeed_day",
+        label="リフィードデイ",
+        dtype=FeatureDtype.BOOLEAN,
+        nullable=False,
+        source_col="is_refeed_day",
+        encoder_hint=EncoderHint.ORDINAL,
+        active=False,
+    ),
+    FeatureDef(
+        name="is_eating_out",
+        label="外食日",
+        dtype=FeatureDtype.BOOLEAN,
+        nullable=False,
+        source_col="is_eating_out",
+        encoder_hint=EncoderHint.ORDINAL,
+        active=False,
+    ),
+    FeatureDef(
+        name="is_poor_sleep",
+        label="睡眠不足",
+        dtype=FeatureDtype.BOOLEAN,
+        nullable=False,
+        source_col="is_poor_sleep",
+        encoder_hint=EncoderHint.ORDINAL,
+        active=False,
+    ),
+    FeatureDef(
+        name="leg_flag",
+        label="脚トレ日",
+        dtype=FeatureDtype.BOOLEAN,
+        nullable=True,
+        source_col="leg_flag",
+        encoder_hint=EncoderHint.ORDINAL,
+        active=False,
+    ),
+    FeatureDef(
+        name="training_type",
+        label="トレーニング種別",
+        dtype=FeatureDtype.CATEGORY,
+        nullable=True,
+        source_col="training_type",
+        encoder_hint=EncoderHint.ONE_HOT,
+        active=False,
+    ),
+    FeatureDef(
+        name="work_mode",
+        label="勤務形態",
+        dtype=FeatureDtype.CATEGORY,
+        nullable=True,
+        source_col="work_mode",
+        encoder_hint=EncoderHint.ONE_HOT,
+        active=False,
+    ),
+]
+
+
+# ── ユーティリティ ──────────────────────────────────────────────────────────────
+
+def active_features() -> list[FeatureDef]:
+    """現在学習に使用するアクティブな特徴量リストを返す。"""
+    return [f for f in FEATURE_REGISTRY if f.active]
+
+
+def active_feature_cols() -> list[str]:
+    """現在学習に使用する特徴量列名リストを返す。analyze.py の FEATURE_COLS に相当。"""
+    return [f.name for f in FEATURE_REGISTRY if f.active]
+
+
+def active_feature_labels() -> dict[str, str]:
+    """現在学習に使用する特徴量の {name: label} 辞書を返す。
+
+    analyze.py の run_importance() が label を解決するために使う。
+    payload の _meta.feature_labels に格納することでフロントが fallback として使える。
+    """
+    return {f.name: f.label for f in FEATURE_REGISTRY if f.active}
+
+
+def all_feature_labels() -> dict[str, str]:
+    """全特徴量 (active/inactive 問わず) の {name: label} 辞書を返す。
+
+    featureLabels.ts の FEATURE_LABEL_MAP との同期確認や
+    将来の SHAP 結果表示に使用する。
+    """
+    return {f.name: f.label for f in FEATURE_REGISTRY}

--- a/ml-pipeline/test_analyze.py
+++ b/ml-pipeline/test_analyze.py
@@ -15,12 +15,14 @@ import pytest
 from analyze import (
     run_importance,
     apply_feature_engineering,
+    compute_feature_coverage,
     compute_meta,
     compute_stability,
     build_payload,
     FEATURE_COLS,
     MIN_ROWS,
 )
+from feature_registry import TargetType
 
 
 # ── ヘルパー ──────────────────────────────────────────────────────────────────
@@ -279,7 +281,10 @@ class TestComputeMeta:
         """必要な全キーが返される。"""
         df = _make_df(n=20)
         meta = compute_meta(df)
-        for key in ["sample_count", "date_from", "date_to", "total_rows", "dropped_count"]:
+        for key in [
+            "sample_count", "date_from", "date_to", "total_rows", "dropped_count",
+            "feature_labels", "feature_coverage", "target_type",
+        ]:
             assert key in meta
 
     def test_total_rows_reflects_input_length(self):
@@ -316,6 +321,94 @@ class TestComputeMeta:
         assert meta["sample_count"] == 0
         assert meta["total_rows"] == 0
         assert meta["dropped_count"] == 0
+
+    def test_feature_labels_is_dict_of_strings(self):
+        """feature_labels は {str: str} の辞書で返る。"""
+        df = _make_df(n=20)
+        meta = compute_meta(df)
+        labels = meta["feature_labels"]
+        assert isinstance(labels, dict)
+        for k, v in labels.items():
+            assert isinstance(k, str)
+            assert isinstance(v, str)
+
+    def test_feature_labels_keys_match_feature_cols(self):
+        """feature_labels のキーが FEATURE_COLS と一致する。"""
+        df = _make_df(n=20)
+        meta = compute_meta(df)
+        assert set(meta["feature_labels"].keys()) == set(FEATURE_COLS)
+
+    def test_feature_coverage_is_dict_of_floats(self):
+        """feature_coverage は {str: float} の辞書で返る。"""
+        df = _make_df(n=20)
+        meta = compute_meta(df)
+        cov = meta["feature_coverage"]
+        assert isinstance(cov, dict)
+        for k, v in cov.items():
+            assert isinstance(k, str)
+            assert isinstance(v, float)
+
+    def test_feature_coverage_values_in_range(self):
+        """coverage 値は 0.0〜1.0 の範囲に収まる。"""
+        df = _make_df(n=20)
+        meta = compute_meta(df)
+        for v in meta["feature_coverage"].values():
+            assert 0.0 <= v <= 1.0
+
+    def test_target_type_is_string(self):
+        """target_type は文字列で返る（TargetType.value）。"""
+        df = _make_df(n=20)
+        meta = compute_meta(df)
+        assert isinstance(meta["target_type"], str)
+
+    def test_target_type_default_is_next_day_change(self):
+        """デフォルトの target_type は 'next_day_change'。"""
+        df = _make_df(n=20)
+        meta = compute_meta(df)
+        assert meta["target_type"] == TargetType.NEXT_DAY_CHANGE.value
+
+
+# ── compute_feature_coverage のテスト ────────────────────────────────────────
+
+class TestComputeFeatureCoverage:
+    def test_returns_dict_keyed_by_feature_name(self):
+        """FEATURE_COLS のキーで辞書が返る。"""
+        df = _make_df(n=20)
+        result = compute_feature_coverage(df)
+        assert isinstance(result, dict)
+        for col in FEATURE_COLS:
+            assert col in result
+
+    def test_full_data_returns_1_0(self):
+        """欠損なしデータでは全特徴量の coverage が 1.0 になる。"""
+        df = _make_df(n=20)
+        result = compute_feature_coverage(df)
+        for col in FEATURE_COLS:
+            assert result[col] == 1.0, f"{col}: expected 1.0 but got {result[col]}"
+
+    def test_partial_missing_reduces_coverage(self):
+        """一部欠損があると coverage が 1.0 未満になる。"""
+        df = _make_df(n=20)
+        df.loc[:9, "calories"] = None  # 20行中10行を欠損にする
+        result = compute_feature_coverage(df)
+        # calories を source_col に持つ特徴量 (cal_lag1, rolling_cal_7) が影響を受ける
+        assert result["cal_lag1"] < 1.0
+        assert result["rolling_cal_7"] < 1.0
+
+    def test_coverage_values_in_range(self):
+        """coverage は 0.0〜1.0 に収まる。"""
+        df = _make_df(n=20)
+        df.loc[0, "calories"] = None
+        result = compute_feature_coverage(df)
+        for v in result.values():
+            assert 0.0 <= v <= 1.0
+
+    def test_empty_dataframe_returns_zeros(self):
+        """空 DataFrame では全特徴量が 0.0 になる。"""
+        df = pd.DataFrame(columns=["log_date", "weight", "calories", "protein", "fat", "carbs"])
+        result = compute_feature_coverage(df)
+        for col in FEATURE_COLS:
+            assert result[col] == 0.0
 
 
 # ── build_payload のテスト ───────────────────────────────────────────────────

--- a/ml-pipeline/test_feature_registry.py
+++ b/ml-pipeline/test_feature_registry.py
@@ -1,0 +1,230 @@
+"""
+test_feature_registry.py — feature_registry.py の単体テスト
+
+実行: pytest ml-pipeline/test_feature_registry.py -v
+依存: 標準ライブラリのみ（pandas / xgboost 不要）
+"""
+
+import pytest
+
+from feature_registry import (
+    FEATURE_REGISTRY,
+    EncoderHint,
+    FeatureDef,
+    FeatureDtype,
+    TargetType,
+    active_feature_cols,
+    active_feature_labels,
+    active_features,
+    all_feature_labels,
+)
+
+
+# ── FeatureDtype のテスト ─────────────────────────────────────────────────────
+
+class TestFeatureDtype:
+    def test_values_are_strings(self):
+        """Enum 値が str として機能する。"""
+        assert FeatureDtype.NUMERIC == "numeric"
+        assert FeatureDtype.BOOLEAN == "boolean"
+        assert FeatureDtype.CATEGORY == "category"
+
+    def test_all_members_defined(self):
+        """3種類の dtype が定義されている。"""
+        names = {m.name for m in FeatureDtype}
+        assert names == {"NUMERIC", "BOOLEAN", "CATEGORY"}
+
+
+# ── EncoderHint のテスト ──────────────────────────────────────────────────────
+
+class TestEncoderHint:
+    def test_values_are_strings(self):
+        assert EncoderHint.PASSTHROUGH == "passthrough"
+        assert EncoderHint.ORDINAL == "ordinal"
+        assert EncoderHint.ONE_HOT == "one_hot"
+        assert EncoderHint.TARGET_ENCODE == "target_encode"
+
+    def test_all_members_defined(self):
+        names = {m.name for m in EncoderHint}
+        assert names == {"PASSTHROUGH", "ORDINAL", "ONE_HOT", "TARGET_ENCODE"}
+
+
+# ── TargetType のテスト ───────────────────────────────────────────────────────
+
+class TestTargetType:
+    def test_next_day_change_value(self):
+        assert TargetType.NEXT_DAY_CHANGE == "next_day_change"
+
+    def test_at_least_one_member(self):
+        assert len(list(TargetType)) >= 1
+
+
+# ── FeatureDef のテスト ───────────────────────────────────────────────────────
+
+class TestFeatureDef:
+    def test_frozen_dataclass_immutable(self):
+        """frozen=True のため、フィールドの書き換えが TypeError になる。"""
+        feat = FeatureDef(
+            name="test_col",
+            label="テスト",
+            dtype=FeatureDtype.NUMERIC,
+            nullable=False,
+            source_col="test_col",
+        )
+        with pytest.raises((TypeError, AttributeError)):
+            feat.name = "other"  # type: ignore[misc]
+
+    def test_default_encoder_hint_is_passthrough(self):
+        """encoder_hint のデフォルトは PASSTHROUGH。"""
+        feat = FeatureDef(
+            name="x", label="x", dtype=FeatureDtype.NUMERIC,
+            nullable=False, source_col="x",
+        )
+        assert feat.encoder_hint == EncoderHint.PASSTHROUGH
+
+    def test_default_active_is_true(self):
+        """active のデフォルトは True。"""
+        feat = FeatureDef(
+            name="x", label="x", dtype=FeatureDtype.NUMERIC,
+            nullable=False, source_col="x",
+        )
+        assert feat.active is True
+
+    def test_active_false(self):
+        """active=False を明示できる。"""
+        feat = FeatureDef(
+            name="x", label="x", dtype=FeatureDtype.NUMERIC,
+            nullable=False, source_col="x", active=False,
+        )
+        assert feat.active is False
+
+
+# ── FEATURE_REGISTRY のテスト ─────────────────────────────────────────────────
+
+class TestFeatureRegistry:
+    def test_is_nonempty_list(self):
+        """FEATURE_REGISTRY は空でないリスト。"""
+        assert isinstance(FEATURE_REGISTRY, list)
+        assert len(FEATURE_REGISTRY) > 0
+
+    def test_all_entries_are_featuredef(self):
+        """全エントリが FeatureDef インスタンス。"""
+        for f in FEATURE_REGISTRY:
+            assert isinstance(f, FeatureDef)
+
+    def test_names_are_unique(self):
+        """name は重複しない。"""
+        names = [f.name for f in FEATURE_REGISTRY]
+        assert len(names) == len(set(names))
+
+    def test_active_features_include_current_xgboost_cols(self):
+        """現在の XGBoost 特徴量 5 つが active=True で登録されている。"""
+        active_names = {f.name for f in FEATURE_REGISTRY if f.active}
+        expected = {"cal_lag1", "rolling_cal_7", "p_lag1", "f_lag1", "c_lag1"}
+        assert expected.issubset(active_names)
+
+    def test_inactive_features_have_future_candidates(self):
+        """将来候補が active=False で登録されている。"""
+        inactive_names = {f.name for f in FEATURE_REGISTRY if not f.active}
+        # 睡眠・便通・トレーニング種別は将来候補として登録済み
+        assert "sleep_hours" in inactive_names
+        assert "had_bowel_movement" in inactive_names
+        assert "training_type" in inactive_names
+
+    def test_all_entries_have_nonempty_name_and_label(self):
+        """name / label が空文字でない。"""
+        for f in FEATURE_REGISTRY:
+            assert f.name.strip() != "", f"empty name in {f}"
+            assert f.label.strip() != "", f"empty label in {f}"
+
+    def test_all_entries_have_nonempty_source_col(self):
+        """source_col が空文字でない。"""
+        for f in FEATURE_REGISTRY:
+            assert f.source_col.strip() != "", f"empty source_col in {f}"
+
+
+# ── active_features のテスト ──────────────────────────────────────────────────
+
+class TestActiveFeatures:
+    def test_returns_only_active_entries(self):
+        """active=True のエントリのみ返す。"""
+        result = active_features()
+        assert all(f.active for f in result)
+
+    def test_returns_list_of_featuredef(self):
+        result = active_features()
+        assert isinstance(result, list)
+        for f in result:
+            assert isinstance(f, FeatureDef)
+
+    def test_count_matches_registry(self):
+        expected = [f for f in FEATURE_REGISTRY if f.active]
+        assert len(active_features()) == len(expected)
+
+
+# ── active_feature_cols のテスト ──────────────────────────────────────────────
+
+class TestActiveFeatureCols:
+    def test_returns_list_of_strings(self):
+        result = active_feature_cols()
+        assert isinstance(result, list)
+        assert all(isinstance(c, str) for c in result)
+
+    def test_contains_current_xgboost_cols(self):
+        cols = active_feature_cols()
+        for col in ["cal_lag1", "rolling_cal_7", "p_lag1", "f_lag1", "c_lag1"]:
+            assert col in cols
+
+    def test_no_inactive_cols(self):
+        """inactive な特徴量の name が含まれない。"""
+        cols = set(active_feature_cols())
+        for f in FEATURE_REGISTRY:
+            if not f.active:
+                assert f.name not in cols
+
+    def test_order_matches_registry_order(self):
+        """active_features() と同じ順序で name が並ぶ。"""
+        expected = [f.name for f in FEATURE_REGISTRY if f.active]
+        assert active_feature_cols() == expected
+
+
+# ── active_feature_labels のテスト ────────────────────────────────────────────
+
+class TestActiveFeatureLabels:
+    def test_returns_dict(self):
+        result = active_feature_labels()
+        assert isinstance(result, dict)
+
+    def test_keys_match_active_cols(self):
+        assert set(active_feature_labels().keys()) == set(active_feature_cols())
+
+    def test_values_are_nonempty_strings(self):
+        for key, label in active_feature_labels().items():
+            assert isinstance(label, str), f"{key}: label must be str"
+            assert label.strip() != "", f"{key}: label must not be empty"
+
+    def test_labels_have_no_internal_name_patterns(self):
+        """ラベルに _lag1 / rolling_ などの内部名接尾辞が含まれない。"""
+        for label in active_feature_labels().values():
+            assert "_lag" not in label, f"internal suffix in label: {label!r}"
+            assert "rolling_" not in label, f"internal prefix in label: {label!r}"
+
+
+# ── all_feature_labels のテスト ───────────────────────────────────────────────
+
+class TestAllFeatureLabels:
+    def test_includes_inactive_features(self):
+        """active=False のエントリも含む。"""
+        all_labels = all_feature_labels()
+        for f in FEATURE_REGISTRY:
+            assert f.name in all_labels
+
+    def test_superset_of_active_labels(self):
+        active = active_feature_labels()
+        all_labels = all_feature_labels()
+        for key in active:
+            assert key in all_labels
+            assert all_labels[key] == active[key]
+
+    def test_count_matches_registry(self):
+        assert len(all_feature_labels()) == len(FEATURE_REGISTRY)

--- a/src/lib/utils/featureLabels.ts
+++ b/src/lib/utils/featureLabels.ts
@@ -8,7 +8,9 @@
  *
  * 追加手順:
  *   1. このマップに追記する
- *   2. analyze.py の FEATURE_LABELS と同期する
+ *      ※ ml-pipeline/feature_registry.py が特徴量定義の正本。
+ *        未登録キーは _meta.feature_labels (payload) が fallback になるため
+ *        このマップへの追加は任意だが、direction/note/hint も合わせて追加することを推奨。
  */
 export const FEATURE_LABEL_MAP: Readonly<Record<string, string>> = {
   // ── 現在の XGBoost 特徴量 (analyze.py FEATURE_COLS) ──────────────────────


### PR DESCRIPTION
Closes #24

## Summary
- **`ml-pipeline/feature_registry.py`** (新規): `FeatureDef` frozen dataclass と `FeatureDtype` / `EncoderHint` / `TargetType` enum を定義。`FEATURE_REGISTRY` に現在アクティブな 5 特徴量と将来候補 9 件を登録。`active_feature_cols()` / `active_feature_labels()` 等のユーティリティを提供。
- **`ml-pipeline/analyze.py`** (更新): `FEATURE_COLS` を registry から動的取得（直書き廃止）、`FEATURE_LABELS` dict を削除、`apply_feature_engineering` に `target_type` 引数を追加、`compute_feature_coverage()` を新設、`compute_meta` の戻り値に `feature_labels` / `feature_coverage` / `target_type` を追加。
- **`src/lib/utils/featureLabels.ts`** (更新): 「`analyze.py の FEATURE_LABELS と同期すること`」手順を削除し、`feature_registry.py` を正本として参照するコメントに置き換え。
- **`ml-pipeline/test_feature_registry.py`** (新規): 31 テスト。supabase / xgboost / pandas 不要。
- **`ml-pipeline/test_analyze.py`** (更新): `compute_meta` の新キー検証 7 件、`TestComputeFeatureCoverage` 5 件を追加。合計 81 テスト全通過。

## Test plan
- [x] `pytest test_feature_registry.py test_analyze.py -v` → 81/81 passed
- [x] `analyze.py` のモジュール定数 `FEATURE_COLS` が registry の `active_feature_cols()` と一致することを確認
- [x] `compute_meta` の戻り値に `feature_labels` / `feature_coverage` / `target_type` が含まれることをテストで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)