### PR TITLE
docs: clarify parseSettings contract and remove partial-update ambiguity (#62)

### DIFF
--- a/src/lib/schemas/settingsSchema.test.ts
+++ b/src/lib/schemas/settingsSchema.test.ts
@@ -24,7 +24,9 @@ describe("parseSettings — 正常系", () => {
     expect(rec!.value_str).toBeNull();
   });
 
-  it("全フィールド省略でも通る（部分更新対応）", () => {
+  it("全フィールド省略でも通る（全キーが null レコードとして生成される）", () => {
+    // parseSettings は部分更新関数ではなく全項目保存関数。
+    // 省略フィールドは null として records に積まれ DB で上書きされる。
     const result = parseSettings({});
     expect(result.ok).toBe(true);
     if (!result.ok) return;
@@ -35,6 +37,24 @@ describe("parseSettings — 正常系", () => {
       expect(rec.value_num).toBeNull();
       expect(rec.value_str).toBeNull();
     }
+  });
+
+  it("一部キーだけ渡しても残りのキーは null レコードとして生成される（全キー上書き）", () => {
+    // 「goal_weight だけ更新したい」と思って一部キーだけ渡しても、
+    // 他の全キーが null で upsert され既存値が消えることを明示するテスト。
+    // parseSettings は partial update ではなく full-save 関数である。
+    const result = parseSettings({ goal_weight: "65.0" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // goal_weight は正しく設定される
+    const gw = result.records.find((r) => r.key === "goal_weight");
+    expect(gw!.value_num).toBe(65.0);
+    // 渡していない contest_date は null レコードとして生成されている（上書き対象になる）
+    const cd = result.records.find((r) => r.key === "contest_date");
+    expect(cd!.value_str).toBeNull();
+    // 渡していない height_cm も null レコードとして生成されている
+    const hc = result.records.find((r) => r.key === "height_cm");
+    expect(hc!.value_num).toBeNull();
   });
 
   it("空文字列フィールドは null として保存される", () => {

--- a/src/lib/schemas/settingsSchema.ts
+++ b/src/lib/schemas/settingsSchema.ts
@@ -37,7 +37,11 @@ export type SettingKey = NumericSettingKey | StringSettingKey;
 
 /**
  * 保存対象の設定値 (入力値は文字列で渡ってくることを前提)。
- * 全フィールドが省略可能 — 部分更新をサポートする。
+ *
+ * 全フィールドが省略可能だが、省略したフィールドは parseSettings() 内で
+ * null として扱われ DB に上書きされる。
+ * これは部分更新インターフェースではなく、全項目一括保存を前提とした入力型である。
+ * 一部キーだけを渡すと、残りのキーが null で消えるため注意すること。
  */
 export interface SettingsInput {
   // 数値系 (文字列として渡し、schema 側で number に変換する)
@@ -133,10 +137,15 @@ function isValidDate(s: string): boolean {
 /**
  * SettingsInput を検証・変換して DB upsert 用の SettingRecord[] を返す。
  *
- * - 空文字列・null・undefined のフィールドは「未設定」とみなし value_num/value_str を null で保存する。
- * - 部分更新対応: 省略されたフィールドもキーを含めて null upsert する（上書き）。
- *   呼び出し側が「渡したいキーだけ SettingsInput に含める」ことで選択的更新を行えるが、
- *   現状の UI は全キー一括保存のため全フィールドを渡す。
+ * 【全項目保存関数】
+ * この関数は常に全設定キー (NUMERIC_SETTING_KEYS + STRING_SETTING_KEYS) の
+ * レコードを生成する。省略・null・空文字のフィールドは value_num/value_str = null
+ * として records に積まれ、DB で上書きされる。
+ *
+ * partial update（一部キーのみ更新）には対応していない。
+ * 一部キーだけ渡すと、残りキーが null で消えるため、必ず全フィールドを渡すこと。
+ * 現状の唯一の caller (saveSettings) は SettingsForm から全フィールドを受け取って渡す。
+ *
  * - バリデーションエラーがひとつでもあれば ok: false を返す（保存は行わない）。
  */
 export function parseSettings(input: SettingsInput): ParseSettingsResult {


### PR DESCRIPTION
## 概要

`parseSettings()` のコメントに「部分更新対応」という誤った記述があり、将来の caller が一部キーだけ渡して選択的更新できると誤解するリスクがあった。コメントを実装の実態に合わせて修正する。

## 変更内容

### `src/lib/schemas/settingsSchema.ts`

**`SettingsInput` 型コメント**
- 変更前: 「全フィールドが省略可能 — 部分更新をサポートする。」
- 変更後: 省略フィールドは null として上書きされる全項目保存前提の入力型であることを明記

**`parseSettings()` JSDoc**
- 変更前: 「部分更新対応: 省略フィールドもキーを含めて null upsert する。呼び出し側が渡したいキーだけ含めることで選択的更新を行える」
- 変更後: 「全項目保存関数。partial update 非対応。一部キーだけ渡すと残りが null で消える」を明記

### `src/lib/schemas/settingsSchema.test.ts`

- テスト名「全フィールド省略でも通る（部分更新対応）」→ 実態に合った名前に修正
- 一部キーだけ渡すと他キーが null レコードとして生成される挙動を示す新テストを追加（誤用防止の回帰テスト）

## parseSettings の契約整理

| 項目 | 内容 |
|---|---|
| 関数の性質 | 全項目保存関数（partial update 非対応） |
| 省略フィールドの扱い | null として records に積まれ DB で上書きされる |
| 現在の唯一の caller | `saveSettings` — SettingsForm から全フィールドを受け取って渡す |

## caller への影響

なし。実装は変更していないため、現行の動作は完全に維持される。

## 確認内容

- 626 tests passed
- コメント修正のみで実装変更なし

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)