### PR TITLE
fix: simplify weight chart y-axis labels and tick intervals

### DIFF
--- a/src/components/charts/ForecastChart.tsx
+++ b/src/components/charts/ForecastChart.tsx
@@ -117,6 +117,16 @@ export function ForecastChart({
     : Math.floor((dataMin - yPad) * 10) / 10;
   const yMax = Math.ceil((dataMax + yPad) * 10) / 10;
 
+  // Y軸 tick 配列（7日: 1kg刻み、31日: 2kg刻み、全体: Recharts 自動）
+  const yTicks: number[] | undefined = (() => {
+    if (rangeTab === "default") return undefined;
+    const step = rangeTab === "7d" ? 1 : 2;
+    const start = Math.ceil(yMin / step) * step;
+    const ticks: number[] = [];
+    for (let v = start; v <= yMax; v += step) ticks.push(v);
+    return ticks;
+  })();
+
   return (
     <div className="rounded-2xl border border-slate-100 bg-white p-5 shadow-sm">
       {/* ヘッダー + タブ */}
@@ -151,8 +161,8 @@ export function ForecastChart({
           <YAxis
             domain={[yMin, yMax]}
             tick={{ fontSize: 11 }}
-            tickFormatter={(v: number) => `${v}kg`}
-            tickCount={rangeTab === "7d" ? 4 : rangeTab === "31d" ? 5 : undefined}
+            tickFormatter={(v: number) => `${Math.floor(v)}kg`}
+            ticks={yTicks}
             width={52}
           />
           <Tooltip


### PR DESCRIPTION
## 概要

体重推移・予測チャートの縦軸ラベルを整数表示に統一し、7日/31日の刻み幅を調整。

## 変更内容

**`src/components/charts/ForecastChart.tsx`**

| 変更点 | 変更前 | 変更後 |
|---|---|---|
| Y軸 formatter | `` `${v}kg` `` | `` `${Math.floor(v)}kg` `` |
| 7日 tick | `tickCount={4}` | 1kg刻み整数配列 |
| 31日 tick | `tickCount={5}` | 2kg刻み整数配列 |
| 全体 tick | `tickCount={undefined}` | `ticks={undefined}`（Recharts自動、現状維持） |

## Y軸ラベル方針

`tickFormatter` を `Math.floor(v)` で整数化し全タブ共通で適用。四捨五入ではなく切り捨て。データ系列・Line/Dot の値は変更なし。

## tick 間隔の変更

`tickCount` を廃止し、`ticks` prop に明示的な整数配列を渡す方式に統一：
- 7日: step=1 → `Math.ceil(yMin)` から `Math.floor(yMax)` まで 1kg ごと
- 31日: step=2 → 2kg ごと（偶数整数に揃える）
- 全体: `ticks={undefined}` で Recharts デフォルト（変更なし）

## テスト

tsc エラーなし、jest 606/606 pass。ForecastChart の専用テストは元から存在しない。

## 影響範囲

`ForecastChart.tsx` のみ。domain・線・点・ReferenceLine は変更なし。

Closes #46