### PR TITLE
fix: allow partial updates on existing daily logs without hitting insert not-null errors

### DIFF
--- a/src/app/actions/__tests__/saveDailyLog.test.ts
+++ b/src/app/actions/__tests__/saveDailyLog.test.ts
@@ -608,3 +608,81 @@ describe("saveDailyLog — Phase 2.5 バリデーション", () => {
     expect(result.ok).toBe(false);
   });
 });
+
+// ════════════════════════════════════════════════════════════════════════════
+// RPC 保存戦略: UPDATE 先行 / INSERT fallback
+//
+// 旧実装の INSERT ... ON CONFLICT DO UPDATE は、p_fields に weight がないと
+// INSERT 側の NOT NULL 制約で既存行更新でも失敗する問題があった。
+// 新実装は「UPDATE 先行 → 行なければ INSERT」方式で、
+// 既存行への partial update は INSERT 側に触れない。
+// ════════════════════════════════════════════════════════════════════════════
+
+describe("saveDailyLog — 既存行 partial update (fix: INSERT NOT NULL 回避)", () => {
+  test("既存行に training_type だけ更新: weight なしでも ok: true", async () => {
+    // 既存行への partial update は INSERT 側に触れないため weight 不要
+    const capture = makeRpcMock(); // RPC 成功
+    const result = await saveDailyLog({
+      log_date: "2026-03-13",
+      training_type: "back",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(capture.p_fields?.training_type).toBe("back");
+    expect(capture.p_fields?.leg_flag).toBe(false);
+    // weight は p_fields に含まれない（既存行の値を保持する意図）
+    expect("weight" in (capture.p_fields ?? {})).toBe(false);
+  });
+
+  test("既存行に work_mode だけ更新: weight なしでも ok: true", async () => {
+    const capture = makeRpcMock();
+    const result = await saveDailyLog({
+      log_date: "2026-03-13",
+      work_mode: "remote",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(capture.p_fields?.work_mode).toBe("remote");
+    expect("weight" in (capture.p_fields ?? {})).toBe(false);
+  });
+
+  test("既存行に sleep_hours だけ更新: weight なしでも ok: true", async () => {
+    const capture = makeRpcMock();
+    const result = await saveDailyLog({
+      log_date: "2026-03-13",
+      sleep_hours: 6.5,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(capture.p_fields?.sleep_hours).toBe(6.5);
+    expect("weight" in (capture.p_fields ?? {})).toBe(false);
+  });
+
+  test("RPC が new_log_requires_weight を返す → 分かりやすいメッセージ", async () => {
+    // 新規日付への weight なし保存: RPC がエラーコードを返す
+    makeRpcMock({ message: "new_log_requires_weight" });
+    const result = await saveDailyLog({
+      log_date: "2026-03-20",
+      training_type: "chest",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toBe("新しい日付を作成するには体重の入力が必要です");
+    }
+  });
+
+  test("新規日付への weight あり保存は従来通り ok: true", async () => {
+    const capture = makeRpcMock();
+    const result = await saveDailyLog({
+      log_date: "2026-03-20",
+      weight: 70.0,
+      training_type: "chest",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(capture.p_fields?.weight).toBe(70.0);
+    expect(capture.p_fields?.training_type).toBe("chest");
+    expect(capture.p_fields?.leg_flag).toBe(false);
+  });
+});

--- a/src/app/actions/saveDailyLog.ts
+++ b/src/app/actions/saveDailyLog.ts
@@ -107,9 +107,10 @@ export async function saveDailyLog(
     return { ok: false, message: "保存するデータがありません" };
   }
 
-  // --- Supabase: RPC で atomic upsert ---
-  // save_daily_log_partial は INSERT ... ON CONFLICT DO UPDATE で
-  // read-then-write を廃し、1 回の DB 呼び出しで partial upsert を完結させる。
+  // --- Supabase: RPC で atomic save ---
+  // save_daily_log_partial は「UPDATE 先行 → 既存行なければ INSERT」方式。
+  // 既存行への partial update は INSERT 側の NOT NULL 制約に触れない。
+  // 新規行作成時に weight がなければ RPC が new_log_requires_weight 例外を返す。
   // payload の JSONB キー存在が undefined/null/値の 3 状態を担保する。
   const supabase = createClient();
 
@@ -119,6 +120,10 @@ export async function saveDailyLog(
   });
 
   if (saveError) {
+    // RPC が new_log_requires_weight を返した場合は分かりやすいメッセージに変換する
+    if (saveError.message === "new_log_requires_weight") {
+      return { ok: false, message: "新しい日付を作成するには体重の入力が必要です" };
+    }
     console.error("[saveDailyLog] rpc error:", saveError.message, "| payload keys:", Object.keys(payload));
     return { ok: false, message: "保存に失敗しました: " + saveError.message };
   }

--- a/supabase/migrations/20260315000003_fix_save_daily_log_partial_update_first.sql
+++ b/supabase/migrations/20260315000003_fix_save_daily_log_partial_update_first.sql
@@ -1,0 +1,127 @@
+-- save_daily_log_partial を「UPDATE 先行 → INSERT fallback」方式に変更する
+--
+-- 変更理由:
+--   旧実装の `INSERT ... ON CONFLICT DO UPDATE` は、p_fields に weight が含まれない
+--   partial update（例: training_type だけ更新）を既存行に対して実行すると、
+--   PostgreSQL が ON CONFLICT に到達する前に INSERT 側の weight NOT NULL 制約で失敗する。
+--
+-- 新実装の戦略:
+--   1. まず UPDATE を試みる（既存行があれば FOUND = true）
+--   2. FOUND なら即 RETURN（INSERT 側に触れない）
+--   3. 既存行がなければ INSERT（新規作成）
+--      - weight が p_fields に含まれなければ例外 new_log_requires_weight を発生させる
+--
+-- is_travel_day の追加:
+--   20260315000002 で追加された is_travel_day が旧 RPC に含まれていなかったため
+--   今回の置換で合わせて追加する。
+--
+-- 部分更新の意味論（変更なし）:
+--   - キーなし          : 未更新（既存値を保持）
+--   - キーあり, 値 null : 明示クリア
+--   - キーあり, 値あり  : 上書き
+
+CREATE OR REPLACE FUNCTION save_daily_log_partial(
+  p_log_date DATE,
+  p_fields   JSONB
+) RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  -- ── Step 1: 既存行への partial update を試みる ───────────────────────────
+  UPDATE daily_logs SET
+    weight             = CASE WHEN p_fields ? 'weight'
+                              THEN (p_fields->>'weight')::NUMERIC
+                              ELSE weight             END,
+    calories           = CASE WHEN p_fields ? 'calories'
+                              THEN (p_fields->>'calories')::NUMERIC
+                              ELSE calories           END,
+    protein            = CASE WHEN p_fields ? 'protein'
+                              THEN (p_fields->>'protein')::NUMERIC
+                              ELSE protein            END,
+    fat                = CASE WHEN p_fields ? 'fat'
+                              THEN (p_fields->>'fat')::NUMERIC
+                              ELSE fat                END,
+    carbs              = CASE WHEN p_fields ? 'carbs'
+                              THEN (p_fields->>'carbs')::NUMERIC
+                              ELSE carbs              END,
+    note               = CASE WHEN p_fields ? 'note'
+                              THEN p_fields->>'note'
+                              ELSE note               END,
+    is_cheat_day       = CASE WHEN p_fields ? 'is_cheat_day'
+                              THEN (p_fields->>'is_cheat_day')::BOOLEAN
+                              ELSE is_cheat_day       END,
+    is_refeed_day      = CASE WHEN p_fields ? 'is_refeed_day'
+                              THEN (p_fields->>'is_refeed_day')::BOOLEAN
+                              ELSE is_refeed_day      END,
+    is_eating_out      = CASE WHEN p_fields ? 'is_eating_out'
+                              THEN (p_fields->>'is_eating_out')::BOOLEAN
+                              ELSE is_eating_out      END,
+    is_travel_day      = CASE WHEN p_fields ? 'is_travel_day'
+                              THEN (p_fields->>'is_travel_day')::BOOLEAN
+                              ELSE is_travel_day      END,
+    is_poor_sleep      = CASE WHEN p_fields ? 'is_poor_sleep'
+                              THEN (p_fields->>'is_poor_sleep')::BOOLEAN
+                              ELSE is_poor_sleep      END,
+    sleep_hours        = CASE WHEN p_fields ? 'sleep_hours'
+                              THEN (p_fields->>'sleep_hours')::NUMERIC
+                              ELSE sleep_hours        END,
+    had_bowel_movement = CASE WHEN p_fields ? 'had_bowel_movement'
+                              THEN (p_fields->>'had_bowel_movement')::BOOLEAN
+                              ELSE had_bowel_movement END,
+    training_type      = CASE WHEN p_fields ? 'training_type'
+                              THEN p_fields->>'training_type'
+                              ELSE training_type      END,
+    work_mode          = CASE WHEN p_fields ? 'work_mode'
+                              THEN p_fields->>'work_mode'
+                              ELSE work_mode          END,
+    leg_flag           = CASE WHEN p_fields ? 'leg_flag'
+                              THEN (p_fields->>'leg_flag')::BOOLEAN
+                              ELSE leg_flag           END
+  WHERE log_date = p_log_date;
+
+  -- 既存行が更新できたなら終了（INSERT 側には一切触れない）
+  IF FOUND THEN
+    RETURN;
+  END IF;
+
+  -- ── Step 2: 新規行の場合は weight 必須チェック ───────────────────────────
+  -- INSERT 側の NOT NULL 制約に落とすのではなく、アプリが解釈できるエラーを返す
+  IF NOT (p_fields ? 'weight') OR (p_fields->>'weight') IS NULL THEN
+    RAISE EXCEPTION 'new_log_requires_weight';
+  END IF;
+
+  -- ── Step 3: 新規 INSERT ──────────────────────────────────────────────────
+  INSERT INTO daily_logs (
+    log_date,
+    weight, calories, protein, fat, carbs, note,
+    is_cheat_day, is_refeed_day, is_eating_out, is_travel_day, is_poor_sleep,
+    sleep_hours, had_bowel_movement,
+    training_type, work_mode, leg_flag
+  ) VALUES (
+    p_log_date,
+    (p_fields->>'weight')::NUMERIC,
+    (p_fields->>'calories')::NUMERIC,
+    (p_fields->>'protein')::NUMERIC,
+    (p_fields->>'fat')::NUMERIC,
+    (p_fields->>'carbs')::NUMERIC,
+    p_fields->>'note',
+    COALESCE((p_fields->>'is_cheat_day')::BOOLEAN,   FALSE),
+    COALESCE((p_fields->>'is_refeed_day')::BOOLEAN,  FALSE),
+    COALESCE((p_fields->>'is_eating_out')::BOOLEAN,  FALSE),
+    COALESCE((p_fields->>'is_travel_day')::BOOLEAN,  FALSE),
+    COALESCE((p_fields->>'is_poor_sleep')::BOOLEAN,  FALSE),
+    (p_fields->>'sleep_hours')::NUMERIC,
+    (p_fields->>'had_bowel_movement')::BOOLEAN,
+    p_fields->>'training_type',
+    p_fields->>'work_mode',
+    (p_fields->>'leg_flag')::BOOLEAN
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION save_daily_log_partial(DATE, JSONB) IS
+  '日次ログの partial update/insert。
+   既存行: UPDATE のみ実行（INSERT 側の NOT NULL 制約に触れない）。
+   新規行: weight 必須チェック後に INSERT。
+   p_fields の JSONB キー存在で 未更新(キーなし) / 明示クリア(キーあり+null) / 上書き(キーあり+値) を表現。
+   weight なしで新規作成を試みた場合は new_log_requires_weight 例外を発生させる。';


### PR DESCRIPTION
## 概要

既存日付への `training_type` / `work_mode` / `sleep_hours` などの partial update が `save_daily_log_partial` の INSERT 側 `weight NOT NULL` 制約で失敗する問題を修正する。

## 現象と原因

旧実装の `INSERT ... ON CONFLICT DO UPDATE` では、`p_fields` に `weight` が含まれない partial update を既存行に対して実行すると、PostgreSQL が ON CONFLICT に到達する前に INSERT 側の `weight = NULL` が `NOT NULL` 制約に引っかかって失敗する。

```
ERROR: null value in column "weight" of relation "daily_logs" violates not-null constraint
```

## 変更内容

| ファイル | 変更内容 |
|---|---|
| `supabase/migrations/20260315000003_fix_save_daily_log_partial_update_first.sql` | RPC を「UPDATE 先行 → INSERT fallback」方式に置換、`is_travel_day` を追加 |
| `src/app/actions/saveDailyLog.ts` | `new_log_requires_weight` エラーを分かりやすいメッセージに変換 |
| `src/app/actions/__tests__/saveDailyLog.test.ts` | 既存行 partial update テスト群を追加（5件） |

## RPC 保存戦略の変更

### 旧: `INSERT ... ON CONFLICT DO UPDATE`
- 既存行への partial update でも INSERT 側の NOT NULL 制約に当たる

### 新: UPDATE 先行 → INSERT fallback

```sql
-- Step 1: 既存行への partial update
UPDATE daily_logs SET ... WHERE log_date = p_log_date;

-- 既存行があれば終了（INSERT 側に触れない）
IF FOUND THEN RETURN; END IF;

-- Step 2: 新規行は weight 必須チェック
IF NOT (p_fields ? 'weight') OR (p_fields->>'weight') IS NULL THEN
  RAISE EXCEPTION 'new_log_requires_weight';
END IF;

-- Step 3: 新規 INSERT
INSERT INTO daily_logs (...) VALUES (...);
```

## 新規日付と既存日付の扱い

| ケース | 動作 |
|---|---|
| 既存行への partial update（weight なし） | UPDATE のみ実行、ok: true |
| 新規行 + weight あり | INSERT 実行、ok: true |
| 新規行 + weight なし | RPC が `new_log_requires_weight` 例外 → アプリが「新しい日付を作成するには体重の入力が必要です」に変換 |

## `is_travel_day` の追加（あわせて修正）

`20260315000002` で追加された `is_travel_day` が旧 RPC に含まれていなかったため、RPC 置換のタイミングで UPDATE / INSERT 両方に追加。

## テスト

- `training_type` だけ更新（weight なし）→ `ok: true`
- `work_mode` だけ更新（weight なし）→ `ok: true`
- `sleep_hours` だけ更新（weight なし）→ `ok: true`
- RPC が `new_log_requires_weight` を返す → ユーザー向けメッセージを確認
- 新規日付 + weight あり → `ok: true`（従来動作を維持）
- 全 618 件 PASS（+5 件）/ `npx tsc --noEmit` 型エラーなし

## 影響範囲

- `save_daily_log_partial` RPC の保存戦略変更（**本番への migration 適用が必要**）
- アプリ側の動作: `new_log_requires_weight` エラーのメッセージ変換追加
- 部分更新の意味論（undefined/null/値）は変更なし

## 残課題

- **migration を本番 Supabase に適用すること**
- UI 側で「新規日付かつ weight なし」の場合に分かりやすいガイダンスを出す改善は別 Issue として検討可（現状は `MealLogger` の `weight` 入力が空の場合、保存ボタンが反応しない設計になっている）

Closes #58