### PR TITLE
refactor: narrow fetchDailyLogsForSettings return type to selected fields (#63)

### DIFF
--- a/src/lib/queries/dailyLogs.ts
+++ b/src/lib/queries/dailyLogs.ts
@@ -12,6 +12,7 @@
  */
 import { createClient } from "@/lib/supabase/server";
 import type { DailyLog, CareerLog, Prediction } from "@/lib/supabase/types";
+import type { DataQualityLog } from "@/lib/utils/calcDataQuality";
 import type { QueryResult } from "./queryResult";
 
 /**
@@ -59,16 +60,16 @@ export async function fetchWeightLogs(): Promise<Pick<DailyLog, "log_date" | "we
 
 /**
  * daily_logs から log_date / weight / calories のみを取得する。
- * DataQuality 計算（settings ページ）用。
+ * DataQuality 計算（settings ページ）用の軽量クエリ。
  *
- * 戻り値は DailyLog[] として型付けされるが、実際には 3 カラムのみ取得する。
- * calcDataQuality が参照するのは log_date / weight / calories のみのため安全。
+ * 戻り値型は DataQualityLog[] (= Pick<DailyLog, "log_date" | "weight" | "calories">[])
+ * で実取得列に一致させてある。未取得列を呼び出し側が参照すると型エラーになる。
  *
  * 戻り値:
  *   kind: "ok"    — 取得成功。data が空配列 = ログ未入力（正常な空状態）。
  *   kind: "error" — DB フェッチ失敗。呼び出し側で error banner を表示すること。
  */
-export async function fetchDailyLogsForSettings(): Promise<QueryResult<DailyLog[]>> {
+export async function fetchDailyLogsForSettings(): Promise<QueryResult<DataQualityLog[]>> {
   const supabase = createClient();
   const { data, error } = await supabase
     .from("daily_logs")
@@ -78,7 +79,7 @@ export async function fetchDailyLogsForSettings(): Promise<QueryResult<DailyLog[
     console.error("[fetchDailyLogsForSettings] daily_logs fetch error:", error.message, { code: error.code });
     return { kind: "error", message: error.message };
   }
-  return { kind: "ok", data: (data as DailyLog[]) ?? [] };
+  return { kind: "ok", data: (data as DataQualityLog[]) ?? [] };
 }
 
 /**

--- a/src/lib/utils/calcDataQuality.ts
+++ b/src/lib/utils/calcDataQuality.ts
@@ -17,6 +17,13 @@
 import type { DailyLog } from "@/lib/supabase/types";
 import { toJstDateStr, addDaysStr, dateRangeStr } from "./date";
 
+/**
+ * calcDataQuality が実際に参照する列のみを持つ軽量型。
+ * fetchDailyLogsForSettings() の戻り値型と対応する。
+ * DailyLog はこの型のスーパータイプなので、DailyLog[] を渡してもエラーにならない。
+ */
+export type DataQualityLog = Pick<DailyLog, "log_date" | "weight" | "calories">;
+
 // ---- 閾値定数 ----
 /** 前日比でこれを超えたら体重異常値 (kg) */
 export const WEIGHT_JUMP_THRESHOLD_KG = 3.0;
@@ -69,7 +76,7 @@ function calcScore(window: Omit<QualityWindow, "score">): number {
 /** ウィンドウ期間 (dates) の品質を集計 */
 function buildWindow(
   dates: string[],
-  logByDate: Map<string, DailyLog>,
+  logByDate: Map<string, DataQualityLog>,
   sortedWithWeight: Array<{ date: string; weight: number }>
 ): QualityWindow {
   const totalDays = dates.length;
@@ -147,13 +154,13 @@ function buildWindow(
  * @param today 基準日 (YYYY-MM-DD JST). 省略時は JST 今日
  */
 export function calcDataQuality(
-  logs: DailyLog[],
+  logs: DataQualityLog[],
   today?: string
 ): DataQualityReport {
   const todayStr = today ?? toJstDateStr(new Date());
 
   // ---- 日付→ログ Map ----
-  const logByDate = new Map<string, DailyLog>();
+  const logByDate = new Map<string, DataQualityLog>();
   const dateCount = new Map<string, number>();
 
   for (const log of logs) {


### PR DESCRIPTION
## 概要

`fetchDailyLogsForSettings()` は `log_date, weight, calories` の3列しか取得していないのに、戻り値型が `DailyLog[]`（全カラム相当）で広すぎた。未取得列を呼び出し側が参照しても型エラーにならず、将来の変更で事故るリスクがあった。

## 変更内容

### `src/lib/utils/calcDataQuality.ts`

- `DataQualityLog = Pick<DailyLog, "log_date" | "weight" | "calories">` を定義・export
- `calcDataQuality()` の引数型を `DailyLog[]` → `DataQualityLog[]` に変更
- 内部 `Map<string, DailyLog>` と `buildWindow()` の引数型を `DataQualityLog` に変更

### `src/lib/queries/dailyLogs.ts`

- 戻り値型を `QueryResult<DailyLog[]>` → `QueryResult<DataQualityLog[]>` に変更
- 内部の型アサーションも `DataQualityLog[]` に変更
- JSDoc の誤解を招くコメント（「DailyLog[] として型付けされるが実際は3カラムのみ」）を修正

## 戻り値型の見直し

| | 変更前 | 変更後 |
|---|---|---|
| 戻り値型 | `QueryResult<DailyLog[]>` | `QueryResult<DataQualityLog[]>` |
| 未取得列の参照 | 型エラーにならない ❌ | 型エラーで検知できる ✅ |

## caller への影響

- `settings/page.tsx`: `DataQualityLog[]` を `calcDataQuality` に渡す → 問題なし
- `app/page.tsx` (dashboard): `DailyLog[]` を `calcDataQuality` に渡す → `DailyLog` は `DataQualityLog` のスーパータイプなので型エラーなし・変更不要

## 確認内容

- `tsc --noEmit`: エラーなし
- 626 tests passed

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)