### PR TITLE
feat: base KPI goal date on 7-day average and 14-day trend

### DIFF
--- a/src/components/dashboard/KpiCards.tsx
+++ b/src/components/dashboard/KpiCards.tsx
@@ -4,7 +4,8 @@ import { TrendingDown, TrendingUp, Minus, Weight, CalendarClock, Target } from "
 import type { DailyLog } from "@/lib/supabase/types";
 import type { AppSettings } from "@/lib/domain/settings";
 import { calcWeightTrend } from "@/lib/utils/calcTrend";
-import { toJstDateStr, calcDaysLeft, addDaysStr } from "@/lib/utils/date";
+import { toJstDateStr, calcDaysLeft, addDaysStr, dateRangeStr } from "@/lib/utils/date";
+import { calcGoalReachDate } from "@/lib/utils/calcReadiness";
 
 interface KpiCardsProps {
   logs: DailyLog[];
@@ -57,7 +58,8 @@ export function KpiCards({ logs, settings, avgTdee: _avgTdee }: KpiCardsProps) {
   const sorted = [...logs].sort((a, b) => a.log_date.localeCompare(b.log_date));
   const latest = sorted[sorted.length - 1];
 
-  // --- 現在体重 ---
+  // --- 現在体重（最新の生体重。目標到達予定の計算には使わない）---
+  const currentWeight = latest?.weight ?? null;
   const weightData = sorted.slice(-14)
     .filter((d) => d.weight !== null)
     .map((d) => ({ date: d.log_date, weight: d.weight! }));
@@ -83,30 +85,31 @@ export function KpiCards({ logs, settings, avgTdee: _avgTdee }: KpiCardsProps) {
   const weeksLeft =
     daysLeft !== null && daysLeft > 0 ? (daysLeft / 7).toFixed(1) : null;
 
-  // --- 目標到達予定日（線形トレンドから算出）---
+  // --- 目標到達予定日（7日平均 + 14暦日回帰ベース）---
+  // 現在地: 直近7暦日の体重平均（生体重ノイズに強い安定した基準点）
+  // 速度  : 直近14暦日の線形回帰 slope（短期トレンドを捉えつつ単日値への依存を下げる）
+  // AI 予測（NeuralProphet）はチャート側の参考表示に留め、KPI 主表示には採用しない
   const goalWeight = settings.targetWeight;
-  const currentWeight = latest?.weight ?? null;
-  const slopePerDay = trend.slope; // kg/day
 
-  let goalReachDate: string | null = null;
-  let goalReachLabel = "—";
+  const d7Start = addDaysStr(todayStr, -6) ?? todayStr;
+  const d14Start = addDaysStr(todayStr, -13) ?? todayStr;
+  const logByDate = new Map(sorted.map((l) => [l.log_date, l]));
 
-  if (goalWeight !== null && currentWeight !== null) {
-    const gap0 = currentWeight - goalWeight;
-    if (Math.abs(gap0) < 0.1) {
-      goalReachLabel = "達成済み ✓";
-    } else if (slopePerDay === 0 || (gap0 > 0 && slopePerDay >= 0) || (gap0 < 0 && slopePerDay <= 0)) {
-      goalReachLabel = "停滞中";
-    } else {
-      const daysNeeded = gap0 / (-slopePerDay);
-      if (daysNeeded > 0 && daysNeeded < 730) {
-        goalReachDate = addDaysStr(todayStr, Math.round(daysNeeded));
-        goalReachLabel = goalReachDate ? goalReachDate.slice(5) : "停滞中"; // MM-DD
-      } else {
-        goalReachLabel = "停滞中";
-      }
-    }
-  }
+  // 7暦日平均
+  const w7 = dateRangeStr(d7Start, todayStr)
+    .map((d) => logByDate.get(d)?.weight ?? null)
+    .filter((v): v is number => v !== null);
+  const weight_7d_avg = w7.length > 0 ? w7.reduce((a, b) => a + b, 0) / w7.length : null;
+
+  // 14暦日回帰 slope (kg/day)
+  const trend14Data = dateRangeStr(d14Start, todayStr)
+    .map((d) => ({ date: d, weight: logByDate.get(d)?.weight ?? null }))
+    .filter((p): p is { date: string; weight: number } => p.weight !== null);
+  const slopePerDay14 = trend14Data.length >= 2 ? calcWeightTrend(trend14Data).slope : null;
+
+  const goalReachResult = calcGoalReachDate(weight_7d_avg, slopePerDay14, goalWeight, todayStr);
+  const goalReachDate = goalReachResult.date;
+  const goalReachLabel = goalReachResult.label;
 
   return (
     <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
@@ -159,7 +162,7 @@ export function KpiCards({ logs, settings, avgTdee: _avgTdee }: KpiCardsProps) {
         </div>
         {goalReachDate && goalWeight !== null && (
           <p className="mt-2 text-xs text-slate-400">
-            {goalWeight.toFixed(1)} kg 到達の推定日
+            {goalWeight.toFixed(1)} kg 到達の推定日（7日平均ベース）
           </p>
         )}
         {!goalWeight && (

--- a/src/lib/utils/calcReadiness.test.ts
+++ b/src/lib/utils/calcReadiness.test.ts
@@ -9,7 +9,7 @@
  *   - 残り週数 (daysLeft / 7) の表示値
  */
 
-import { calcReadiness, calcRequiredPacePerTwoWeeks, calcActualPacePerTwoWeeks } from "./calcReadiness";
+import { calcReadiness, calcRequiredPacePerTwoWeeks, calcActualPacePerTwoWeeks, calcGoalReachDate } from "./calcReadiness";
 import type { DailyLog } from "@/lib/supabase/types";
 
 // ─── テスト用ヘルパー ──────────────────────────────────────────────────────────
@@ -227,6 +227,95 @@ describe("calcReadiness 2週ペースフィールド", () => {
     const logs = buildLogs(14, 70, -1 / 13);
     const metrics = calcReadiness(logs, { goal_weight: 68 }, today);
     expect(metrics.required_rate_kg_per_2weeks).toBeNull();
+  });
+});
+
+// ─── calcGoalReachDate ────────────────────────────────────────────────────────
+
+describe("calcGoalReachDate", () => {
+  const today = "2026-03-15";
+
+  // ── no_data ──
+  test("weight7dAvg が null → status=no_data, label='—'", () => {
+    const r = calcGoalReachDate(null, -0.1, 68.0, today);
+    expect(r.status).toBe("no_data");
+    expect(r.date).toBeNull();
+    expect(r.label).toBe("—");
+  });
+
+  test("goalWeight が null → status=no_data, label='—'", () => {
+    const r = calcGoalReachDate(70.0, -0.1, null, today);
+    expect(r.status).toBe("no_data");
+    expect(r.date).toBeNull();
+    expect(r.label).toBe("—");
+  });
+
+  // ── achieved ──
+  test("|gap| < 0.1 → status=achieved (7日平均が目標に到達済み)", () => {
+    const r = calcGoalReachDate(68.05, -0.1, 68.0, today);
+    expect(r.status).toBe("achieved");
+    expect(r.label).toBe("達成済み ✓");
+    expect(r.date).toBeNull();
+  });
+
+  test("gap = 0 → status=achieved", () => {
+    const r = calcGoalReachDate(68.0, -0.1, 68.0, today);
+    expect(r.status).toBe("achieved");
+  });
+
+  // ── stalled ──
+  test("slopePerDay が null (データ不足) → status=stalled", () => {
+    const r = calcGoalReachDate(70.0, null, 68.0, today);
+    expect(r.status).toBe("stalled");
+    expect(r.label).toBe("停滞中");
+  });
+
+  test("slopePerDay = 0 → status=stalled", () => {
+    const r = calcGoalReachDate(70.0, 0, 68.0, today);
+    expect(r.status).toBe("stalled");
+  });
+
+  test("Cut: gap > 0 なのに slope >= 0 → status=stalled", () => {
+    // 体重が目標より上なのに増量中
+    const r = calcGoalReachDate(71.0, 0.05, 68.0, today);
+    expect(r.status).toBe("stalled");
+  });
+
+  test("Bulk: gap < 0 なのに slope <= 0 → status=stalled", () => {
+    // 体重が目標より下なのに減量中
+    const r = calcGoalReachDate(65.0, -0.05, 68.0, today);
+    expect(r.status).toBe("stalled");
+  });
+
+  test("daysNeeded > 730 → status=stalled (現実的でない到達日)", () => {
+    // gap = 1.0 kg, slope = -0.001 kg/day → daysNeeded = 1000日
+    const r = calcGoalReachDate(69.0, -0.001, 68.0, today);
+    expect(r.status).toBe("stalled");
+  });
+
+  // ── projected ──
+  test("Cut: 14日後に到達するペース → status=projected, 日付が正しい", () => {
+    // gap = 70 - 68 = 2.0, slopePerDay = -2/14 ≈ -0.1429 → daysNeeded = 14
+    const slope = -2 / 14;
+    const r = calcGoalReachDate(70.0, slope, 68.0, today);
+    expect(r.status).toBe("projected");
+    expect(r.date).toBe("2026-03-29"); // today + 14日
+    expect(r.label).toBe("03-29");
+  });
+
+  test("Cut: 7日後に到達するペース → status=projected", () => {
+    // gap = 1.0, slope = -1/7 → daysNeeded = 7
+    const r = calcGoalReachDate(69.0, -1 / 7, 68.0, today);
+    expect(r.status).toBe("projected");
+    expect(r.date).toBe("2026-03-22"); // today + 7日
+    expect(r.label).toBe("03-22");
+  });
+
+  test("Bulk: 目標より低く増量中 → status=projected", () => {
+    // gap = 65 - 70 = -5, slope = +0.357 ≈ 5/14 → daysNeeded = 14
+    const r = calcGoalReachDate(65.0, 5 / 14, 70.0, today);
+    expect(r.status).toBe("projected");
+    expect(r.date).toBe("2026-03-29");
   });
 });
 

--- a/src/lib/utils/calcReadiness.ts
+++ b/src/lib/utils/calcReadiness.ts
@@ -283,6 +283,78 @@ export function calcGoalStatus(
   return "behind";
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// KPI 目標到達予定日計算（7日平均 + 14暦日回帰ベース）
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * KPI 目標到達予定の計算結果。
+ *
+ * - no_data   : 7日平均または目標体重が取得できない
+ * - achieved  : |7日平均 − 目標体重| < 0.1 kg
+ * - stalled   : 到達方向へ進んでいない、またはデータ不足でペース不明
+ * - projected : 到達予定日が推定できた
+ */
+export interface GoalReachResult {
+  status: "achieved" | "stalled" | "projected" | "no_data";
+  /** 到達予定日 (YYYY-MM-DD)。status="projected" 時のみ非 null */
+  date: string | null;
+  /** 表示ラベル ("MM-DD" / "達成済み ✓" / "停滞中" / "—") */
+  label: string;
+}
+
+/**
+ * KPI の「目標到達予定日」を 7日平均 + 14暦日回帰ペースから算出する。
+ *
+ * - 現在地: weight7dAvg（生体重ノイズを除いた安定した基準点）
+ * - 進行速度: slopePerDay（直近14暦日の線形回帰 kg/day）
+ * - 到達日数: (現在地 − 目標体重) / (-slopePerDay)
+ *
+ * KPI 主表示に AI 予測は採用しない。
+ * AI 予測はダッシュボードのチャート（ForecastChart）で参考表示する。
+ *
+ * @param weight7dAvg  直近7暦日の体重平均 (kg)。null ならラベル "—" を返す
+ * @param slopePerDay  直近14暦日の線形回帰 slope (kg/day)。null なら停滞中扱い
+ * @param goalWeight   目標体重 (kg)。null ならラベル "—" を返す
+ * @param today        基準日 (YYYY-MM-DD)
+ */
+export function calcGoalReachDate(
+  weight7dAvg: number | null,
+  slopePerDay: number | null,
+  goalWeight: number | null,
+  today: string
+): GoalReachResult {
+  if (weight7dAvg === null || goalWeight === null) {
+    return { status: "no_data", date: null, label: "—" };
+  }
+
+  const gap = weight7dAvg - goalWeight; // 正=まだ上 (Cut), 負=下回った (Bulk)
+
+  if (Math.abs(gap) < 0.1) {
+    return { status: "achieved", date: null, label: "達成済み ✓" };
+  }
+
+  // 停滞中: ペース不明 / ゼロ / 到達方向と逆
+  if (
+    slopePerDay === null ||
+    slopePerDay === 0 ||
+    (gap > 0 && slopePerDay >= 0) || // Cut: 減量必要なのに増減なし or 増量中
+    (gap < 0 && slopePerDay <= 0)    // Bulk: 増量必要なのに増減なし or 減量中
+  ) {
+    return { status: "stalled", date: null, label: "停滞中" };
+  }
+
+  const daysNeeded = gap / (-slopePerDay);
+  if (daysNeeded <= 0 || daysNeeded >= 730) {
+    return { status: "stalled", date: null, label: "停滞中" };
+  }
+
+  const date = addDaysStr(today, Math.round(daysNeeded));
+  if (!date) return { status: "stalled", date: null, label: "停滞中" };
+
+  return { status: "projected", date, label: date.slice(5) }; // MM-DD
+}
+
 /**
  * 実績ペースを必要ペースに合わせるための 1日あたりカロリー調整量 (kcal)。
  * 負 = 摂取量を減らす、正 = 増やす。50 kcal 単位に丸め。


### PR DESCRIPTION
## 概要

KPI「目標到達予定」の算出ロジックを、生体重ノイズに引っ張られにくい安定した方式へ見直す。

## 変更内容

### `src/lib/utils/calcReadiness.ts`
- `calcGoalReachDate()` を追加（純粋関数・テスト可能）
- `GoalReachResult` 型を追加（`status / date / label`）

### `src/components/dashboard/KpiCards.tsx`
- 目標到達予定の計算を `calcGoalReachDate()` に委譲
- サブテキストに「（7日平均ベース）」を追加

### `src/lib/utils/calcReadiness.test.ts`
- `calcGoalReachDate` のテストを 12件追加（35 tests total）

## KPI 到達予定ロジックの見直し

| 変更前 | 変更後 |
|--------|--------|
| 現在地: `latest.weight`（最新の生体重） | 現在地: 直近7暦日の体重平均（ノイズ耐性） |
| 速度: 直近14**件**（記録日ベース）回帰 | 速度: 直近14**暦日**（カレンダーベース）回帰 |

## 7日平均 / 14日回帰の使い方

- **7日平均**: 水分・外食・便通などの単日ノイズを吸収した安定した現在地
- **14暦日回帰**: 直近トレンドを取り込みつつ、単一記録日への依存を下げた速度
- 到達日数 = `(7d_avg - goal) / (-slope)`、今日に加算して到達日を算出

## 達成済み / 停滞中 / 予想到達日の判定

| status | 条件 |
|--------|------|
| `no_data` | 7日平均または目標体重が null |
| `achieved` | \|7日平均 − 目標\| < 0.1 kg |
| `stalled` | ペース不明 / 0 / 到達方向と逆 / daysNeeded > 730 |
| `projected` | 上記以外。到達日を算出してラベルに MM-DD を表示 |

## AI予測チャートへの影響

なし。`ForecastChart`（NeuralProphet）は引き続きチャート上の参考表示として維持される。KPI 主表示への AI 予測採用はしない。

## テスト

- 641 tests passed（既存 629 + 新規 12）

## 影響範囲

- `KpiCards.tsx` の「目標到達予定」カードのみ
- `GoalNavigator` / `calcReadiness` のロジック・インタフェースは変更なし

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)