### PR TITLE
chore: add feature registry and backtest tests to Python CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,4 +56,4 @@ jobs:
 
       - name: Test
         working-directory: ml-pipeline
-        run: pytest test_analyze.py test_enrich.py -v
+        run: pytest test_analyze.py test_enrich.py test_feature_registry.py test_backtest.py -v


### PR DESCRIPTION
Closes #32

## 概要
Python CI (`python-test` ジョブ) のテスト実行対象に `test_feature_registry.py` と `test_backtest.py` を追加する。

## 変更内容
- `.github/workflows/ci.yml` の `Test` ステップに2ファイルを追加

**変更前:**
```
pytest test_analyze.py test_enrich.py -v
```
**変更後:**
```
pytest test_analyze.py test_enrich.py test_feature_registry.py test_backtest.py -v
```

## CI に追加したテスト

| ファイル | テスト数 | 追加依存 |
|---|---|---|
| `test_feature_registry.py` | 31 | なし（標準ライブラリ + pytest のみ） |
| `test_backtest.py` | 33 | なし（pandas / numpy は既存 requirements-ci.txt から充足） |

## 実行結果
```
64 passed in 0.40s
```
既存の `test_analyze.py` / `test_enrich.py` への影響なし。

## 影響範囲
- `.github/workflows/ci.yml` のみ変更（差分 1 行）
- `requirements-ci.txt` の変更なし
- ML ロジックの変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)