### PR TITLE
fix: allow training_type='off' in DB check constraint (#68)

### DIFF
--- a/src/lib/utils/__tests__/trainingType.test.ts
+++ b/src/lib/utils/__tests__/trainingType.test.ts
@@ -8,6 +8,41 @@ import {
 } from "../trainingType";
 
 // ════════════════════════════════════════════════════════════════════════════
+// DB 制約との整合
+//
+// DB の daily_logs_training_type_check 制約が許可する値と TRAINING_TYPES が一致すること。
+// TRAINING_TYPES を変更する際は、対応する migration も更新すること。
+// 参照: supabase/migrations/20260316000000_fix_training_type_check_add_off.sql
+// ════════════════════════════════════════════════════════════════════════════
+
+const DB_ALLOWED_TRAINING_TYPES = [
+  "off",
+  "chest",
+  "back",
+  "shoulders",
+  "glutes_hamstrings",
+  "quads",
+] as const;
+
+describe("TRAINING_TYPES と DB 制約の整合", () => {
+  test("TRAINING_TYPES が DB 制約の許可値と完全一致する", () => {
+    expect([...TRAINING_TYPES].sort()).toEqual([...DB_ALLOWED_TRAINING_TYPES].sort());
+  });
+
+  test("DB 制約の全許可値が isValidTrainingType で valid と判定される", () => {
+    for (const v of DB_ALLOWED_TRAINING_TYPES) {
+      expect(isValidTrainingType(v)).toBe(true);
+    }
+  });
+
+  test("DB 制約に含まれない値は isValidTrainingType で invalid と判定される", () => {
+    expect(isValidTrainingType("legs")).toBe(false);
+    expect(isValidTrainingType("")).toBe(false);
+    expect(isValidTrainingType("OFF")).toBe(false);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
 // deriveLegFlag
 // ════════════════════════════════════════════════════════════════════════════
 

--- a/supabase/migrations/20260316000000_fix_training_type_check_add_off.sql
+++ b/supabase/migrations/20260316000000_fix_training_type_check_add_off.sql
@@ -1,0 +1,23 @@
+-- daily_logs_training_type_check に 'off' を追加する
+--
+-- 問題:
+--   アプリ側の TRAINING_TYPES には 'off' が含まれており、
+--   isValidTrainingType('off') も true を返す。
+--   しかし DB の CHECK 制約には 'off' が含まれていなかったため、
+--   training_type = 'off' を保存しようとすると
+--   "violates check constraint daily_logs_training_type_check" エラーが発生していた。
+--
+-- 修正内容:
+--   既存の制約を DROP して、'off' を含む新しい制約に置き換える。
+--   NULL は元の制約でも暗黙的に許容されており（CHECK は NULL に対して UNKNOWN を返し通過する）、
+--   新制約でも同様に NULL を許容する。
+--
+-- 許可値（アプリ側 TRAINING_TYPES と一致させる）:
+--   off / chest / back / shoulders / glutes_hamstrings / quads
+
+ALTER TABLE daily_logs
+  DROP CONSTRAINT IF EXISTS daily_logs_training_type_check;
+
+ALTER TABLE daily_logs
+  ADD CONSTRAINT daily_logs_training_type_check
+    CHECK (training_type IN ('off', 'chest', 'back', 'shoulders', 'glutes_hamstrings', 'quads'));


### PR DESCRIPTION
## Summary

- `daily_logs_training_type_check` 制約を DROP → 再作成し、`'off'` を許可値に追加
- 許可値: `off / chest / back / shoulders / glutes_hamstrings / quads`（アプリ側 `TRAINING_TYPES` と完全一致）
- `src/lib/utils/__tests__/trainingType.test.ts` に DB 制約同期テストを追加（38 tests）

## Root Cause

既存の CHECK 制約に `'off'` が含まれていなかったため、`training_type = 'off'` を保存しようとすると `violates check constraint "daily_logs_training_type_check"` エラーが発生していた。

## Test plan

- [x] `trainingType.test.ts` 38 tests passing
- [x] `supabase db push` 適用済み
- [x] `TRAINING_TYPES` と `DB_ALLOWED_TRAINING_TYPES` の完全一致をテストで固定

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)