### PR TITLE
feat: add monthly dashboard calendar with react-day-picker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "lucide-react": "^0.577.0",
         "next": "16.1.6",
         "react": "19.2.3",
+        "react-day-picker": "^9.14.0",
         "react-dom": "19.2.3",
         "recharts": "^3.8.0",
         "swr": "^2.4.1"
@@ -696,6 +697,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@date-fns/tz": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
+      "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
+      "license": "MIT"
     },
     "node_modules/@emnapi/core": {
       "version": "1.8.1",
@@ -2622,6 +2629,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tabby_ai/hijri-converter": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@tabby_ai/hijri-converter/-/hijri-converter-1.0.5.tgz",
+      "integrity": "sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@tailwindcss/node": {
@@ -4999,6 +5015,22 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-jalali": {
+      "version": "4.1.0-0",
+      "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
+      "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -9635,6 +9667,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-day-picker": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.14.0.tgz",
+      "integrity": "sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@date-fns/tz": "^1.4.1",
+        "@tabby_ai/hijri-converter": "1.0.5",
+        "date-fns": "^4.1.0",
+        "date-fns-jalali": "4.1.0-0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/gpbl"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lucide-react": "^0.577.0",
     "next": "16.1.6",
     "react": "19.2.3",
+    "react-day-picker": "^9.14.0",
     "react-dom": "19.2.3",
     "recharts": "^3.8.0",
     "swr": "^2.4.1"

--- a/src/components/dashboard/LogsAndSummaryTabs.tsx
+++ b/src/components/dashboard/LogsAndSummaryTabs.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { RecentLogsTable } from "./RecentLogsTable";
+import { MonthlyCalendar } from "./MonthlyCalendar";
 import { SeasonSummary } from "@/components/history/SeasonSummary";
 import type { DailyLog } from "@/lib/supabase/types";
 import type { MonthStats } from "@/components/history/SeasonSummary";
@@ -13,7 +14,13 @@ interface LogsAndSummaryTabsProps {
   currentSeason?: string | null;
 }
 
-type Tab = "logs" | "monthly";
+type Tab = "logs" | "calendar" | "monthly";
+
+const TAB_LABELS: Record<Tab, string> = {
+  logs:     "直近ログ",
+  calendar: "カレンダー",
+  monthly:  "月別サマリー",
+};
 
 export function LogsAndSummaryTabs({ logs, monthStats, seasonMap, currentSeason }: LogsAndSummaryTabsProps) {
   const [tab, setTab] = useState<Tab>("logs");
@@ -21,25 +28,29 @@ export function LogsAndSummaryTabs({ logs, monthStats, seasonMap, currentSeason 
   return (
     <div className="rounded-2xl border border-slate-100 bg-white shadow-sm">
       <div className="flex border-b border-slate-100">
-        {(["logs", "monthly"] as Tab[]).map((t) => (
+        {(["logs", "calendar", "monthly"] as Tab[]).map((t) => (
           <button
             key={t}
             onClick={() => setTab(t)}
-            className={`flex-1 px-5 py-3.5 text-sm font-semibold transition-colors ${
+            className={`flex-1 px-3 py-3.5 text-sm font-semibold transition-colors ${
               tab === t
                 ? "border-b-2 border-blue-600 text-blue-600"
                 : "text-slate-400 hover:text-slate-600"
             }`}
           >
-            {t === "logs" ? "直近ログ" : "月別サマリー"}
+            {TAB_LABELS[t]}
           </button>
         ))}
       </div>
 
-      <div className="p-5">
-        {tab === "logs" ? (
+      <div className="p-4 sm:p-5">
+        {tab === "logs" && (
           <RecentLogsTable logs={logs} embedded seasonMap={seasonMap} currentSeason={currentSeason} />
-        ) : (
+        )}
+        {tab === "calendar" && (
+          <MonthlyCalendar logs={logs} />
+        )}
+        {tab === "monthly" && (
           monthStats.length > 0
             ? <SeasonSummary stats={monthStats} />
             : <p className="py-6 text-center text-sm text-slate-400">データがありません</p>

--- a/src/components/dashboard/MonthlyCalendar.tsx
+++ b/src/components/dashboard/MonthlyCalendar.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+/**
+ * MonthlyCalendar — 月間ログカレンダー
+ *
+ * react-day-picker v9 の DayPicker をベースに、各日セルを DailyLog データで
+ * カスタム描画する。
+ *
+ * 表示仕様:
+ *   - デフォルト表示: 当月（JST 基準）
+ *   - 前月 / 翌月切替: DayPicker 組み込みナビゲーション
+ *   - ログあり日セル:
+ *       - 日付番号（左上）+ 体重 / 体重差分（右上）
+ *       - カロリー / カロリー差分（中段）
+ *       - 特殊日タグ（下段）
+ *       - コンディション要約（最下段・モバイルでは省略）
+ *   - ログなし日セル: 日付番号のみ（淡色）
+ *   - 今月以外の日（outside day）: 表示しない
+ *
+ * 差分計算: buildCalendarDayMap に委譲。
+ * 直前ログ（欠損日跨ぎあり）との差分を表示する。
+ */
+
+import { createContext, useContext, useMemo, useState } from "react";
+import { DayPicker } from "react-day-picker";
+import { ja } from "date-fns/locale";
+import type { DailyLog } from "@/lib/supabase/types";
+import { buildCalendarDayMap, toDateKey, type CalendarDayData } from "@/lib/utils/calendarUtils";
+import type { DayProps } from "react-day-picker";
+import { toJstDateStr } from "@/lib/utils/date";
+
+// ── コンテキスト ──────────────────────────────────────────────────────────────
+
+interface CalendarCtx {
+  dayMap: Map<string, CalendarDayData>;
+  todayKey: string;
+}
+
+const CalendarContext = createContext<CalendarCtx>({
+  dayMap:   new Map(),
+  todayKey: "",
+});
+
+// ── カスタム Day コンポーネント ─────────────────────────────────────────────
+
+function CalendarDayCell({ day, modifiers }: DayProps) {
+  const { dayMap, todayKey } = useContext(CalendarContext);
+
+  // outside: 表示月以外の日（非表示）
+  if (modifiers.outside) {
+    return <td className="border border-slate-50 bg-slate-50/30 p-0" />;
+  }
+
+  const dateKey = toDateKey(day.date);
+  const isToday = dateKey === todayKey;
+  const data    = dayMap.get(dateKey);
+  const dayNum  = day.date.getDate();
+
+  const cellBase =
+    "border border-slate-100 align-top p-1 min-h-[72px] sm:min-h-[84px] " +
+    (isToday ? "bg-blue-50/60" : "bg-white hover:bg-slate-50/70 transition-colors");
+
+  if (!data) {
+    // ログなし
+    return (
+      <td className={cellBase}>
+        <span className={`text-[11px] font-medium ${isToday ? "text-blue-500" : "text-slate-300"}`}>
+          {dayNum}
+        </span>
+      </td>
+    );
+  }
+
+  const { log, weightDelta, calDelta, dayTags, conditionSummary } = data;
+
+  return (
+    <td className={cellBase}>
+      {/* 1行目: 日付 + 体重 */}
+      <div className="flex items-start justify-between gap-0.5">
+        <span className={`text-[11px] font-semibold ${isToday ? "text-blue-600" : "text-slate-500"}`}>
+          {dayNum}
+        </span>
+
+        {log.weight !== null && (
+          <div className="text-right leading-none">
+            <span className="text-[11px] font-semibold text-slate-700">
+              {log.weight.toFixed(1)}
+            </span>
+            <span className="ml-0.5 text-[9px] text-slate-400">kg</span>
+            {weightDelta !== null && (
+              <div className={`text-[9px] font-medium leading-none mt-0.5 ${
+                weightDelta > 0
+                  ? "text-rose-500"
+                  : weightDelta < 0
+                  ? "text-blue-500"
+                  : "text-slate-300"
+              }`}>
+                {weightDelta > 0 ? "+" : ""}{weightDelta.toFixed(1)}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* 2行目: カロリー */}
+      {log.calories !== null && (
+        <div className="mt-0.5 flex items-baseline gap-0.5 leading-none">
+          <span className="text-[9px] text-slate-500">
+            {log.calories.toLocaleString()}
+          </span>
+          <span className="text-[8px] text-slate-400">kcal</span>
+          {calDelta !== null && (
+            <span className={`text-[8px] font-medium ${
+              calDelta > 0
+                ? "text-blue-400"
+                : calDelta < 0
+                ? "text-rose-400"
+                : "text-slate-300"
+            }`}>
+              ({calDelta > 0 ? "+" : ""}{calDelta})
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* 3行目: 特殊日タグ */}
+      {dayTags.length > 0 && (
+        <div className="mt-0.5 flex flex-wrap gap-0.5">
+          {dayTags.map((tag) => (
+            <span
+              key={tag.key}
+              className={`rounded-full px-1 py-0 text-[8px] font-semibold leading-4 ${tag.colorClass}`}
+            >
+              {tag.label}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* 4行目: コンディション（モバイルでは hidden → sm 以上で表示） */}
+      {conditionSummary && (
+        <div className="mt-0.5 hidden text-[8px] leading-snug text-slate-400 sm:block">
+          {conditionSummary}
+        </div>
+      )}
+    </td>
+  );
+}
+
+// ── メインコンポーネント ──────────────────────────────────────────────────────
+
+interface MonthlyCalendarProps {
+  logs: DailyLog[];
+}
+
+export function MonthlyCalendar({ logs }: MonthlyCalendarProps) {
+  // 当月（JST 基準）でデフォルト初期化
+  const todayKey   = toJstDateStr();
+  const [y, m]     = todayKey.split("-").map(Number);
+  const [month, setMonth] = useState<Date>(new Date(y, m - 1, 1));
+
+  const dayMap = useMemo(() => buildCalendarDayMap(logs), [logs]);
+
+  const ctxValue: CalendarCtx = useMemo(
+    () => ({ dayMap, todayKey }),
+    [dayMap, todayKey]
+  );
+
+  return (
+    <CalendarContext.Provider value={ctxValue}>
+      <DayPicker
+        month={month}
+        onMonthChange={setMonth}
+        locale={ja}
+        weekStartsOn={1}
+        showOutsideDays
+        components={{ Day: CalendarDayCell }}
+        classNames={{
+          root:             "w-full",
+          months:           "w-full",
+          month:            "w-full",
+          month_caption:    "flex items-center justify-between mb-3 px-1",
+          caption_label:    "text-sm font-semibold text-slate-700",
+          nav:              "flex items-center gap-1",
+          button_previous:
+            "flex h-7 w-7 items-center justify-center rounded-lg border border-slate-200 text-slate-400 " +
+            "hover:border-slate-300 hover:text-slate-600 transition-colors",
+          button_next:
+            "flex h-7 w-7 items-center justify-center rounded-lg border border-slate-200 text-slate-400 " +
+            "hover:border-slate-300 hover:text-slate-600 transition-colors",
+          chevron:          "h-3.5 w-3.5",
+          month_grid:       "w-full border-collapse",
+          weekdays:         "",
+          weekday:          "py-1.5 text-[11px] font-semibold uppercase tracking-wide text-slate-400 text-center",
+          weeks:            "",
+          week:             "",
+          // Day は CalendarDayCell が直接 <td> を返すのでクラス指定不要
+          day:              "",
+          day_button:       "hidden", // DayButton は使わない（CalendarDayCell が全描画）
+        }}
+      />
+    </CalendarContext.Provider>
+  );
+}

--- a/src/lib/utils/calendarUtils.test.ts
+++ b/src/lib/utils/calendarUtils.test.ts
@@ -1,0 +1,215 @@
+/**
+ * calendarUtils テスト
+ *
+ * buildCalendarDayMap の差分計算・タグ処理・コンディション整形を検証する。
+ */
+
+import { buildCalendarDayMap, toDateKey } from "./calendarUtils";
+import type { DailyLog } from "@/lib/supabase/types";
+
+// ── テストデータ工場 ─────────────────────────────────────────────────────────
+
+function makeLog(overrides: Partial<DailyLog> & { log_date: string }): DailyLog {
+  return {
+    log_date:           overrides.log_date,
+    weight:             overrides.weight             ?? null,
+    calories:           overrides.calories           ?? null,
+    protein:            overrides.protein            ?? null,
+    fat:                overrides.fat                ?? null,
+    carbs:              overrides.carbs              ?? null,
+    note:               overrides.note               ?? null,
+    is_cheat_day:       overrides.is_cheat_day       ?? false,
+    is_refeed_day:      overrides.is_refeed_day      ?? false,
+    is_eating_out:      overrides.is_eating_out      ?? false,
+    is_poor_sleep:      overrides.is_poor_sleep      ?? false,
+    sleep_hours:        overrides.sleep_hours        ?? null,
+    had_bowel_movement: overrides.had_bowel_movement ?? null,
+    training_type:      overrides.training_type      ?? null,
+    work_mode:          overrides.work_mode          ?? null,
+    leg_flag:           overrides.leg_flag           ?? null,
+  };
+}
+
+// ── buildCalendarDayMap ──────────────────────────────────────────────────────
+
+describe("buildCalendarDayMap", () => {
+  it("ログがない場合は空 Map を返す", () => {
+    const result = buildCalendarDayMap([]);
+    expect(result.size).toBe(0);
+  });
+
+  it("ログ日が Map のキーになる", () => {
+    const logs = [
+      makeLog({ log_date: "2026-03-10", weight: 75.0, calories: 2000 }),
+      makeLog({ log_date: "2026-03-12", weight: 74.8, calories: 1900 }),
+    ];
+    const map = buildCalendarDayMap(logs);
+    expect(map.has("2026-03-10")).toBe(true);
+    expect(map.has("2026-03-12")).toBe(true);
+    expect(map.has("2026-03-11")).toBe(false); // ログなし日は含まれない
+  });
+
+  // ── 体重差分 ──────────────────────────────────────────────────────────────
+
+  describe("weightDelta", () => {
+    it("最初の体重記録の weightDelta は null", () => {
+      const logs = [makeLog({ log_date: "2026-03-10", weight: 75.0 })];
+      const map = buildCalendarDayMap(logs);
+      expect(map.get("2026-03-10")!.weightDelta).toBeNull();
+    });
+
+    it("連続ログの weightDelta = 当日 - 前日", () => {
+      const logs = [
+        makeLog({ log_date: "2026-03-10", weight: 75.0 }),
+        makeLog({ log_date: "2026-03-11", weight: 74.7 }),
+      ];
+      const map = buildCalendarDayMap(logs);
+      expect(map.get("2026-03-11")!.weightDelta).toBeCloseTo(-0.3);
+    });
+
+    it("欠損日を跨いだ差分: 直前体重記録との差分を返す", () => {
+      const logs = [
+        makeLog({ log_date: "2026-03-10", weight: 75.0 }),
+        // 2026-03-11 欠損
+        makeLog({ log_date: "2026-03-12", weight: 74.6 }),
+      ];
+      const map = buildCalendarDayMap(logs);
+      // 直前体重記録は 2026-03-10 (75.0)
+      expect(map.get("2026-03-12")!.weightDelta).toBeCloseTo(-0.4);
+    });
+
+    it("体重が null のエントリは weightDelta も null", () => {
+      const logs = [
+        makeLog({ log_date: "2026-03-10", weight: 75.0 }),
+        makeLog({ log_date: "2026-03-11", weight: null }), // 体重なし
+      ];
+      const map = buildCalendarDayMap(logs);
+      expect(map.get("2026-03-11")!.weightDelta).toBeNull();
+    });
+
+    it("体重 0.0 は有効値として扱い差分を計算する (falsy trap)", () => {
+      const logs = [
+        makeLog({ log_date: "2026-03-10", weight: 0.1 }),
+        makeLog({ log_date: "2026-03-11", weight: 0.0 }),
+      ];
+      const map = buildCalendarDayMap(logs);
+      expect(map.get("2026-03-11")!.weightDelta).toBeCloseTo(-0.1);
+    });
+  });
+
+  // ── カロリー差分 ──────────────────────────────────────────────────────────
+
+  describe("calDelta", () => {
+    it("最初のカロリー記録の calDelta は null", () => {
+      const logs = [makeLog({ log_date: "2026-03-10", calories: 2000 })];
+      const map = buildCalendarDayMap(logs);
+      expect(map.get("2026-03-10")!.calDelta).toBeNull();
+    });
+
+    it("連続ログの calDelta = 当日 - 前日", () => {
+      const logs = [
+        makeLog({ log_date: "2026-03-10", calories: 2000 }),
+        makeLog({ log_date: "2026-03-11", calories: 1800 }),
+      ];
+      const map = buildCalendarDayMap(logs);
+      expect(map.get("2026-03-11")!.calDelta).toBe(-200);
+    });
+
+    it("calories が null の場合 calDelta は null", () => {
+      const logs = [
+        makeLog({ log_date: "2026-03-10", calories: 2000 }),
+        makeLog({ log_date: "2026-03-11", calories: null }),
+      ];
+      const map = buildCalendarDayMap(logs);
+      expect(map.get("2026-03-11")!.calDelta).toBeNull();
+    });
+
+    it("欠損日を跨いだカロリー差分: 直前カロリー記録との差分を返す", () => {
+      const logs = [
+        makeLog({ log_date: "2026-03-10", calories: 2000 }),
+        makeLog({ log_date: "2026-03-13", calories: 2200 }), // 11, 12 は欠損
+      ];
+      const map = buildCalendarDayMap(logs);
+      expect(map.get("2026-03-13")!.calDelta).toBe(200);
+    });
+
+    it("体重とカロリーの差分は独立して計算される", () => {
+      // 2026-03-11: 体重あり・カロリーなし → weightDelta あり、calDelta なし
+      const logs = [
+        makeLog({ log_date: "2026-03-10", weight: 75.0, calories: 2000 }),
+        makeLog({ log_date: "2026-03-11", weight: 74.8, calories: null }),
+        makeLog({ log_date: "2026-03-12", weight: null, calories: 1900 }),
+      ];
+      const map = buildCalendarDayMap(logs);
+      expect(map.get("2026-03-11")!.weightDelta).toBeCloseTo(-0.2);
+      expect(map.get("2026-03-11")!.calDelta).toBeNull();
+      expect(map.get("2026-03-12")!.weightDelta).toBeNull();
+      expect(map.get("2026-03-12")!.calDelta).toBe(-100);
+    });
+  });
+
+  // ── 特殊日タグ ────────────────────────────────────────────────────────────
+
+  describe("dayTags", () => {
+    it("is_cheat_day=true のとき dayTags にチートデイが含まれる", () => {
+      const logs = [makeLog({ log_date: "2026-03-10", is_cheat_day: true })];
+      const map = buildCalendarDayMap(logs);
+      const tags = map.get("2026-03-10")!.dayTags;
+      expect(tags.some((t) => t.key === "is_cheat_day")).toBe(true);
+      expect(tags.find((t) => t.key === "is_cheat_day")!.label).toBe("チートデイ");
+    });
+
+    it("is_cheat_day=false のとき dayTags に含まれない", () => {
+      const logs = [makeLog({ log_date: "2026-03-10", is_cheat_day: false })];
+      const map = buildCalendarDayMap(logs);
+      expect(map.get("2026-03-10")!.dayTags).toHaveLength(0);
+    });
+
+    it("複数タグが同時に true のとき全て含まれる", () => {
+      const logs = [makeLog({ log_date: "2026-03-10", is_cheat_day: true, is_eating_out: true })];
+      const map = buildCalendarDayMap(logs);
+      const keys = map.get("2026-03-10")!.dayTags.map((t) => t.key);
+      expect(keys).toContain("is_cheat_day");
+      expect(keys).toContain("is_eating_out");
+    });
+  });
+
+  // ── コンディション ────────────────────────────────────────────────────────
+
+  describe("conditionSummary", () => {
+    it("便通・training_type・work_mode から1行テキストを生成する", () => {
+      const logs = [makeLog({
+        log_date: "2026-03-10",
+        had_bowel_movement: true,
+        training_type: "quads",
+        work_mode: "remote",
+      })];
+      const map = buildCalendarDayMap(logs);
+      expect(map.get("2026-03-10")!.conditionSummary).toBe("便通あり / 四頭 / 在宅");
+    });
+
+    it("全て null の場合 conditionSummary は null", () => {
+      const logs = [makeLog({ log_date: "2026-03-10" })];
+      const map = buildCalendarDayMap(logs);
+      expect(map.get("2026-03-10")!.conditionSummary).toBeNull();
+    });
+
+    it("had_bowel_movement=false のとき「便通なし」が含まれる", () => {
+      const logs = [makeLog({ log_date: "2026-03-10", had_bowel_movement: false })];
+      const map = buildCalendarDayMap(logs);
+      expect(map.get("2026-03-10")!.conditionSummary).toBe("便通なし");
+    });
+  });
+});
+
+// ── toDateKey ────────────────────────────────────────────────────────────────
+
+describe("toDateKey", () => {
+  it("Date → YYYY-MM-DD 文字列に変換する", () => {
+    expect(toDateKey(new Date(2026, 2, 10))).toBe("2026-03-10"); // 月は 0-indexed
+  });
+
+  it("1桁の月・日をゼロパディングする", () => {
+    expect(toDateKey(new Date(2026, 0, 5))).toBe("2026-01-05");
+  });
+});

--- a/src/lib/utils/calendarUtils.ts
+++ b/src/lib/utils/calendarUtils.ts
@@ -1,0 +1,114 @@
+/**
+ * calendarUtils — 月間カレンダー表示用データ変換
+ *
+ * DailyLog[] を YYYY-MM-DD キーの Map に変換し、各日のカレンダーセル描画に必要な
+ * 情報（体重差分・カロリー差分・特殊日タグ・コンディション）を導出する。
+ *
+ * 差分計算ルール:
+ *   体重差分: ログ日付昇順で並べたとき、直前に体重記録があるエントリとの差分。
+ *             欠損日をまたぐ（例: 月曜→木曜）場合も直前ログとの差分を返す。
+ *   カロリー差分: 同じく直前にカロリー記録があるエントリとの差分。
+ */
+
+import type { DailyLog } from "@/lib/supabase/types";
+import { DAY_TAGS, DAY_TAG_LABELS, DAY_TAG_BADGE_COLORS } from "./dayTags";
+import { formatConditionSummary } from "./trainingType";
+
+// ── 型定義 ──────────────────────────────────────────────────────────────────
+
+export interface CalendarDayTagInfo {
+  key: string;
+  label: string;
+  colorClass: string;
+}
+
+/**
+ * 1日分のカレンダーセル表示データ。
+ * ログが存在する日のみ Map に含まれる（ログなし日は undefined）。
+ */
+export interface CalendarDayData {
+  log: DailyLog;
+  /** 直前体重記録との差分。直前ログがないか、体重 null の場合は null */
+  weightDelta: number | null;
+  /** 直前カロリー記録との差分。直前ログがないか、calories null の場合は null */
+  calDelta: number | null;
+  /** 有効な特殊日タグ（true のものだけ） */
+  dayTags: CalendarDayTagInfo[];
+  /**
+   * 便通・トレーニング種別・勤務形態の一行整形テキスト。
+   * 表示項目がない場合は null。
+   */
+  conditionSummary: string | null;
+}
+
+// ── 主要関数 ──────────────────────────────────────────────────────────────
+
+/**
+ * DailyLog[] を YYYY-MM-DD キーの CalendarDayData マップに変換する。
+ *
+ * - ログが存在しない日は Map に含まれない
+ * - 差分は「直前のログ日の記録値」との差分（欠損日を跨ぐ）
+ */
+export function buildCalendarDayMap(logs: DailyLog[]): Map<string, CalendarDayData> {
+  const sorted = [...logs].sort((a, b) => a.log_date.localeCompare(b.log_date));
+
+  // 体重・カロリーそれぞれの「記録ありログ」リスト（差分計算用）
+  const withWeight = sorted.filter((d) => d.weight !== null);
+  const withCals   = sorted.filter((d) => d.calories !== null);
+
+  const map = new Map<string, CalendarDayData>();
+
+  for (const log of sorted) {
+    // 体重差分
+    let weightDelta: number | null = null;
+    if (log.weight !== null) {
+      const idx = withWeight.findIndex((d) => d.log_date === log.log_date);
+      if (idx > 0) {
+        weightDelta = Math.round((log.weight - withWeight[idx - 1].weight!) * 100) / 100;
+      }
+    }
+
+    // カロリー差分
+    let calDelta: number | null = null;
+    if (log.calories !== null) {
+      const idx = withCals.findIndex((d) => d.log_date === log.log_date);
+      if (idx > 0) {
+        calDelta = Math.round(log.calories - withCals[idx - 1].calories!);
+      }
+    }
+
+    // 特殊日タグ（true のもののみ）
+    const dayTags: CalendarDayTagInfo[] = DAY_TAGS
+      .filter((tag) => log[tag])
+      .map((tag) => ({
+        key:        tag,
+        label:      DAY_TAG_LABELS[tag],
+        colorClass: DAY_TAG_BADGE_COLORS[tag],
+      }));
+
+    // コンディション情報
+    const conditionSummary = formatConditionSummary({
+      had_bowel_movement: log.had_bowel_movement as boolean | null,
+      training_type:      log.training_type,
+      work_mode:          log.work_mode,
+    });
+
+    map.set(log.log_date, { log, weightDelta, calDelta, dayTags, conditionSummary });
+  }
+
+  return map;
+}
+
+/**
+ * Date オブジェクトを YYYY-MM-DD 文字列に変換する（ローカル日付）。
+ *
+ * `new Date(dateStr)` は UTC 解釈になるため使用禁止。
+ * DayPicker が渡す Date は JS の new Date(year, monthIndex, day) で生成される
+ * ローカル日付のため、この関数でローカル年月日を取り出す。
+ */
+export function toDateKey(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}


### PR DESCRIPTION
## 概要

ダッシュボードの「直近ログ」「月別サマリー」に加えて、**カレンダータブ**を追加する。
月単位でログの体重・カロリー・特殊日・コンディション情報を俯瞰できる。

## 変更内容

| ファイル | 変更内容 |
|---|---|
| `src/lib/utils/calendarUtils.ts` | DailyLog[] → CalendarDayData マップ変換ロジック |
| `src/lib/utils/calendarUtils.test.ts` | calendarUtils の単体テスト 20件 |
| `src/components/dashboard/MonthlyCalendar.tsx` | react-day-picker ベースの月間カレンダーコンポーネント |
| `src/components/dashboard/LogsAndSummaryTabs.tsx` | calendar タブ追加（2タブ→3タブ） |
| `package.json` / `package-lock.json` | react-day-picker v9 追加 |

## react-day-picker 採用理由

- 月グリッドの構造（週行・曜日ヘッダー・月ナビゲーション）を提供する
- `components.Day` で各日セルを完全にカスタム描画できる
- FullCalendar 相当のイベント管理機能は今回過剰；react-day-picker は軽量で十分

## カレンダー表示仕様

| 項目 | 表示ルール |
|---|---|
| デフォルト月 | JST 当月 |
| ナビゲーション | DayPicker 組み込み前月 / 翌月ボタン |
| 表示月以外の日（outside day） | 非表示（淡い背景のみ） |
| 今日 | セル背景を青みがかりで強調 |
| 体重差分 | 直前体重記録との差分（欠損日跨ぎあり） |
| カロリー差分 | 直前カロリー記録との差分（欠損日跨ぎあり）、体重差分とは独立 |
| 特殊日タグ | is_cheat_day / is_refeed_day / is_eating_out（true のみ） |
| コンディション要約 | 便通 / トレーニング種別 / 勤務形態（sm 以上で表示、モバイルは省略） |
| ログなし日 | 日付番号のみ（淡色） |

## テスト

- `calendarUtils.test.ts` 20件追加（weightDelta / calDelta / dayTags / conditionSummary / toDateKey）
- 全 597 テスト pass
- `npx tsc --noEmit` pass
- `next build` pass

## 影響範囲

- ダッシュボードのみ。他ページは無影響。
- `LogsAndSummaryTabs` は既存の「直近ログ」「月別サマリー」を維持したまま3タブ化。

## 残課題（今回スコープ外）

- 日セルクリック → 詳細ポップオーバー / ログ編集導線（別 Issue）
- 週表示モード（別 Issue）
- 月ヘッダーに月間サマリー（平均体重・平均カロリー）を表示（別 Issue）

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)