### PR TITLE
refactor: distinguish read errors from unavailable states

### DIFF
--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -13,6 +13,7 @@ import {
 import { toJstDateStr } from "@/lib/utils/date";
 import { fetchCareerLogs, fetchWeightLogs } from "@/lib/queries/dailyLogs";
 import { fetchSettings } from "@/lib/queries/settings";
+import { mapToAppSettings } from "@/lib/domain/settings";
 import type { CareerLog } from "@/lib/supabase/types";
 
 /** 比較するマイルストーン (大会日からの日数) */
@@ -21,11 +22,14 @@ const MILESTONES = [-180, -120, -90, -60, -30, -14];
 export const revalidate = 3600;
 
 export default async function HistoryPage() {
-  const [careerLogs, currentLogs, settings] = await Promise.all([
+  const [careerLogs, currentLogs, settingsResult] = await Promise.all([
     fetchCareerLogs(),
     fetchWeightLogs(),
     fetchSettings(),
   ]);
+
+  // QueryResult を展開。エラー時はフォールバック値で graceful degradation を維持する。
+  const settings = settingsResult.kind === "ok" ? settingsResult.data : mapToAppSettings([]);
 
   const contestDate = settings.contestDate ?? toJstDateStr();
 
@@ -70,6 +74,13 @@ export default async function HistoryPage() {
   return (
     <main className="min-h-screen bg-gray-50 p-6">
       <h1 className="mb-6 text-xl font-bold text-gray-800">キャリア比較</h1>
+
+      {/* Read error banner — graceful degradation: コンテンツはブロックしない */}
+      {settingsResult.kind === "error" && (
+        <div className="mb-4 rounded-2xl border border-rose-100 bg-rose-50 px-5 py-3 text-sm text-rose-700">
+          設定データの取得中にエラーが発生しました。コンテスト日・シーズン名がデフォルト値になります。
+        </div>
+      )}
 
       {/* 現在シーズン情報（読み取り専用・設定ページから変更可能） */}
       <div className="mb-4 flex flex-wrap items-center gap-3 text-xs text-slate-500">

--- a/src/app/macro/page.tsx
+++ b/src/app/macro/page.tsx
@@ -17,10 +17,23 @@ import { fetchFactorAnalysis } from "@/lib/queries/analytics";
 export const revalidate = 3600;
 
 export default async function MacroPage() {
-  const [logs, targetsResult] = await Promise.all([
+  const [logsResult, targetsResult] = await Promise.all([
     fetchDailyLogs(),
     fetchMacroTargets(),
   ]);
+
+  if (logsResult.kind === "error") {
+    return (
+      <main className="min-h-screen bg-gray-50 p-6">
+        <h1 className="mb-6 text-xl font-bold text-gray-800">栄養分析</h1>
+        <div className="rounded-2xl border border-rose-100 bg-rose-50 px-5 py-3 text-sm text-rose-700">
+          ログデータの取得中にエラーが発生しました。ページを再読み込みしてください。
+        </div>
+      </main>
+    );
+  }
+
+  const logs = logsResult.data;
 
   if (logs.length === 0) {
     return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,7 @@ import { calcWeeklyReview } from "@/lib/utils/calcWeeklyReview";
 import { fetchDailyLogs, fetchPredictions, fetchCareerLogsForDashboard } from "@/lib/queries/dailyLogs";
 import { fetchSettings } from "@/lib/queries/settings";
 import { fetchEnrichedLogs } from "@/lib/queries/analytics";
+import { mapToAppSettings } from "@/lib/domain/settings";
 import type { DailyLog, CareerLog } from "@/lib/supabase/types";
 import type { MonthStats } from "@/components/history/SeasonSummary";
 
@@ -77,12 +78,16 @@ function buildMonthStats(logs: DailyLog[], months = 3): MonthStats[] {
 }
 
 export default async function DashboardPage() {
-  const [logs, predictions, settings, careerLogs] = await Promise.all([
+  const [logsResult, predictions, settingsResult, careerLogs] = await Promise.all([
     fetchDailyLogs(),
     fetchPredictions(),
     fetchSettings(),
     fetchCareerLogsForDashboard(),
   ]);
+
+  // QueryResult を展開。エラー時はフォールバック値で graceful degradation を維持する。
+  const logs = logsResult.kind === "ok" ? logsResult.data : [];
+  const settings = settingsResult.kind === "ok" ? settingsResult.data : mapToAppSettings([]);
 
   // enriched_logs は rawLogs の最新日を渡して新鮮さを判定する
   const latestRawLogDate = logs[logs.length - 1]?.log_date ?? null;
@@ -137,7 +142,23 @@ export default async function DashboardPage() {
 
   return (
     <DashboardLayout>
-      {logs.length > 0 ? (
+      {/* Read error banners — graceful degradation: コンテンツはブロックしない */}
+      {logsResult.kind === "error" && (
+        <div className="mb-4 rounded-2xl border border-rose-100 bg-rose-50 px-5 py-3 text-sm text-rose-700">
+          ログデータの取得中にエラーが発生しました。ページを再読み込みしてください。
+        </div>
+      )}
+      {settingsResult.kind === "error" && (
+        <div className="mb-4 rounded-2xl border border-rose-100 bg-rose-50 px-5 py-3 text-sm text-rose-700">
+          設定データの取得中にエラーが発生しました。一部の表示がデフォルト値になります。
+        </div>
+      )}
+
+      {logsResult.kind === "error" ? (
+        <p className="rounded-2xl border border-slate-100 bg-white p-8 text-center text-sm text-slate-400 shadow-sm">
+          データを取得できませんでした。
+        </p>
+      ) : logs.length > 0 ? (
         <>
           {/* シーズンバッジ */}
           {currentSeason && (

--- a/src/app/tdee/page.tsx
+++ b/src/app/tdee/page.tsx
@@ -19,15 +19,20 @@ import {
 import { fetchDailyLogs } from "@/lib/queries/dailyLogs";
 import { fetchSettings } from "@/lib/queries/settings";
 import { fetchEnrichedLogs } from "@/lib/queries/analytics";
+import { mapToAppSettings } from "@/lib/domain/settings";
 import type { CurrentPhase } from "@/lib/utils/energyBalance";
 
 export const revalidate = 3600;
 
 export default async function TdeePage() {
-  const [rawLogs, settings] = await Promise.all([
+  const [rawLogsResult, settingsResult] = await Promise.all([
     fetchDailyLogs(),
     fetchSettings(),
   ]);
+
+  // QueryResult を展開。エラー時はフォールバック値で graceful degradation を維持する。
+  const rawLogs = rawLogsResult.kind === "ok" ? rawLogsResult.data : [];
+  const settings = settingsResult.kind === "ok" ? settingsResult.data : mapToAppSettings([]);
 
   const sortedRaw = [...rawLogs].sort((a, b) => a.log_date.localeCompare(b.log_date));
   const latestRawLogDate = sortedRaw[sortedRaw.length - 1]?.log_date ?? null;
@@ -172,6 +177,19 @@ export default async function TdeePage() {
   return (
     <main className="min-h-screen bg-gray-50 p-6">
       <h1 className="mb-6 text-xl font-bold text-gray-800">TDEE・代謝分析</h1>
+
+      {/* Read error banners — graceful degradation: コンテンツはブロックしない */}
+      {rawLogsResult.kind === "error" && (
+        <div className="mb-5 rounded-2xl border border-rose-100 bg-rose-50 px-5 py-3 text-sm text-rose-700">
+          ログデータの取得中にエラーが発生しました。ページを再読み込みしてください。
+          グラフ・表は取得エラー前のデータを表示しています。
+        </div>
+      )}
+      {settingsResult.kind === "error" && (
+        <div className="mb-5 rounded-2xl border border-rose-100 bg-rose-50 px-5 py-3 text-sm text-rose-700">
+          設定データの取得中にエラーが発生しました。理論 TDEE の計算に設定値を使用できません。
+        </div>
+      )}
 
       {/* enriched_logs の状態バナー（コンテンツはブロックしない） */}
       {enrichedAvailability.status === "error" && (

--- a/src/lib/queries/dailyLogs.test.ts
+++ b/src/lib/queries/dailyLogs.test.ts
@@ -48,27 +48,36 @@ function setupChain(result: ChainResult) {
 describe("fetchDailyLogs", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it("正常系: DailyLog[] を返す", async () => {
+  it("正常系: kind=ok で DailyLog[] を返す", async () => {
     const rows = [
       { log_date: "2026-03-01", weight: 72.5, calories: 2000 },
       { log_date: "2026-03-02", weight: 72.3, calories: 1900 },
     ];
     setupChain({ data: rows, error: null });
     const result = await fetchDailyLogs();
-    expect(result).toHaveLength(2);
-    expect(result[0].log_date).toBe("2026-03-01");
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.data).toHaveLength(2);
+      expect(result.data[0].log_date).toBe("2026-03-01");
+    }
   });
 
-  it("正常系: データが null のとき空配列を返す", async () => {
+  it("正常系: データが null のとき kind=ok で空配列を返す", async () => {
     setupChain({ data: null, error: null });
     const result = await fetchDailyLogs();
-    expect(result).toEqual([]);
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.data).toEqual([]);
+    }
   });
 
-  it("異常系: DB エラーのとき空配列を返す", async () => {
-    setupChain({ data: null, error: { message: "connection error" } });
+  it("異常系: DB エラーのとき kind=error を返す", async () => {
+    setupChain({ data: null, error: { message: "connection error", code: "PGRST000" } });
     const result = await fetchDailyLogs();
-    expect(result).toEqual([]);
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.message).toBe("connection error");
+    }
   });
 });
 

--- a/src/lib/queries/dailyLogs.ts
+++ b/src/lib/queries/dailyLogs.ts
@@ -12,24 +12,27 @@
  */
 import { createClient } from "@/lib/supabase/server";
 import type { DailyLog, CareerLog, Prediction } from "@/lib/supabase/types";
+import type { QueryResult } from "./queryResult";
 
 /**
  * daily_logs を全カラム・日付昇順で取得する。
  * Dashboard / TDEE / Macro ページで最もよく使われる形式。
  *
- * フォールバック: エラー時は空配列を返す。
+ * 戻り値:
+ *   kind: "ok"    — 取得成功。data が空配列 = ログ未入力（正常な空状態）。
+ *   kind: "error" — DB フェッチ失敗。呼び出し側で error banner を表示すること。
  */
-export async function fetchDailyLogs(): Promise<DailyLog[]> {
+export async function fetchDailyLogs(): Promise<QueryResult<DailyLog[]>> {
   const supabase = createClient();
   const { data, error } = await supabase
     .from("daily_logs")
     .select("*")
     .order("log_date", { ascending: true });
   if (error) {
-    console.error("daily_logs fetch error:", error.message);
-    return [];
+    console.error("[fetchDailyLogs] daily_logs fetch error:", error.message, { code: error.code });
+    return { kind: "error", message: error.message };
   }
-  return (data as DailyLog[]) ?? [];
+  return { kind: "ok", data: (data as DailyLog[]) ?? [] };
 }
 
 /**

--- a/src/lib/queries/queryResult.ts
+++ b/src/lib/queries/queryResult.ts
@@ -1,0 +1,17 @@
+/**
+ * サーバーサイドクエリの状態付き戻り値型。
+ *
+ * kind: "ok"    — 取得成功。data は空配列・null フィールドも含む正常値。
+ * kind: "error" — Supabase フェッチで予期しないエラー発生。
+ *
+ * 使い分け:
+ *   ok with empty data — "データがない" (未入力・未設定) = 正常な空状態
+ *   error              — "取得エラー" (DB 接続失敗・認証エラー等)
+ *
+ * analytics_cache の fresh / stale / unavailable は
+ * AnalyticsAvailability (analytics/status.ts) で管理する。
+ * daily_logs / settings はこの型を使用する。
+ */
+export type QueryResult<T> =
+  | { kind: "ok"; data: T }
+  | { kind: "error"; message: string };

--- a/src/lib/queries/settings.test.ts
+++ b/src/lib/queries/settings.test.ts
@@ -21,7 +21,7 @@ jest.mock("@/lib/supabase/server", () => ({
 describe("fetchSettings", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it("正常系: value_num があるキーは AppSettings の数値フィールドとして返る", async () => {
+  it("正常系: kind=ok で value_num があるキーを AppSettings として返す", async () => {
     const rows = [
       { key: "goal_weight",   value_num: 72.5, value_str: null },
       { key: "contest_date",  value_num: null,  value_str: "2026-10-01" },
@@ -31,50 +31,67 @@ describe("fetchSettings", () => {
     mockFrom.mockReturnValue({ select: selectFn });
 
     const result = await fetchSettings();
-    expect(result.targetWeight).toBe(72.5);
-    expect(result.contestDate).toBe("2026-10-01");
-    expect(result.currentPhase).toBe("Cut");
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.data.targetWeight).toBe(72.5);
+      expect(result.data.contestDate).toBe("2026-10-01");
+      expect(result.data.currentPhase).toBe("Cut");
+    }
   });
 
-  it("正常系: データが空のとき全フィールドが null の AppSettings を返す", async () => {
+  it("正常系: データが空のとき kind=ok で全フィールドが null の AppSettings を返す", async () => {
     const selectFn = jest.fn().mockResolvedValue({ data: [], error: null });
     mockFrom.mockReturnValue({ select: selectFn });
     const result = await fetchSettings();
-    expect(result.targetWeight).toBeNull();
-    expect(result.contestDate).toBeNull();
-    expect(result.currentPhase).toBeNull();
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.data.targetWeight).toBeNull();
+      expect(result.data.contestDate).toBeNull();
+      expect(result.data.currentPhase).toBeNull();
+    }
   });
 
-  it("正常系: データが null のとき全フィールドが null の AppSettings を返す", async () => {
+  it("正常系: データが null のとき kind=ok で全フィールドが null の AppSettings を返す", async () => {
     const selectFn = jest.fn().mockResolvedValue({ data: null, error: null });
     mockFrom.mockReturnValue({ select: selectFn });
     const result = await fetchSettings();
-    expect(result.targetWeight).toBeNull();
-    expect(result.contestDate).toBeNull();
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.data.targetWeight).toBeNull();
+      expect(result.data.contestDate).toBeNull();
+    }
   });
 
-  it("value_num が 0 (falsy) のとき 0 を返す", async () => {
+  it("value_num が 0 (falsy) のとき kind=ok で 0 を返す", async () => {
     const rows = [{ key: "activity_factor", value_num: 0, value_str: null }];
     const selectFn = jest.fn().mockResolvedValue({ data: rows, error: null });
     mockFrom.mockReturnValue({ select: selectFn });
     const result = await fetchSettings();
-    expect(result.activityFactor).toBe(0);
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.data.activityFactor).toBe(0);
+    }
   });
 
-  it("value_num も value_str も null のとき該当フィールドは null を返す", async () => {
+  it("value_num も value_str も null のとき kind=ok で該当フィールドは null を返す", async () => {
     const rows = [{ key: "goal_weight", value_num: null, value_str: null }];
     const selectFn = jest.fn().mockResolvedValue({ data: rows, error: null });
     mockFrom.mockReturnValue({ select: selectFn });
     const result = await fetchSettings();
-    expect(result.targetWeight).toBeNull();
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.data.targetWeight).toBeNull();
+    }
   });
 
-  it("DB エラーのとき全フィールドが null の AppSettings を返す", async () => {
-    const selectFn = jest.fn().mockResolvedValue({ data: null, error: { message: "DB error" } });
+  it("DB エラーのとき kind=error を返す", async () => {
+    const selectFn = jest.fn().mockResolvedValue({ data: null, error: { message: "DB error", code: "PGRST000" } });
     mockFrom.mockReturnValue({ select: selectFn });
     const result = await fetchSettings();
-    expect(result.targetWeight).toBeNull();
-    expect(result.contestDate).toBeNull();
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.message).toBe("DB error");
+    }
   });
 });
 

--- a/src/lib/queries/settings.ts
+++ b/src/lib/queries/settings.ts
@@ -13,18 +13,25 @@ import type { Setting } from "@/lib/supabase/types";
 import type { MacroTargets } from "@/lib/utils/calcMacro";
 import { mapToAppSettings } from "@/lib/domain/settings";
 import type { AppSettings } from "@/lib/domain/settings";
+import type { QueryResult } from "./queryResult";
 
 /**
  * settings テーブルを全件取得し、AppSettings ドメイン型に変換して返す。
  *
  * - DB row[] → AppSettings の変換は mapToAppSettings (lib/domain/settings.ts) に委譲する。
- * - フォールバック: エラー時は全フィールドが null の AppSettings を返す。
+ * 戻り値:
+ *   kind: "ok"    — 取得成功。data の全フィールド null = 設定未入力（正常な空状態）。
+ *   kind: "error" — DB フェッチ失敗。呼び出し側で error banner を表示すること。
  */
-export async function fetchSettings(): Promise<AppSettings> {
+export async function fetchSettings(): Promise<QueryResult<AppSettings>> {
   const supabase = createClient();
-  const { data } = await supabase.from("settings").select("key, value_num, value_str");
+  const { data, error } = await supabase.from("settings").select("key, value_num, value_str");
+  if (error) {
+    console.error("[fetchSettings] settings fetch error:", error.message, { code: error.code });
+    return { kind: "error", message: error.message };
+  }
   const rows = (data as Setting[] | null) ?? [];
-  return mapToAppSettings(rows);
+  return { kind: "ok", data: mapToAppSettings(rows) };
 }
 
 /**


### PR DESCRIPTION
Closes #33

## 概要
`fetchDailyLogs` / `fetchSettings` の read 失敗時に「データがない（未入力）」と「取得エラー」が区別できなかった問題を解消する。`QueryResult<T>` discriminated union を導入し、UI と server log で状態を明示する。

## query layer の状態整理

新規: `src/lib/queries/queryResult.ts`
```typescript
type QueryResult<T> =
  | { kind: "ok"; data: T }      // 取得成功（空配列・null フィールドも正常な空状態）
  | { kind: "error"; message: string }  // DB フェッチ失敗
```

| 関数 | 変更前 | 変更後 |
|---|---|---|
| `fetchDailyLogs()` | `DailyLog[]`（エラー時は`[]`） | `QueryResult<DailyLog[]>` |
| `fetchSettings()` | `AppSettings`（エラーを静かに飲み込む） | `QueryResult<AppSettings>` |
| analytics_cache 系 | 変更なし（既存 `AnalyticsAvailability` で管理済み）✓ | — |

## UI での error / unavailable の分離

| 状態 | 表示 |
|---|---|
| `ok` + 空データ | 「左のフォームから最初のログを入力してください」（未入力） |
| `error` | rose バナー「ログデータの取得中にエラーが発生しました」 |

全ページとも graceful degradation を維持（エラー時もフォールバック値でページを継続表示）。

## server ログ
```
[fetchDailyLogs] daily_logs fetch error: <message> { code: <code> }
[fetchSettings] settings fetch error: <message> { code: <code> }
```
関数名・エラーメッセージ・エラーコードを含めることで、ログからの障害追跡を容易にした。

## テスト
- `fetchDailyLogs` エラーケース: `[]` を期待 → `kind: "error"` を期待に更新
- `fetchSettings` エラーケース: null-filled AppSettings を期待 → `kind: "error"` を期待に更新
- 全テスト 575/575 pass

## 影響範囲
- `src/lib/queries/queryResult.ts` (新規)
- `src/lib/queries/dailyLogs.ts` / `settings.ts`
- `src/app/page.tsx` / `tdee/page.tsx` / `macro/page.tsx` / `history/page.tsx`
- `src/lib/queries/dailyLogs.test.ts` / `settings.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)