### PR TITLE
feat: add travel as a special day tag

### DIFF
--- a/src/app/actions/buildUpdatePayload.ts
+++ b/src/app/actions/buildUpdatePayload.ts
@@ -27,6 +27,7 @@ export function buildUpdatePayload(
   if (input.is_cheat_day !== undefined)  payload.is_cheat_day  = input.is_cheat_day;
   if (input.is_refeed_day !== undefined) payload.is_refeed_day = input.is_refeed_day;
   if (input.is_eating_out !== undefined) payload.is_eating_out = input.is_eating_out;
+  if (input.is_travel_day !== undefined) payload.is_travel_day = input.is_travel_day;
   if (input.is_poor_sleep !== undefined) payload.is_poor_sleep = input.is_poor_sleep;
 
   // Phase 2.5 新規フィールド

--- a/src/app/actions/saveDailyLog.ts
+++ b/src/app/actions/saveDailyLog.ts
@@ -25,6 +25,7 @@ export type SaveDailyLogInput = {
   is_cheat_day?: boolean;
   is_refeed_day?: boolean;
   is_eating_out?: boolean;
+  is_travel_day?: boolean;
   /** @deprecated UIからの入力廃止。既存データとの互換のため型には残す。 */
   is_poor_sleep?: boolean;
   // ── Phase 2.5 追加 ──

--- a/src/app/api/export/route.ts
+++ b/src/app/api/export/route.ts
@@ -35,7 +35,7 @@ export async function GET(req: NextRequest) {
 
     const columns = [
       "log_date", "weight", "calories", "protein", "fat", "carbs", "note",
-      "is_cheat_day", "is_refeed_day", "is_eating_out", "is_poor_sleep",
+      "is_cheat_day", "is_refeed_day", "is_eating_out", "is_travel_day", "is_poor_sleep",
       "sleep_hours", "had_bowel_movement", "training_type", "work_mode", "leg_flag",
     ];
     const csv = toCSV((data ?? []) as Record<string, unknown>[], columns);

--- a/src/components/meal/MealLogger.tsx
+++ b/src/components/meal/MealLogger.tsx
@@ -268,7 +268,7 @@ export function MealLogger({ sidebar = false }: MealLoggerProps) {
         </div>
       </div>
 
-      {/* 特殊日タグ (is_cheat_day / is_refeed_day / is_eating_out) */}
+      {/* 特殊日タグ (is_cheat_day / is_refeed_day / is_eating_out / is_travel_day) */}
       <div>
         <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">特殊日</p>
         <div className="grid grid-cols-3 gap-2">

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -152,6 +152,7 @@ export type Database = {
           is_cheat_day: boolean;
           is_refeed_day: boolean;
           is_eating_out: boolean;
+          is_travel_day: boolean;
           /** @deprecated UIからの入力を廃止。既存データ互換のため型は残す。sleep_hours を使用すること。 */
           is_poor_sleep: boolean;
           // ── Phase 2.5 追加カラム ──
@@ -176,6 +177,7 @@ export type Database = {
           is_cheat_day?: boolean;
           is_refeed_day?: boolean;
           is_eating_out?: boolean;
+          is_travel_day?: boolean;
           is_poor_sleep?: boolean;
           sleep_hours?: number | null;
           had_bowel_movement?: boolean | null;
@@ -194,6 +196,7 @@ export type Database = {
           is_cheat_day?: boolean;
           is_refeed_day?: boolean;
           is_eating_out?: boolean;
+          is_travel_day?: boolean;
           is_poor_sleep?: boolean;
           sleep_hours?: number | null;
           had_bowel_movement?: boolean | null;

--- a/src/lib/utils/calcMacro.test.ts
+++ b/src/lib/utils/calcMacro.test.ts
@@ -14,6 +14,7 @@ function makeLog(log_date: string, overrides: Partial<DailyLog> = {}): DailyLog 
     is_cheat_day:      false,
     is_refeed_day:     false,
     is_eating_out:     false,
+    is_travel_day:     false,
     is_poor_sleep:     false,
     sleep_hours:       null,
     had_bowel_movement: false,

--- a/src/lib/utils/calcReadiness.test.ts
+++ b/src/lib/utils/calcReadiness.test.ts
@@ -35,6 +35,7 @@ function makeDailyLog(
     is_cheat_day: false,
     is_refeed_day: false,
     is_eating_out: false,
+    is_travel_day: false,
     is_poor_sleep: false,
     leg_flag: false,
     ...overrides,

--- a/src/lib/utils/calcWeeklyReview.ts
+++ b/src/lib/utils/calcWeeklyReview.ts
@@ -84,6 +84,7 @@ export interface SpecialDaySummary {
   cheatDays: number;
   refeedDays: number;
   eatingOutDays: number;
+  travelDays: number;
   poorSleepDays: number;
   /** いずれかのタグが付いた日数 */
   totalTaggedDays: number;
@@ -308,6 +309,7 @@ function generateFindings(
     if (specialDays.cheatDays   > 0) parts.push(`${DAY_TAG_LABELS.is_cheat_day} ${specialDays.cheatDays} 日`);
     if (specialDays.refeedDays  > 0) parts.push(`${DAY_TAG_LABELS.is_refeed_day} ${specialDays.refeedDays} 日`);
     if (specialDays.eatingOutDays > 0) parts.push(`${DAY_TAG_LABELS.is_eating_out} ${specialDays.eatingOutDays} 日`);
+    if (specialDays.travelDays  > 0) parts.push(`${DAY_TAG_LABELS.is_travel_day} ${specialDays.travelDays} 日`);
     if (specialDays.poorSleepDays > 0) parts.push(`${DAY_TAG_LABELS.is_poor_sleep} ${specialDays.poorSleepDays} 日`);
     findings.push(`今週の特殊日: ${parts.join("、")}。体重変動の一因として参考にしてください`);
 
@@ -467,14 +469,16 @@ export function calcWeeklyReview(
   const cheatDays     = windowLogs.filter((l) => l.is_cheat_day).length;
   const refeedDays    = windowLogs.filter((l) => l.is_refeed_day).length;
   const eatingOutDays = windowLogs.filter((l) => l.is_eating_out).length;
+  const travelDays    = windowLogs.filter((l) => l.is_travel_day).length;
   const poorSleepDays = windowLogs.filter((l) => l.is_poor_sleep).length;
   const specialDays: SpecialDaySummary = {
     cheatDays,
     refeedDays,
     eatingOutDays,
+    travelDays,
     poorSleepDays,
     totalTaggedDays: windowLogs.filter(
-      (l) => l.is_cheat_day || l.is_refeed_day || l.is_eating_out || l.is_poor_sleep
+      (l) => l.is_cheat_day || l.is_refeed_day || l.is_eating_out || l.is_travel_day || l.is_poor_sleep
     ).length,
   };
 

--- a/src/lib/utils/calendarUtils.test.ts
+++ b/src/lib/utils/calendarUtils.test.ts
@@ -21,6 +21,7 @@ function makeLog(overrides: Partial<DailyLog> & { log_date: string }): DailyLog 
     is_cheat_day:       overrides.is_cheat_day       ?? false,
     is_refeed_day:      overrides.is_refeed_day      ?? false,
     is_eating_out:      overrides.is_eating_out      ?? false,
+    is_travel_day:      overrides.is_travel_day      ?? false,
     is_poor_sleep:      overrides.is_poor_sleep      ?? false,
     sleep_hours:        overrides.sleep_hours        ?? null,
     had_bowel_movement: overrides.had_bowel_movement ?? null,
@@ -171,6 +172,20 @@ describe("buildCalendarDayMap", () => {
       const keys = map.get("2026-03-10")!.dayTags.map((t) => t.key);
       expect(keys).toContain("is_cheat_day");
       expect(keys).toContain("is_eating_out");
+    });
+
+    it("is_travel_day=true のとき dayTags に旅行が含まれる", () => {
+      const logs = [makeLog({ log_date: "2026-03-10", is_travel_day: true })];
+      const map = buildCalendarDayMap(logs);
+      const tags = map.get("2026-03-10")!.dayTags;
+      expect(tags.some((t) => t.key === "is_travel_day")).toBe(true);
+      expect(tags.find((t) => t.key === "is_travel_day")!.label).toBe("旅行");
+    });
+
+    it("is_travel_day=false のとき dayTags に含まれない", () => {
+      const logs = [makeLog({ log_date: "2026-03-10", is_travel_day: false })];
+      const map = buildCalendarDayMap(logs);
+      expect(map.get("2026-03-10")!.dayTags).toHaveLength(0);
     });
   });
 

--- a/src/lib/utils/csvParser.test.ts
+++ b/src/lib/utils/csvParser.test.ts
@@ -5,6 +5,7 @@ const NEW_FIELD_DEFAULTS = {
   is_cheat_day: false,
   is_refeed_day: false,
   is_eating_out: false,
+  is_travel_day: false,
   is_poor_sleep: false,
   sleep_hours: null,
   had_bowel_movement: null,
@@ -33,7 +34,7 @@ function toCSV(rows: Record<string, unknown>[], columns: string[]): string {
 
 const DAILY_LOG_COLUMNS = [
   "log_date", "weight", "calories", "protein", "fat", "carbs", "note",
-  "is_cheat_day", "is_refeed_day", "is_eating_out", "is_poor_sleep",
+  "is_cheat_day", "is_refeed_day", "is_eating_out", "is_travel_day", "is_poor_sleep",
   "sleep_hours", "had_bowel_movement", "training_type", "work_mode", "leg_flag",
 ];
 
@@ -325,7 +326,7 @@ describe("round-trip: export → import", () => {
       log_date: "2026-03-20", weight: 65.0, calories: 2000,
       protein: 150, fat: 50, carbs: 200,
       note: "chicken, rice",
-      is_cheat_day: false, is_refeed_day: false, is_eating_out: false, is_poor_sleep: false,
+      is_cheat_day: false, is_refeed_day: false, is_eating_out: false, is_travel_day: false, is_poor_sleep: false,
       sleep_hours: null, had_bowel_movement: false,
       training_type: null, work_mode: null, leg_flag: null,
     }];
@@ -344,7 +345,7 @@ describe("round-trip: export → import", () => {
       log_date: "2026-03-21", weight: 64.5, calories: 1800,
       protein: 130, fat: 45, carbs: 180,
       note: 'say "hello" today',
-      is_cheat_day: false, is_refeed_day: false, is_eating_out: false, is_poor_sleep: false,
+      is_cheat_day: false, is_refeed_day: false, is_eating_out: false, is_travel_day: false, is_poor_sleep: false,
       sleep_hours: null, had_bowel_movement: false,
       training_type: null, work_mode: null, leg_flag: null,
     }];
@@ -361,7 +362,7 @@ describe("round-trip: export → import", () => {
       log_date: "2026-03-22", weight: 64.0, calories: 1900,
       protein: 140, fat: 40, carbs: 190,
       note: "朝: オートミール\n昼: チキン\n夜: サラダ",
-      is_cheat_day: false, is_refeed_day: false, is_eating_out: false, is_poor_sleep: false,
+      is_cheat_day: false, is_refeed_day: false, is_eating_out: false, is_travel_day: false, is_poor_sleep: false,
       sleep_hours: 7, had_bowel_movement: true,
       training_type: "chest", work_mode: "office", leg_flag: false,
     }];
@@ -381,7 +382,7 @@ describe("round-trip: export → import", () => {
         log_date: "2026-03-23", weight: 63.5, calories: 1750,
         protein: 120, fat: 38, carbs: 170,
         note: "line1\nline2",
-        is_cheat_day: false, is_refeed_day: false, is_eating_out: false, is_poor_sleep: false,
+        is_cheat_day: false, is_refeed_day: false, is_eating_out: false, is_travel_day: false, is_poor_sleep: false,
         sleep_hours: null, had_bowel_movement: false,
         training_type: null, work_mode: null, leg_flag: null,
       },
@@ -389,7 +390,7 @@ describe("round-trip: export → import", () => {
         log_date: "2026-03-24", weight: 63.0, calories: 1800,
         protein: 130, fat: 40, carbs: 175,
         note: null,
-        is_cheat_day: true, is_refeed_day: false, is_eating_out: false, is_poor_sleep: false,
+        is_cheat_day: true, is_refeed_day: false, is_eating_out: false, is_travel_day: false, is_poor_sleep: false,
         sleep_hours: 6.5, had_bowel_movement: true,
         training_type: "back", work_mode: "remote", leg_flag: false,
       },
@@ -412,7 +413,7 @@ describe("round-trip: export → import", () => {
       log_date: "2026-03-25", weight: 62.8, calories: 2100,
       protein: 160, fat: 55, carbs: 210,
       note: "test note",
-      is_cheat_day: true, is_refeed_day: true, is_eating_out: true, is_poor_sleep: true,
+      is_cheat_day: true, is_refeed_day: true, is_eating_out: true, is_travel_day: true, is_poor_sleep: true,
       sleep_hours: 5.5, had_bowel_movement: true,
       training_type: "quads", work_mode: "remote", leg_flag: true,
     }];
@@ -425,6 +426,7 @@ describe("round-trip: export → import", () => {
     expect(row.is_cheat_day).toBe(true);
     expect(row.is_refeed_day).toBe(true);
     expect(row.is_eating_out).toBe(true);
+    expect(row.is_travel_day).toBe(true);
     expect(row.is_poor_sleep).toBe(true);
     expect(row.sleep_hours).toBe(5.5);
     expect(row.had_bowel_movement).toBe(true);

--- a/src/lib/utils/csvParser.ts
+++ b/src/lib/utils/csvParser.ts
@@ -22,6 +22,7 @@ export interface ParsedRow {
   is_cheat_day: boolean;
   is_refeed_day: boolean;
   is_eating_out: boolean;
+  is_travel_day: boolean;
   is_poor_sleep: boolean;
   sleep_hours: number | null;
   /** null=未記録, true=便通あり, false=便通なし */
@@ -48,6 +49,7 @@ const ALIASES: Record<string, keyof ParsedRow> = {
   is_cheat_day: "is_cheat_day",
   is_refeed_day: "is_refeed_day",
   is_eating_out: "is_eating_out",
+  is_travel_day: "is_travel_day",
   is_poor_sleep: "is_poor_sleep",
   sleep_hours: "sleep_hours",
   had_bowel_movement: "had_bowel_movement",
@@ -234,6 +236,7 @@ export function parseCSV(text: string): ParseResult {
       is_cheat_day: parseBool(raw["is_cheat_day"] ?? ""),
       is_refeed_day: parseBool(raw["is_refeed_day"] ?? ""),
       is_eating_out: parseBool(raw["is_eating_out"] ?? ""),
+      is_travel_day: parseBool(raw["is_travel_day"] ?? ""),
       is_poor_sleep: parseBool(raw["is_poor_sleep"] ?? ""),
       sleep_hours: parseNum(raw["sleep_hours"] ?? ""),
       had_bowel_movement: parseBoolNullable(raw["had_bowel_movement"] ?? ""),

--- a/src/lib/utils/dayTags.ts
+++ b/src/lib/utils/dayTags.ts
@@ -21,6 +21,7 @@ export type DayTag =
   | "is_cheat_day"
   | "is_refeed_day"
   | "is_eating_out"
+  | "is_travel_day"
   | "is_poor_sleep"; // @deprecated 入力UI廃止。表示互換のため型に残す。
 
 /**
@@ -31,6 +32,7 @@ export const DAY_TAGS: DayTag[] = [
   "is_cheat_day",
   "is_refeed_day",
   "is_eating_out",
+  "is_travel_day",
   // is_poor_sleep は UI 入力廃止のためここには含めない
 ];
 
@@ -39,6 +41,7 @@ export const DAY_TAG_LABELS: Record<DayTag, string> = {
   is_cheat_day:  "チートデイ",
   is_refeed_day: "リフィード",
   is_eating_out: "外食",
+  is_travel_day: "旅行",
   is_poor_sleep: "睡眠不良",
 };
 
@@ -47,6 +50,7 @@ export const DAY_TAG_BADGE_COLORS: Record<DayTag, string> = {
   is_cheat_day:  "bg-rose-100 text-rose-700",
   is_refeed_day: "bg-amber-100 text-amber-700",
   is_eating_out: "bg-blue-100 text-blue-700",
+  is_travel_day: "bg-teal-100 text-teal-700",
   is_poor_sleep: "bg-purple-100 text-purple-700",
 };
 
@@ -55,6 +59,7 @@ export const DAY_TAG_ACTIVE_COLORS: Record<DayTag, string> = {
   is_cheat_day:  "bg-rose-500 text-white border-rose-500",
   is_refeed_day: "bg-amber-500 text-white border-amber-500",
   is_eating_out: "bg-blue-500 text-white border-blue-500",
+  is_travel_day: "bg-teal-500 text-white border-teal-500",
   is_poor_sleep: "bg-purple-500 text-white border-purple-500",
 };
 
@@ -62,10 +67,11 @@ export const DAY_TAG_ACTIVE_COLORS: Record<DayTag, string> = {
  * 入力 UI に表示するタグを false で初期化したオブジェクトを返す。
  * is_poor_sleep は入力 UI から廃止されたため含まない。
  */
-export function emptyTagState(): Pick<Record<DayTag, boolean>, "is_cheat_day" | "is_refeed_day" | "is_eating_out"> {
+export function emptyTagState(): Pick<Record<DayTag, boolean>, "is_cheat_day" | "is_refeed_day" | "is_eating_out" | "is_travel_day"> {
   return {
     is_cheat_day:  false,
     is_refeed_day: false,
     is_eating_out: false,
+    is_travel_day: false,
   };
 }

--- a/supabase/migrations/20260315000002_add_travel_day_to_daily_logs.sql
+++ b/supabase/migrations/20260315000002_add_travel_day_to_daily_logs.sql
@@ -1,0 +1,6 @@
+-- daily_logs に旅行タグ列を追加
+-- NOT NULL DEFAULT FALSE: 既存行は全て false になる
+ALTER TABLE daily_logs
+  ADD COLUMN IF NOT EXISTS is_travel_day BOOLEAN NOT NULL DEFAULT FALSE;
+
+COMMENT ON COLUMN daily_logs.is_travel_day IS '旅行: 旅行・遠征など通常生活から外れた日。体重・カロリー・活動量の外れ値を後から識別するために使用する。';


### PR DESCRIPTION
## 概要

特殊日タグ体系に「旅行 (`is_travel_day`)」を追加する。旅行日は体重・カロリー・活動量が通常日と異なりやすく、カレンダーやダッシュボードで後から外れ値の要因を識別できるようにする。

## 変更内容

| ファイル | 変更内容 |
|---|---|
| `src/lib/utils/dayTags.ts` | `is_travel_day` を `DayTag` 型・`DAY_TAGS`・ラベル・バッジ色・`emptyTagState` に追加 |
| `src/lib/supabase/types.ts` | `daily_logs` の Row/Insert/Update 型に `is_travel_day: boolean` を追加 |
| `src/app/actions/saveDailyLog.ts` | `SaveDailyLogInput` に `is_travel_day?: boolean` を追加 |
| `src/app/actions/buildUpdatePayload.ts` | `is_travel_day` のペイロード構築を追加 |
| `src/lib/utils/csvParser.ts` | `ParsedRow`・`ALIASES`・parse ロジックに `is_travel_day` を追加 |
| `src/app/api/export/route.ts` | CSV エクスポート列に `is_travel_day` を追加 |
| `src/lib/utils/calcWeeklyReview.ts` | `SpecialDaySummary.travelDays` を追加、週次レビューの特殊日集計・findings テキストに旅行日を反映 |
| `src/components/meal/MealLogger.tsx` | コメント更新（UI は `DAY_TAGS` 参照で自動追従） |
| `supabase/migrations/20260315000002_add_travel_day_to_daily_logs.sql` | DB カラム追加 migration |

## 旅行タグの扱い

- **入力**: `MealLogger` は `DAY_TAGS` を map して UI を描画するため、自動的に「旅行」ボタンが表示される
- **バッジ色**: teal (青緑) — 既存の rose/amber/blue/purple と識別しやすい色を選択
- **保存**: `emptyTagState` に `is_travel_day: false` を追加したため、touched 管理で既存タグと同じ動作をする
- **表示**: カレンダータグ (`buildConditionTags`) は `DAY_TAGS` ベースで動作するため、自動追従
- **週次レビュー**: `WeeklyReviewData.specialDays.travelDays` として集計され、旅行がある週は findings に「旅行 N 日」が表示される
- **CSV**: エクスポート・インポート両方で `is_travel_day` を処理する

## テスト

- `calendarUtils.test.ts`: `is_travel_day=true` でタグ表示・`false` で非表示を検証する 2 件を追加
- `csvParser.test.ts`: `DAILY_LOG_COLUMNS`・`NEW_FIELD_DEFAULTS` に追加、"全新カラム往復テスト" で検証
- `calcReadiness.test.ts` / `calcMacro.test.ts`: テストデータの `makeLog` に `is_travel_day: false` を追加
- 全 609 件 PASS（+2 件）/ `npx tsc --noEmit` 型エラーなし

## 影響範囲

- MealLogger の入力 UI に「旅行」ボタンが追加される
- カレンダータグ・RecentLogsTable の condition タグ表示に旅行が出る
- 週次レビューの特殊日サマリーに旅行日が含まれる
- CSV エクスポート / インポートに `is_travel_day` 列が追加される
- **DB migration 要**: `supabase/migrations/20260315000002_add_travel_day_to_daily_logs.sql` を本番に適用すること

## 残課題 (別 Issue)

- 特になし。今回のスコープ（旅行タグ追加）は完結している

Closes #52