### PR TITLE
feat: simplify work mode options to three categories

### DIFF
--- a/src/app/actions/saveDailyLog.ts
+++ b/src/app/actions/saveDailyLog.ts
@@ -33,7 +33,7 @@ export type SaveDailyLogInput = {
   had_bowel_movement?: boolean | null;
   /** 'chest' | 'back' | 'shoulders' | 'glutes_hamstrings' | 'quads' */
   training_type?: string | null;
-  /** 'off' | 'office' | 'remote' | 'active' | 'travel' | 'other' */
+  /** 'off' | 'office' | 'remote' */
   work_mode?: string | null;
   // leg_flag はユーザーから受け取らない。training_type から導出する。
 };

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -160,7 +160,7 @@ export type Database = {
           had_bowel_movement: boolean | null;
           /** 値: 'chest' | 'back' | 'shoulders' | 'glutes_hamstrings' | 'quads' */
           training_type: string | null;
-          /** 値: 'off' | 'office' | 'remote' | 'active' | 'travel' | 'other' */
+          /** 値: 'off' | 'office' | 'remote' */
           work_mode: string | null;
           /** training_type から導出 (quads/glutes_hamstrings → true, それ以外 → false, 未入力 → null) */
           leg_flag: boolean | null;

--- a/src/lib/utils/__tests__/trainingType.test.ts
+++ b/src/lib/utils/__tests__/trainingType.test.ts
@@ -173,13 +173,19 @@ describe("formatConditionSummary", () => {
       ["off",    "休日"],
       ["office", "出社"],
       ["remote", "在宅"],
-      ["active", "活動"],
-      ["travel", "遠征"],
-      ["other",  "その他"],
     ];
     for (const [mode, label] of cases) {
       const result = formatConditionSummary({ had_bowel_movement: null, training_type: null, work_mode: mode });
       expect(result).toBe(label);
+    }
+  });
+
+  test("廃止された work_mode 値は isValidWorkMode で false になる", () => {
+    // active / travel / other は UI から削除済み。既存データとして残る可能性があるが、
+    // 表示では無効値として扱い、formatConditionSummary は null を返す。
+    for (const v of ["active", "travel", "other"]) {
+      const result = formatConditionSummary({ had_bowel_movement: null, training_type: null, work_mode: v });
+      expect(result).toBeNull();
     }
   });
 

--- a/src/lib/utils/calendarUtils.ts
+++ b/src/lib/utils/calendarUtils.ts
@@ -48,14 +48,11 @@ export interface CalendarDayData {
 
 // ── コンディションタグ ────────────────────────────────────────────────────────
 
-/** 勤務モード別バッジカラー */
+/** 勤務モード別バッジカラー (off / office / remote の3カテゴリ) */
 const WORK_MODE_COLOR: Record<string, string> = {
   off:    "bg-amber-100 text-amber-700",
   office: "bg-slate-100 text-slate-600",
   remote: "bg-cyan-100 text-cyan-700",
-  active: "bg-orange-100 text-orange-700",
-  travel: "bg-purple-100 text-purple-700",
-  other:  "bg-slate-100 text-slate-500",
 };
 
 /**

--- a/src/lib/utils/csvParser.test.ts
+++ b/src/lib/utils/csvParser.test.ts
@@ -414,7 +414,7 @@ describe("round-trip: export → import", () => {
       note: "test note",
       is_cheat_day: true, is_refeed_day: true, is_eating_out: true, is_poor_sleep: true,
       sleep_hours: 5.5, had_bowel_movement: true,
-      training_type: "quads", work_mode: "travel", leg_flag: true,
+      training_type: "quads", work_mode: "remote", leg_flag: true,
     }];
 
     const csv = toCSV(original as Record<string, unknown>[], DAILY_LOG_COLUMNS);
@@ -429,7 +429,7 @@ describe("round-trip: export → import", () => {
     expect(row.sleep_hours).toBe(5.5);
     expect(row.had_bowel_movement).toBe(true);
     expect(row.training_type).toBe("quads");
-    expect(row.work_mode).toBe("travel");
+    expect(row.work_mode).toBe("remote");
     expect(row.leg_flag).toBe(true);
   });
 });

--- a/src/lib/utils/trainingType.ts
+++ b/src/lib/utils/trainingType.ts
@@ -34,9 +34,6 @@ export const WORK_MODES = [
   "off",
   "office",
   "remote",
-  "active",
-  "travel",
-  "other",
 ] as const;
 
 export type WorkMode = typeof WORK_MODES[number];
@@ -45,9 +42,6 @@ export const WORK_MODE_LABELS: Record<WorkMode, string> = {
   off:    "休日",
   office: "出社",
   remote: "在宅",
-  active: "活動",
-  travel: "遠征",
-  other:  "その他",
 };
 
 // ── leg_flag 導出 ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## 概要

work_mode の選択肢を 6 カテゴリから「休日 / 出社 / 在宅」の 3 カテゴリに整理する。
日次入力時の迷いを減らし、将来の condition 系特徴量投入時のカテゴリ分布を絞る。

## 変更内容

| ファイル | 変更内容 |
|---|---|
| `src/lib/utils/trainingType.ts` | `WORK_MODES` を `["off", "office", "remote"]` に削減、`WORK_MODE_LABELS` も同様に整理 |
| `src/lib/utils/calendarUtils.ts` | `WORK_MODE_COLOR` から `active` / `travel` / `other` のエントリを削除 |
| `src/app/actions/saveDailyLog.ts` | `work_mode` フィールドのコメントを更新 |
| `src/lib/supabase/types.ts` | `work_mode` のコメントを更新 |
| `src/lib/utils/__tests__/trainingType.test.ts` | 廃止カテゴリのテストを除外 + 廃止値が `isValidWorkMode` で false になることを検証するテストを追加 |
| `src/lib/utils/csvParser.test.ts` | 往復テストの `work_mode: "travel"` を有効値 `"remote"` に変更 |

## UI / 型 / 保存の整合

- **UI**: `WORK_MODES` を参照してチップ描画するため、自動的に 3 カテゴリのみ表示される
- **保存**: `isValidWorkMode` が validation gate になっており、廃止カテゴリは server action で弾かれる
- **表示**: `formatConditionSummary` / `buildConditionTags` は `isValidWorkMode` が false の値を非表示にする
- **型**: `WorkMode = "off" | "office" | "remote"` に絞られ、型レベルで整合が担保される

## 既存データの扱い

DB に `active` / `travel` / `other` が保存されているレコードが残る可能性がある。

方針:
- UI 表示では `isValidWorkMode` で弾かれるため、廃止値は非表示として扱われる（壊れない）
- 強制変換は今回のスコープ外。データが気になる場合は別 Issue で `UPDATE daily_logs SET work_mode = NULL WHERE work_mode NOT IN ('off', 'office', 'remote')` の migration を実施する

## テスト

- `trainingType.test.ts`: 有効な 3 カテゴリの表示テストを維持、廃止値が `isValidWorkMode` で false になるテストを追加
- 全テスト 607 件 PASS
- `npx tsc --noEmit` 型エラーなし

## 影響範囲

- MealLogger の UI チップが 3 つに絞られる
- カレンダータグ・RecentLogsTable の表示（既存データの廃止値は非表示になる）
- feature_registry.py の work_mode 定義は `active=False` のまま変更なし

## 残課題 (別 Issue)

- 既存データに `active` / `travel` / `other` が残っている場合の DB migration
  - `UPDATE daily_logs SET work_mode = NULL WHERE work_mode NOT IN ('off', 'office', 'remote')`

Closes #51