### PR TITLE
feat: show sleep hours in the UI

### DIFF
--- a/src/components/dashboard/RecentLogsTable.tsx
+++ b/src/components/dashboard/RecentLogsTable.tsx
@@ -84,9 +84,14 @@ export function RecentLogsTable({ logs, embedded = false, seasonMap, currentSeas
                       </span>
                     ))}
                   </div>
-                  {conditionSummary && (
+                  {(conditionSummary || log.sleep_hours !== null) && (
                     <div className="mt-1 text-xs leading-snug text-slate-500">
-                      {conditionSummary}
+                      {[
+                        conditionSummary,
+                        log.sleep_hours !== null ? `${log.sleep_hours}h` : null,
+                      ]
+                        .filter(Boolean)
+                        .join(" / ")}
                     </div>
                   )}
                 </td>


### PR DESCRIPTION
## 概要

入力した睡眠時間 (`sleep_hours`) を直近ログテーブルで確認できるようにする。入力済みと未入力の区別が付くようにする。

## 変更内容

| ファイル | 変更内容 |
|---|---|
| `src/components/dashboard/RecentLogsTable.tsx` | 日付セルの conditionSummary 行に `sleep_hours` を追加 |

## sleep_hours の表示方針

既存の `conditionSummary`（便通・トレーニング・仕事モードの1行テキスト）と同じ行に `" / "` で結合して表示する。

| 状態 | 表示 |
|---|---|
| conditionSummary あり + sleep_hours あり | `便通あり / 四頭 / 在宅 / 6.5h` |
| conditionSummary なし + sleep_hours あり | `6.5h` |
| conditionSummary あり + sleep_hours なし | `便通あり / 四頭 / 在宅` |
| 両方なし | 非表示（既存動作を維持） |

- 単位は `h` を付けて `6.5h` のように自然に見えるようにする
- `null` は表示しない（未入力と入力済みが一目で区別できる）
- 新しいコンポーネント・ユーティリティ関数は不要（インラインで完結）

## テスト

- 全 613 件 PASS（変更なし）/ `npx tsc --noEmit` 型エラーなし
- `RecentLogsTable` は Unit test がないため、型チェックと既存テストの通過で確認

## 影響範囲

- ダッシュボードの「直近ログ」タブ（`LogsAndSummaryTabs`）の直近ログ表示
- 既存の conditionSummary の表示動作は変わらない

## 残課題 (別 Issue)

- カレンダータブへの横展開（`MonthlyCalendar` のコンディションタグに sleep_hours を追加）
  - 情報過多になりやすいため今回は対象外
- WeeklyReviewCard への sleep_hours サマリー表示（7日平均など）
  - 分析的な表示になるため別 Issue として検討

Closes #56