### PR TITLE
feat: show monthly target weight line on 7d and 31d charts

### DIFF
--- a/src/components/charts/ForecastChart.tsx
+++ b/src/components/charts/ForecastChart.tsx
@@ -105,6 +105,7 @@ export function ForecastChart({
     ...visibleActual,
     ...visibleForecast,
     ...(goalWeight && rangeTab === "default" ? [goalWeight] : []),
+    ...(monthlyTarget && monthlyTarget > 0 ? [monthlyTarget] : []),
   ];
 
   // タブごとのパディング（7日は±1.5kg、31日は±2.5kg、全体は広め）
@@ -189,7 +190,7 @@ export function ForecastChart({
               label={{ value: "Goal", fontSize: 10, fill: "#ef4444" }}
             />
           )}
-          {rangeTab === "default" && monthlyTarget && monthlyTarget > 0 && (
+          {monthlyTarget && monthlyTarget > 0 && (
             <ReferenceLine
               y={monthlyTarget}
               stroke="#f97316"


### PR DESCRIPTION
## 概要

7日・31日表示でも月次目標体重ラインを表示する。全体表示のみに限定していた条件を解除し、全タブで共通表示するよう変更。

## 変更内容

**`src/components/charts/ForecastChart.tsx`** — 2行変更

1. `monthlyTarget` の `ReferenceLine` 条件から `rangeTab === "default" &&` を削除  
   → 全タブ（7日・31日・全体）で同じオレンジ点線を表示
2. `rangeWeights`（Y軸範囲計算）に `monthlyTarget` を全タブで追加  
   → target 値がグラフ範囲外に隠れないよう保証

## target ラインの共通化方針

月次目標体重は単一値（設定画面の `monthly_target`）のため、表示期間による切り替えは不要。  
`ReferenceLine y={monthlyTarget}` を全タブで無条件描画することで、最小差分で共通化した。  
色 (`#f97316`)・線種 (`strokeDasharray="6 3"`)・ラベル (`"Monthly"`) は全体表示と統一。

## target 未設定時の扱い

`monthlyTarget && monthlyTarget > 0` の条件を維持しており、未設定（`undefined` / `0`）時は表示しない。既存挙動と同じ。

## テスト

ForecastChart の専用テストは既存なし。tsc + jest 606/606 pass を確認。

## 影響範囲

- `ForecastChart.tsx` のみ
- 既存の全体表示の `goalWeight` ライン・`contestDate` ライン・予測線は変更なし
- Y 軸範囲計算に `monthlyTarget` が加わるため、target 値が極端に離れている場合は軸が広がる可能性あり（実運用上は問題ない範囲）

Closes #44