### PR TITLE
fix: revalidate settings-dependent pages after saveSettings (#60)

### DIFF
--- a/src/app/settings/actions.ts
+++ b/src/app/settings/actions.ts
@@ -7,6 +7,7 @@
  * バリデーションは src/lib/schemas/settingsSchema.ts の parseSettings に委譲する。
  */
 
+import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { parseSettings } from "@/lib/schemas/settingsSchema";
 import type { SettingsInput } from "@/lib/schemas/settingsSchema";
@@ -42,6 +43,13 @@ export async function saveSettings(
     console.error("settings upsert error:", error.message);
     return { ok: false, error: "保存に失敗しました。しばらく後に再試行してください。" };
   }
+
+  // 3. On-demand revalidation（設定依存ページのキャッシュを破棄）
+  revalidatePath("/");
+  revalidatePath("/history");
+  revalidatePath("/macro");
+  revalidatePath("/tdee");
+  revalidatePath("/settings");
 
   return { ok: true };
 }


### PR DESCRIPTION
## Summary

- `saveSettings` 成功後に `revalidatePath` を呼んでいなかったため、設定変更後も古いキャッシュが各ページに残る問題を修正
- `/`, `/history`, `/macro`, `/tdee`, `/settings` を revalidate 対象に追加
- `saveDailyLog` と同じパターンに統一

## Test plan

- [ ] SettingsForm integration test (9件) パス確認
- [ ] settings schema / query / domain tests (52件) パス確認
- [ ] 設定変更後にダッシュボード・各画面が最新値を表示することを本番で確認

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)