### PR TITLE
feat: add off option to training type

### DIFF
--- a/src/app/actions/__tests__/saveDailyLog.test.ts
+++ b/src/app/actions/__tests__/saveDailyLog.test.ts
@@ -163,6 +163,13 @@ describe("buildUpdatePayload — Phase 2.5 新規フィールド", () => {
     expect("had_bowel_movement" in payload).toBe(false);
   });
 
+  test("training_type: 'off' → leg_flag: false (オフ日 = 非レッグ日と確定)", () => {
+    // off は「トレーニングなしと明示した日」。null (未記録) とは区別する。
+    const payload = buildUpdatePayload({ training_type: "off" });
+    expect(payload.training_type).toBe("off");
+    expect(payload.leg_flag).toBe(false);
+  });
+
   test("training_type: 'chest' → leg_flag: false が同時に設定される", () => {
     const payload = buildUpdatePayload({ training_type: "chest" });
     expect(payload.training_type).toBe("chest");
@@ -581,6 +588,14 @@ describe("saveDailyLog — Phase 2.5 バリデーション", () => {
     const result = await saveDailyLog({ log_date: "2026-03-13", sleep_hours: 0 });
     expect(result.ok).toBe(true);
     expect(capture.p_fields?.sleep_hours).toBe(0);
+  });
+
+  test("training_type: 'off' → ok: true (有効値)", async () => {
+    const capture = makeRpcMock();
+    const result = await saveDailyLog({ log_date: "2026-03-13", training_type: "off" });
+    expect(result.ok).toBe(true);
+    expect(capture.p_fields?.training_type).toBe("off");
+    expect(capture.p_fields?.leg_flag).toBe(false);
   });
 
   test("training_type が不正な値 → ok: false", async () => {

--- a/src/app/actions/saveDailyLog.ts
+++ b/src/app/actions/saveDailyLog.ts
@@ -32,7 +32,7 @@ export type SaveDailyLogInput = {
   sleep_hours?: number | null;
   /** null = 明示クリア（未記録に戻す） */
   had_bowel_movement?: boolean | null;
-  /** 'chest' | 'back' | 'shoulders' | 'glutes_hamstrings' | 'quads' */
+  /** 'off' | 'chest' | 'back' | 'shoulders' | 'glutes_hamstrings' | 'quads' */
   training_type?: string | null;
   /** 'off' | 'office' | 'remote' */
   work_mode?: string | null;

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -159,7 +159,7 @@ export type Database = {
           sleep_hours: number | null;
           /** null=未記録, true=便通あり, false=便通なし */
           had_bowel_movement: boolean | null;
-          /** 値: 'chest' | 'back' | 'shoulders' | 'glutes_hamstrings' | 'quads' */
+          /** 値: 'off' | 'chest' | 'back' | 'shoulders' | 'glutes_hamstrings' | 'quads' */
           training_type: string | null;
           /** 値: 'off' | 'office' | 'remote' */
           work_mode: string | null;

--- a/src/lib/utils/__tests__/trainingType.test.ts
+++ b/src/lib/utils/__tests__/trainingType.test.ts
@@ -32,6 +32,12 @@ describe("deriveLegFlag", () => {
     expect(deriveLegFlag("shoulders")).toBe(false);
   });
 
+  test("off → false (オフ日 = 非レッグ日と確定)", () => {
+    // off はトレーニングなしと明示した日。脚トレをしていないことが確定するため false。
+    // null (未記録・不明) とは区別する。
+    expect(deriveLegFlag("off")).toBe(false);
+  });
+
   test("null → null (未入力は未判定 ≠ false)", () => {
     expect(deriveLegFlag(null)).toBeNull();
   });
@@ -156,6 +162,7 @@ describe("formatConditionSummary", () => {
 
   test("全 training_type の表示文言が正しい", () => {
     const cases: [string, string][] = [
+      ["off",               "オフ"],
       ["chest",             "胸"],
       ["back",              "背中"],
       ["shoulders",         "肩"],

--- a/src/lib/utils/trainingType.ts
+++ b/src/lib/utils/trainingType.ts
@@ -11,6 +11,7 @@
 // ── training_type ────────────────────────────────────────────────────────────
 
 export const TRAINING_TYPES = [
+  "off",
   "chest",
   "back",
   "shoulders",
@@ -21,6 +22,7 @@ export const TRAINING_TYPES = [
 export type TrainingType = typeof TRAINING_TYPES[number];
 
 export const TRAINING_TYPE_LABELS: Record<TrainingType, string> = {
+  off:               "オフ",
   chest:             "胸",
   back:              "背中",
   shoulders:         "肩",
@@ -50,9 +52,12 @@ export const WORK_MODE_LABELS: Record<WorkMode, string> = {
  * training_type から leg_flag を導出する。
  *
  * ルール:
- *   - quads または glutes_hamstrings → true (レッグ日)
- *   - chest / back / shoulders      → false (非レッグ日)
- *   - null / undefined (未入力)     → null (未判定 ≠ false)
+ *   - quads または glutes_hamstrings → true  (レッグ日)
+ *   - chest / back / shoulders / off → false (非レッグ日)
+ *   - null / undefined (未入力)      → null  (未判定 ≠ false)
+ *
+ * off は「トレーニングなしと明示した日」であり、脚トレをしていないことが確定するため false。
+ * null は「training_type 未記録」であり、脚トレの有無が不明なため null (≠ false)。
  *
  * ユーザーが leg_flag を直接編集する UI は作らない。
  * この関数が leg_flag の唯一の定義源。


### PR DESCRIPTION
## 概要

`training_type` の選択肢に「オフ (`off`)」を追加し、「未記録 (`null`)」と「トレーニングなし (`off`)」を UI・保存・型の全レイヤーで明示的に区別できるようにする。

## 変更内容

| ファイル | 変更内容 |
|---|---|
| `src/lib/utils/trainingType.ts` | `TRAINING_TYPES` に `"off"` を追加、`TRAINING_TYPE_LABELS` に `"オフ"` を追加、`deriveLegFlag` のコメントに `off → false` の仕様を明文化 |
| `src/app/actions/saveDailyLog.ts` | `training_type` フィールドのコメントを更新 |
| `src/lib/supabase/types.ts` | `training_type` のコメントを更新 |
| `src/lib/utils/__tests__/trainingType.test.ts` | `deriveLegFlag("off") → false` テスト追加、表示文言テストに `off/オフ` を追加 |
| `src/app/actions/__tests__/saveDailyLog.test.ts` | `training_type: "off" → leg_flag: false` のテスト追加、server-side validation テスト追加 |

## training_type / leg_flag の仕様整理

### `off` と `null` の違い

| 値 | 意味 | `leg_flag` |
|---|---|---|
| `null` | 未記録（脚トレの有無が不明） | `null` |
| `"off"` | トレーニングなし（明示的にオフ日と記録） | `false` |
| `"chest"` / `"back"` / `"shoulders"` | 非レッグ日のトレーニング | `false` |
| `"quads"` / `"glutes_hamstrings"` | レッグ日 | `true` |

### `deriveLegFlag` の動作

`deriveLegFlag` のロジック変更は**不要**。`"off"` は `"quads" || "glutes_hamstrings"` にマッチしないため、自動的に `false` を返す。仕様をコメントに明文化のみ。

### UI 上の区別

- MealLogger は `TRAINING_TYPES` を map してチップ描画するため、自動的に「オフ」ボタンが追加される
- チップを再クリックすると `null`（未記録）に戻る（既存の touched 管理の動作を維持）

## テスト

- `deriveLegFlag("off") → false` を明示的に検証
- `training_type: "off"` を `saveDailyLog` に渡した際に `leg_flag: false` が payload に含まれることを検証
- server-side validation で `"off"` が `ok: true` になることを検証
- 全 613 件 PASS（+4 件）/ `npx tsc --noEmit` 型エラーなし

## 影響範囲

- MealLogger の入力 UI に「オフ」ボタンが追加される
- カレンダータグ・RecentLogsTable の condition タグ表示に「オフ」が出る
- `formatConditionSummary` で `training_type: "off"` → `"オフ"` として表示される
- CSV エクスポート / インポートは `training_type` を `string | null` で扱うため変更不要

## 残課題 (別 Issue)

- 特になし。今回のスコープ（`off` の追加）は完結している

Closes #50