### PR TITLE
refactor: strengthen AI explanation layer single source (Issue #41)

### DIFF
--- a/ml-pipeline/analyze.py
+++ b/ml-pipeline/analyze.py
@@ -47,6 +47,7 @@ from feature_registry import (
     TargetType,
     active_feature_cols,
     active_feature_labels,
+    active_feature_names,
     active_features,
 )
 
@@ -286,6 +287,7 @@ def compute_meta(
         - date_to (str | None): 有効サンプルの最新日付。サンプルなしなら None
         - total_rows (int): 入力 df の行数（フィルタ前）
         - dropped_count (int): 欠損除外 + shift(-1) 末尾除外の合計
+        - feature_names (list[str]): アクティブ特徴量名リスト。featureLabels.ts との同期確認用。
         - feature_labels (dict[str, str]): {feature_name: label}。フロントの fallback 用。
         - feature_coverage (dict[str, float]): {feature_name: 非欠損率 0.0〜1.0}
         - target_type (str): 使用した目的変数の種類（TargetType の値）
@@ -300,6 +302,7 @@ def compute_meta(
         "date_to":          str(df_proc["log_date"].iloc[-1]) if sample_count > 0 else None,
         "total_rows":       total_rows,
         "dropped_count":    total_rows - sample_count,
+        "feature_names":    active_feature_names(),
         "feature_labels":   active_feature_labels(),
         "feature_coverage": compute_feature_coverage(df),
         "target_type":      target_type.value,

--- a/ml-pipeline/feature_registry.py
+++ b/ml-pipeline/feature_registry.py
@@ -6,10 +6,12 @@ feature_registry.py — 因子分析 特徴量定義の単一ソース
 ■ 設計方針
   - 特徴量の「名前 / 表示ラベル / 型 / nullable / ソース列 / encoder 方針 / 有効フラグ」を
     FeatureDef に集約する。
-  - analyze.py は active_feature_cols() / active_feature_labels() を呼んで使う。
+  - analyze.py は active_feature_cols() / active_feature_labels() / active_feature_names() を呼んで使う。
     FEATURE_COLS / FEATURE_LABELS を直書きしない。
   - フロントエンドは _meta.feature_labels (payload に含まれる) をフォールバックとして使える。
     featureLabels.ts の FEATURE_LABEL_MAP が第一優先だが、未登録キーは payload 側を使用する。
+  - featureLabels.ts の ACTIVE_FEATURE_NAMES との同期は test_feature_registry.py の
+    TestActiveFeatureNamesSync が自動検証する。
 
 ■ active フラグの意味
   active=True  : 現在の XGBoost 学習で使用する
@@ -240,6 +242,15 @@ def active_features() -> list[FeatureDef]:
 def active_feature_cols() -> list[str]:
     """現在学習に使用する特徴量列名リストを返す。analyze.py の FEATURE_COLS に相当。"""
     return [f.name for f in FEATURE_REGISTRY if f.active]
+
+
+def active_feature_names() -> list[str]:
+    """現在学習に使用する特徴量名リストを返す。active_feature_cols() の意図明示版。
+
+    compute_meta() の "feature_names" キーに格納し、フロントエンドが
+    featureLabels.ts の ACTIVE_FEATURE_NAMES との同期確認に利用できるようにする。
+    """
+    return active_feature_cols()
 
 
 def active_feature_labels() -> dict[str, str]:

--- a/ml-pipeline/test_analyze.py
+++ b/ml-pipeline/test_analyze.py
@@ -283,7 +283,7 @@ class TestComputeMeta:
         meta = compute_meta(df)
         for key in [
             "sample_count", "date_from", "date_to", "total_rows", "dropped_count",
-            "feature_labels", "feature_coverage", "target_type",
+            "feature_names", "feature_labels", "feature_coverage", "target_type",
         ]:
             assert key in meta
 
@@ -366,6 +366,20 @@ class TestComputeMeta:
         df = _make_df(n=20)
         meta = compute_meta(df)
         assert meta["target_type"] == TargetType.NEXT_DAY_CHANGE.value
+
+    def test_feature_names_is_list_of_strings(self):
+        """feature_names はアクティブ特徴量名の文字列リストで返る。"""
+        df = _make_df(n=20)
+        meta = compute_meta(df)
+        names = meta["feature_names"]
+        assert isinstance(names, list)
+        assert all(isinstance(n, str) for n in names)
+
+    def test_feature_names_matches_feature_cols(self):
+        """feature_names は FEATURE_COLS と同じ内容を返す。"""
+        df = _make_df(n=20)
+        meta = compute_meta(df)
+        assert meta["feature_names"] == FEATURE_COLS
 
 
 # ── compute_feature_coverage のテスト ────────────────────────────────────────

--- a/ml-pipeline/test_feature_registry.py
+++ b/ml-pipeline/test_feature_registry.py
@@ -5,6 +5,9 @@ test_feature_registry.py — feature_registry.py の単体テスト
 依存: 標準ライブラリのみ（pandas / xgboost 不要）
 """
 
+import pathlib
+import re
+
 import pytest
 
 from feature_registry import (
@@ -15,6 +18,7 @@ from feature_registry import (
     TargetType,
     active_feature_cols,
     active_feature_labels,
+    active_feature_names,
     active_features,
     all_feature_labels,
 )
@@ -228,3 +232,88 @@ class TestAllFeatureLabels:
 
     def test_count_matches_registry(self):
         assert len(all_feature_labels()) == len(FEATURE_REGISTRY)
+
+
+# ── active_feature_names のテスト ─────────────────────────────────────────────
+
+class TestActiveFeatureNames:
+    def test_returns_list_of_strings(self):
+        result = active_feature_names()
+        assert isinstance(result, list)
+        assert all(isinstance(n, str) for n in result)
+
+    def test_equals_active_feature_cols(self):
+        """active_feature_names() は active_feature_cols() と同じ値を返す。"""
+        assert active_feature_names() == active_feature_cols()
+
+    def test_contains_current_xgboost_features(self):
+        names = active_feature_names()
+        for expected in ["cal_lag1", "rolling_cal_7", "p_lag1", "f_lag1", "c_lag1"]:
+            assert expected in names
+
+    def test_no_inactive_features_included(self):
+        names = set(active_feature_names())
+        for f in FEATURE_REGISTRY:
+            if not f.active:
+                assert f.name not in names
+
+
+# ── featureLabels.ts との同期確認テスト ───────────────────────────────────────
+
+_FEATURE_LABELS_TS = (
+    pathlib.Path(__file__).parent.parent
+    / "src" / "lib" / "utils" / "featureLabels.ts"
+)
+
+
+def _parse_active_feature_names_from_ts() -> list[str]:
+    """featureLabels.ts から ACTIVE_FEATURE_NAMES 配列の要素を正規表現で抽出する。"""
+    text = _FEATURE_LABELS_TS.read_text(encoding="utf-8")
+    # ACTIVE_FEATURE_NAMES = [ ... ] as const; ブロックを抽出
+    block_match = re.search(
+        r"export const ACTIVE_FEATURE_NAMES\s*=\s*\[(.*?)\]\s*as const",
+        text,
+        re.DOTALL,
+    )
+    if not block_match:
+        raise ValueError("ACTIVE_FEATURE_NAMES not found in featureLabels.ts")
+    block = block_match.group(1)
+    # "..." 形式の文字列リテラルを全て抽出
+    return re.findall(r'"([^"]+)"', block)
+
+
+class TestActiveFeatureNamesSync:
+    """Python feature_registry と TypeScript featureLabels.ts の同期を検証する。
+
+    特徴量を追加・削除したとき、両ファイルを同時に更新しないと
+    このテストが失敗して変更漏れを検知できる。
+    """
+
+    def test_featurelabels_ts_exists(self):
+        """featureLabels.ts がリポジトリに存在する。"""
+        assert _FEATURE_LABELS_TS.exists(), f"not found: {_FEATURE_LABELS_TS}"
+
+    def test_active_feature_names_match_ts(self):
+        """Python の active_feature_names() と TS の ACTIVE_FEATURE_NAMES が一致する。"""
+        py_names = sorted(active_feature_names())
+        ts_names = sorted(_parse_active_feature_names_from_ts())
+        assert py_names == ts_names, (
+            f"Python と TypeScript のアクティブ特徴量が不一致。\n"
+            f"  Python (feature_registry.py): {py_names}\n"
+            f"  TypeScript (featureLabels.ts): {ts_names}\n"
+            f"両ファイルを同期させてください。"
+        )
+
+    def test_no_extra_names_in_ts(self):
+        """TS の ACTIVE_FEATURE_NAMES に Python 側にない名前が含まれない。"""
+        py_names = set(active_feature_names())
+        ts_names = set(_parse_active_feature_names_from_ts())
+        extra = ts_names - py_names
+        assert not extra, f"TS にのみ存在する特徴量名: {extra}"
+
+    def test_no_missing_names_in_ts(self):
+        """Python の active_feature_names() が TS の ACTIVE_FEATURE_NAMES を完全に含む。"""
+        py_names = set(active_feature_names())
+        ts_names = set(_parse_active_feature_names_from_ts())
+        missing = py_names - ts_names
+        assert not missing, f"TS に追加が必要な特徴量名: {missing}"

--- a/src/lib/utils/factorAnalysisUtils.ts
+++ b/src/lib/utils/factorAnalysisUtils.ts
@@ -55,7 +55,9 @@ export interface FactorMeta {
   date_from: string | null;
   date_to: string | null;
   total_rows: number;
-  dropped_count?: number;  // 旧キャッシュとの後方互換で省略可
+  dropped_count?: number;     // 旧キャッシュとの後方互換で省略可
+  feature_names?: string[];   // アクティブ特徴量名リスト (featureLabels.ts との同期確認用)
+  feature_labels?: Record<string, string>; // {feature_name: label} フロントの fallback 用
 }
 
 /**


### PR DESCRIPTION
## Summary

- **`feature_registry.py`**: `active_feature_names()` を追加（`active_feature_cols()` の意図明示版）
- **`analyze.py`**: `compute_meta()` の出力に `feature_names` キーを追加（featureLabels.ts との同期確認用）
- **`factorAnalysisUtils.ts`**: `FactorMeta` に `feature_names?: string[]` / `feature_labels?: Record<string, string>` を追加（旧キャッシュ後方互換で省略可）
- **`test_feature_registry.py`**: `TestActiveFeatureNames`（4 tests）+ `TestActiveFeatureNamesSync`（4 tests）を追加。後者は featureLabels.ts の `ACTIVE_FEATURE_NAMES` を正規表現で読み取り Python 側 `active_feature_names()` と一致を検証するクロスランゲージ同期テスト
- **`test_analyze.py`**: `TestComputeMeta` に `feature_names` キーの存在・内容テストを 2 件追加

## Test plan

- [x] Python: `pytest ml-pipeline/test_feature_registry.py test_analyze.py -v` — 91 passed
- [x] TypeScript: `npx tsc --noEmit` — 0 errors
- [x] Jest: `npx jest --no-coverage` — 609 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)