### PR TITLE
refactor: align read semantics with README design

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,14 +109,14 @@ DB は `BOOLEAN DEFAULT NULL` に移行済み。
 | featureLabels.ts 同期 | `ACTIVE_FEATURE_NAMES as const` + `ACTIVE_FEATURE_EXPLANATIONS` で TypeScript がコンパイル時に説明マップの完全性を保証 |
 | backtest 実験基盤 | `backtest.py` が CLI オプション（`--series-type` / `--max-origins` / `--origin-step-days` / `--horizons` / `--feature-set`）で実験条件を制御可能。デフォルト設定を変えずに条件比較できる |
 | TDEE batch canonical | フロント再計算を廃止。`enrich.py` が算出した値を canonical として表示 |
-| 読み取りエラー区別 | `QueryResult<T>` discriminated union（`kind: "ok"` / `kind: "error"`）で、DB エラーと正常な空状態を型レベルで分離 |
+| 読み取りエラー区別 | `QueryResult<T>` discriminated union（`kind: "ok"` / `kind: "error"`）で、DB エラーと正常な空状態を型レベルで分離。主要クエリ（daily_logs / career_logs / settings 系）に適用し、各ページで error banner を表示しつつ graceful degradation を維持する |
 
 ### settings / query layer
 
 | 項目 | 内容 |
 |---|---|
 | settings 統一 | Server Action + shared schema（zod）で保存。typed AppSettings で読み取り |
-| query layer | Supabase read 系ロジックを `src/lib/queries/` に集約 |
+| query layer | Supabase read 系ロジックを `src/lib/queries/` に集約。主要クエリは `QueryResult<T>` で状態を明示し、補助的なクエリ（career_logs-for-dashboard / predictions 等）はベストエフォートで空配列フォールバック。意図を JSDoc に明記 |
 | UI integration tests | 保存導線・fallback 導線を jsdom ベースで自動検証 |
 
 ### CI

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -22,13 +22,14 @@ const MILESTONES = [-180, -120, -90, -60, -30, -14];
 export const revalidate = 3600;
 
 export default async function HistoryPage() {
-  const [careerLogs, currentLogs, settingsResult] = await Promise.all([
+  const [careerLogsResult, currentLogs, settingsResult] = await Promise.all([
     fetchCareerLogs(),
     fetchWeightLogs(),
     fetchSettings(),
   ]);
 
   // QueryResult を展開。エラー時はフォールバック値で graceful degradation を維持する。
+  const careerLogs = careerLogsResult.kind === "ok" ? careerLogsResult.data : [];
   const settings = settingsResult.kind === "ok" ? settingsResult.data : mapToAppSettings([]);
 
   const contestDate = settings.contestDate ?? toJstDateStr();
@@ -75,7 +76,12 @@ export default async function HistoryPage() {
     <main className="min-h-screen bg-gray-50 p-6">
       <h1 className="mb-6 text-xl font-bold text-gray-800">キャリア比較</h1>
 
-      {/* Read error banner — graceful degradation: コンテンツはブロックしない */}
+      {/* Read error banners — graceful degradation: コンテンツはブロックしない */}
+      {careerLogsResult.kind === "error" && (
+        <div className="mb-4 rounded-2xl border border-rose-100 bg-rose-50 px-5 py-3 text-sm text-rose-700">
+          キャリアデータの取得中にエラーが発生しました。ページを再読み込みしてください。
+        </div>
+      )}
       {settingsResult.kind === "error" && (
         <div className="mb-4 rounded-2xl border border-rose-100 bg-rose-50 px-5 py-3 text-sm text-rose-700">
           設定データの取得中にエラーが発生しました。コンテスト日・シーズン名がデフォルト値になります。

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -9,17 +9,34 @@ import { fetchDailyLogsForSettings } from "@/lib/queries/dailyLogs";
 export const revalidate = 0;
 
 export default async function SettingsPage() {
-  const [settings, logs] = await Promise.all([
+  const [settingsRowsResult, logsResult] = await Promise.all([
     fetchSettingsRows(),
     fetchDailyLogsForSettings(),
   ]);
+
+  // QueryResult を展開。エラー時はフォールバック値で graceful degradation を維持する。
+  const settingsRows = settingsRowsResult.kind === "ok" ? settingsRowsResult.data : [];
+  const logs = logsResult.kind === "ok" ? logsResult.data : [];
   const qualityReport = calcDataQuality(logs);
 
   return (
     <main className="min-h-screen bg-gray-50 p-6">
       <h1 className="mb-6 text-xl font-bold text-gray-800">設定</h1>
+
+      {/* Read error banners — graceful degradation: コンテンツはブロックしない */}
+      {settingsRowsResult.kind === "error" && (
+        <div className="mb-5 rounded-2xl border border-rose-100 bg-rose-50 px-5 py-3 text-sm text-rose-700">
+          設定データの取得中にエラーが発生しました。ページを再読み込みしてください。
+        </div>
+      )}
+      {logsResult.kind === "error" && (
+        <div className="mb-5 rounded-2xl border border-rose-100 bg-rose-50 px-5 py-3 text-sm text-rose-700">
+          ログデータの取得中にエラーが発生しました。データ品質の表示がデフォルト値になります。
+        </div>
+      )}
+
       <div className="space-y-6">
-        <SettingsForm initialSettings={settings} />
+        <SettingsForm initialSettings={settingsRows} />
         <DataQualityPanel report={qualityReport} />
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
           <ExportSection />

--- a/src/lib/queries/dailyLogs.test.ts
+++ b/src/lib/queries/dailyLogs.test.ts
@@ -13,6 +13,9 @@ import {
   fetchPredictions,
 } from "./dailyLogs";
 
+// fetchDailyLogs, fetchDailyLogsForSettings, fetchCareerLogs は QueryResult<T> を返す。
+// fetchWeightLogs, fetchCareerLogsForDashboard, fetchPredictions はベストエフォートで空配列を返す。
+
 // ── Mock ──────────────────────────────────────────────────────────────────────
 
 const mockOrder = jest.fn();
@@ -110,19 +113,34 @@ describe("fetchWeightLogs", () => {
 describe("fetchDailyLogsForSettings", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it("正常系: ログ行を返す", async () => {
+  it("正常系: kind=ok でログ行を返す", async () => {
     const rows = [
       { log_date: "2026-03-01", weight: 72.5, calories: 2000 },
     ];
     setupChain({ data: rows, error: null });
     const result = await fetchDailyLogsForSettings();
-    expect(result).toHaveLength(1);
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.data).toHaveLength(1);
+    }
   });
 
-  it("異常系: DB エラーのとき空配列を返す", async () => {
-    setupChain({ data: null, error: { message: "DB error" } });
+  it("正常系: データが null のとき kind=ok で空配列を返す", async () => {
+    setupChain({ data: null, error: null });
     const result = await fetchDailyLogsForSettings();
-    expect(result).toEqual([]);
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.data).toEqual([]);
+    }
+  });
+
+  it("異常系: DB エラーのとき kind=error を返す", async () => {
+    setupChain({ data: null, error: { message: "DB error", code: "PGRST000" } });
+    const result = await fetchDailyLogsForSettings();
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.message).toBe("DB error");
+    }
   });
 });
 
@@ -131,20 +149,35 @@ describe("fetchDailyLogsForSettings", () => {
 describe("fetchCareerLogs", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it("正常系: CareerLog[] を返す", async () => {
+  it("正常系: kind=ok で CareerLog[] を返す", async () => {
     const rows = [
       { id: 1, log_date: "2025-01-01", weight: 75.0, season: "2025_Spring", target_date: "2025-06-01", note: null },
     ];
     setupChain({ data: rows, error: null });
     const result = await fetchCareerLogs();
-    expect(result).toHaveLength(1);
-    expect(result[0].season).toBe("2025_Spring");
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].season).toBe("2025_Spring");
+    }
   });
 
-  it("異常系: DB エラーのとき空配列を返す", async () => {
-    setupChain({ data: null, error: { message: "DB error" } });
+  it("正常系: データが null のとき kind=ok で空配列を返す", async () => {
+    setupChain({ data: null, error: null });
     const result = await fetchCareerLogs();
-    expect(result).toEqual([]);
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.data).toEqual([]);
+    }
+  });
+
+  it("異常系: DB エラーのとき kind=error を返す", async () => {
+    setupChain({ data: null, error: { message: "DB error", code: "PGRST000" } });
+    const result = await fetchCareerLogs();
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.message).toBe("DB error");
+    }
   });
 });
 

--- a/src/lib/queries/dailyLogs.ts
+++ b/src/lib/queries/dailyLogs.ts
@@ -40,7 +40,8 @@ export async function fetchDailyLogs(): Promise<QueryResult<DailyLog[]>> {
  * 体重のみが必要な軽量クエリ用（history ページの currentLogs）。
  * weight が null のレコードは除外する。
  *
- * フォールバック: エラー時は空配列を返す。
+ * フォールバック: エラー時は空配列を返す（ベストエフォート）。
+ * 補助的データのため空配列でも history ページの主要機能は維持される。
  */
 export async function fetchWeightLogs(): Promise<Pick<DailyLog, "log_date" | "weight">[]> {
   const supabase = createClient();
@@ -63,45 +64,50 @@ export async function fetchWeightLogs(): Promise<Pick<DailyLog, "log_date" | "we
  * 戻り値は DailyLog[] として型付けされるが、実際には 3 カラムのみ取得する。
  * calcDataQuality が参照するのは log_date / weight / calories のみのため安全。
  *
- * フォールバック: エラー時は空配列を返す。
+ * 戻り値:
+ *   kind: "ok"    — 取得成功。data が空配列 = ログ未入力（正常な空状態）。
+ *   kind: "error" — DB フェッチ失敗。呼び出し側で error banner を表示すること。
  */
-export async function fetchDailyLogsForSettings(): Promise<DailyLog[]> {
+export async function fetchDailyLogsForSettings(): Promise<QueryResult<DailyLog[]>> {
   const supabase = createClient();
   const { data, error } = await supabase
     .from("daily_logs")
     .select("log_date, weight, calories")
     .order("log_date", { ascending: true });
   if (error) {
-    console.error("daily_logs (settings) fetch error:", error.message);
-    return [];
+    console.error("[fetchDailyLogsForSettings] daily_logs fetch error:", error.message, { code: error.code });
+    return { kind: "error", message: error.message };
   }
-  return (data as DailyLog[]) ?? [];
+  return { kind: "ok", data: (data as DailyLog[]) ?? [] };
 }
 
 /**
  * career_logs を全カラム・日付昇順で取得する。
- * History / Dashboard ページで使われる。
+ * History ページの主データとして使われる。
  *
- * フォールバック: エラー時は空配列を返す。
+ * 戻り値:
+ *   kind: "ok"    — 取得成功。data が空配列 = 過去シーズンデータ未登録（正常な空状態）。
+ *   kind: "error" — DB フェッチ失敗。呼び出し側で error banner を表示すること。
  */
-export async function fetchCareerLogs(): Promise<CareerLog[]> {
+export async function fetchCareerLogs(): Promise<QueryResult<CareerLog[]>> {
   const supabase = createClient();
   const { data, error } = await supabase
     .from("career_logs")
     .select("*")
     .order("log_date", { ascending: true });
   if (error) {
-    console.error("career_logs fetch error:", error.message);
-    return [];
+    console.error("[fetchCareerLogs] career_logs fetch error:", error.message, { code: error.code });
+    return { kind: "error", message: error.message };
   }
-  return (data as CareerLog[]) ?? [];
+  return { kind: "ok", data: (data as CareerLog[]) ?? [] };
 }
 
 /**
  * career_logs から log_date / season / target_date のみを取得する。
  * Dashboard ページのシーズンマップ構築用（全カラム不要）。
  *
- * フォールバック: エラー時は空配列を返す。
+ * フォールバック: エラー時は空配列を返す（ベストエフォート）。
+ * シーズンバッジは補助表示のため、取得失敗時は非表示になるだけで主要機能は維持される。
  */
 export async function fetchCareerLogsForDashboard(): Promise<Pick<CareerLog, "log_date" | "season" | "target_date">[]> {
   const supabase = createClient();
@@ -117,7 +123,9 @@ export async function fetchCareerLogsForDashboard(): Promise<Pick<CareerLog, "lo
  * predictions を全カラム・日付昇順で取得する。
  * Dashboard ページの ForecastChart 用。
  *
- * フォールバック: エラー時は空配列を返す。
+ * フォールバック: エラー時は空配列を返す（ベストエフォート）。
+ * ForecastChart は predictions が空のとき非表示になるため、取得失敗時も graceful degradation が成立する。
+ * ML バッチが未実行の場合も空配列が正常な空状態として扱われるため QueryResult 化は不要。
  */
 export async function fetchPredictions(): Promise<Prediction[]> {
   const supabase = createClient();

--- a/src/lib/queries/queryResult.ts
+++ b/src/lib/queries/queryResult.ts
@@ -8,9 +8,20 @@
  *   ok with empty data — "データがない" (未入力・未設定) = 正常な空状態
  *   error              — "取得エラー" (DB 接続失敗・認証エラー等)
  *
- * analytics_cache の fresh / stale / unavailable は
- * AnalyticsAvailability (analytics/status.ts) で管理する。
- * daily_logs / settings はこの型を使用する。
+ * この型を使用する関数 (空状態と取得エラーを区別すべき主要クエリ):
+ *   - fetchDailyLogs            (daily_logs 全件)
+ *   - fetchDailyLogsForSettings (daily_logs — settings ページ用)
+ *   - fetchCareerLogs           (career_logs — history ページ主データ)
+ *   - fetchSettings             (settings → AppSettings 変換)
+ *   - fetchSettingsRows         (settings 行配列 — SettingsForm 用)
+ *
+ * ベストエフォート (空配列フォールバックで graceful degradation が成立する補助クエリ):
+ *   - fetchWeightLogs / fetchCareerLogsForDashboard / fetchPredictions
+ *   - fetchMacroTargets
+ *   各関数の JSDoc に意図を明記している。
+ *
+ * analytics_cache の fresh / stale / unavailable / error は
+ * AnalyticsAvailability (src/lib/analytics/status.ts) で管理する。
  */
 export type QueryResult<T> =
   | { kind: "ok"; data: T }

--- a/src/lib/queries/settings.test.ts
+++ b/src/lib/queries/settings.test.ts
@@ -96,12 +96,12 @@ describe("fetchSettings", () => {
 });
 
 // ── fetchSettingsRows ─────────────────────────────────────────────────────────
-// fetchSettingsRows: .from("settings").select("*") → Promise<{data, error}>
+// fetchSettingsRows: .from("settings").select("*") → Promise<QueryResult<Setting[]>>
 
 describe("fetchSettingsRows", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it("正常系: Setting[] をそのまま返す", async () => {
+  it("正常系: kind=ok で Setting[] をそのまま返す", async () => {
     const rows = [
       { key: "goal_weight", value_num: 72.5, value_str: null },
       { key: "contest_date", value_num: null, value_str: "2026-10-01" },
@@ -109,22 +109,41 @@ describe("fetchSettingsRows", () => {
     const selectFn = jest.fn().mockResolvedValue({ data: rows, error: null });
     mockFrom.mockReturnValue({ select: selectFn });
     const result = await fetchSettingsRows();
-    expect(result).toHaveLength(2);
-    expect(result[0].key).toBe("goal_weight");
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.data).toHaveLength(2);
+      expect(result.data[0].key).toBe("goal_weight");
+    }
   });
 
-  it("正常系: データが空のとき空配列を返す", async () => {
+  it("正常系: データが空のとき kind=ok で空配列を返す", async () => {
     const selectFn = jest.fn().mockResolvedValue({ data: [], error: null });
     mockFrom.mockReturnValue({ select: selectFn });
     const result = await fetchSettingsRows();
-    expect(result).toEqual([]);
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.data).toEqual([]);
+    }
   });
 
-  it("異常系: DB エラーのとき空配列を返す", async () => {
-    const selectFn = jest.fn().mockResolvedValue({ data: null, error: { message: "DB error" } });
+  it("正常系: データが null のとき kind=ok で空配列を返す", async () => {
+    const selectFn = jest.fn().mockResolvedValue({ data: null, error: null });
     mockFrom.mockReturnValue({ select: selectFn });
     const result = await fetchSettingsRows();
-    expect(result).toEqual([]);
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.data).toEqual([]);
+    }
+  });
+
+  it("異常系: DB エラーのとき kind=error を返す", async () => {
+    const selectFn = jest.fn().mockResolvedValue({ data: null, error: { message: "DB error", code: "PGRST000" } });
+    mockFrom.mockReturnValue({ select: selectFn });
+    const result = await fetchSettingsRows();
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.message).toBe("DB error");
+    }
   });
 });
 

--- a/src/lib/queries/settings.ts
+++ b/src/lib/queries/settings.ts
@@ -38,23 +38,27 @@ export async function fetchSettings(): Promise<QueryResult<AppSettings>> {
  * settings テーブルを全件取得し、行配列をそのまま返す。
  * SettingsForm など、個別の key / value_num / value_str にアクセスする場面で使う。
  *
- * フォールバック: エラー時は空配列を返す。
+ * 戻り値:
+ *   kind: "ok"    — 取得成功。data が空配列 = 設定未入力（正常な空状態）。
+ *   kind: "error" — DB フェッチ失敗。呼び出し側で error banner を表示すること。
  */
-export async function fetchSettingsRows(): Promise<Setting[]> {
+export async function fetchSettingsRows(): Promise<QueryResult<Setting[]>> {
   const supabase = createClient();
   const { data, error } = await supabase.from("settings").select("*");
   if (error) {
-    console.error("settings fetch error:", error.message);
-    return [];
+    console.error("[fetchSettingsRows] settings fetch error:", error.message, { code: error.code });
+    return { kind: "error", message: error.message };
   }
-  return (data as Setting[]) ?? [];
+  return { kind: "ok", data: (data as Setting[]) ?? [] };
 }
 
 /**
  * マクロ目標キーをピンポイントで取得し、MacroTargets と calTarget を返す。
  *
  * 取得キー: target_calories_kcal / target_protein_g / target_fat_g / target_carbs_g / goal_calories
- * フォールバック: エラー時は全 null を返す。
+ * フォールバック: エラー時は全 null を返す（ベストエフォート）。
+ * macro/page.tsx では fetchDailyLogs が別途 QueryResult を返すため、
+ * 目標値が null のときは "目標未設定" として扱い、ページはブロックしない。
  */
 export async function fetchMacroTargets(): Promise<MacroTargets & { calTarget: number | null }> {
   const supabase = createClient();


### PR DESCRIPTION
## 概要

主要クエリと補助クエリの意味論を整理し、README の設計説明と実コードのズレを解消する。

`fetchDailyLogs` / `fetchSettings` は既に `QueryResult<T>` 化済みだったが、
`fetchCareerLogs` / `fetchDailyLogsForSettings` / `fetchSettingsRows` は silent fallback のままで、
DB 障害時に「データなし」と誤認される状態だった。

## 変更内容

### `QueryResult<T>` 化（主要クエリ）

| 関数 | 変更前 | 変更後 | 呼び出し元の対応 |
|---|---|---|---|
| `fetchCareerLogs` | `CareerLog[]`（エラー時空配列） | `QueryResult<CareerLog[]>` | history/page に error banner 追加 |
| `fetchDailyLogsForSettings` | `DailyLog[]`（エラー時空配列） | `QueryResult<DailyLog[]>` | settings/page に error banner 追加 |
| `fetchSettingsRows` | `Setting[]`（エラー時空配列） | `QueryResult<Setting[]>` | settings/page に error banner 追加 |

### 意図明示（補助クエリ — ベストエフォートを維持）

`fetchWeightLogs` / `fetchCareerLogsForDashboard` / `fetchPredictions` / `fetchMacroTargets` は
空配列フォールバックのままだが JSDoc に「ベストエフォート」の意図と理由を明記した。

## query layer の意味論整理

```
QueryResult<T> を使う（空状態と取得エラーを区別すべき主要クエリ）:
  fetchDailyLogs / fetchDailyLogsForSettings / fetchCareerLogs
  fetchSettings / fetchSettingsRows

ベストエフォート（補助的データで graceful degradation が成立）:
  fetchWeightLogs / fetchCareerLogsForDashboard / fetchPredictions / fetchMacroTargets

analytics_cache:
  AnalyticsAvailability（fresh/stale/unavailable/error）で管理
```

## UI 側の状態整理

| ページ | 追加した error banner |
|---|---|
| history/page.tsx | careerLogsResult.kind === "error" → キャリアデータ取得失敗バナー |
| settings/page.tsx | settingsRowsResult.kind === "error" → 設定データ取得失敗バナー |
| settings/page.tsx | logsResult.kind === "error" → ログデータ取得失敗バナー（DataQuality 用） |

## README 整合

- `読み取りエラー区別` の説明を「主要クエリのみ QueryResult 化」の実態に合わせて補正
- `query layer` の説明にベストエフォートクエリへの言及を追加

## テスト

fetchDailyLogsForSettings / fetchCareerLogs / fetchSettingsRows の各テストを QueryResult パターンに更新・拡充。
606 → 609 tests（3件追加）。tsc エラーなし。

## 影響範囲

- `src/lib/queries/dailyLogs.ts` / `settings.ts` / `queryResult.ts`（query layer）
- `src/app/history/page.tsx` / `src/app/settings/page.tsx`（呼び出し元）
- `src/lib/queries/dailyLogs.test.ts` / `settings.test.ts`（テスト）
- `README.md`（ドキュメント）

Closes #40