### PR TITLE
fix: treat missing calorie and macro records as null instead of zero

### DIFF
--- a/ml-pipeline/enrich.py
+++ b/ml-pipeline/enrich.py
@@ -66,6 +66,13 @@ def enrich_data(df: pd.DataFrame) -> pd.DataFrame:
     # 改善: weight_sma7.diff() = 7日移動平均の差分
     #       SMA7 の差分は 1 日分の変化が 1/7 に分散されるため、短期ノイズに強い
     #       さらに rolling median (min_periods=3) で外れ値日のカロリー記録を平滑化する
+    #
+    # calories 列の意味論:
+    #   NULL (pandas NaN) = 未記録・不明。tdee_candidates も NaN になり rolling median でスキップされる。
+    #   0                 = 実測値（絶食日など）。TDEE 計算に含まれる。
+    #   未記録由来の 0 は migration 20260316000001_backfill_zero_macros_to_null.sql で NULL に補正済み。
+    #   現行保存経路（MealLogger → save_daily_log_partial RPC）は食事未入力を NULL で保存するため
+    #   未記録 0 の再発生は防がれている。
     weight_sma7_delta = df["weight_sma7"].diff()  # kg/day (SMA7 の差分: ≒ (w_t - w_{t-6}) / 6)
     tdee_candidates = df["calories"] - weight_sma7_delta * KCAL_PER_KG_FAT
     df["tdee_estimated"] = tdee_candidates.rolling(

--- a/src/lib/utils/calcMacro.test.ts
+++ b/src/lib/utils/calcMacro.test.ts
@@ -84,6 +84,38 @@ describe("calcMacroKpi", () => {
     const kpi = calcMacroKpi(logs);
     expect(kpi.weekly.avgCalories).toBeCloseTo(2000, 1);
   });
+
+  /**
+   * 未記録 と 実測 0（絶食日）の意味論の違いを固定するテスト。
+   *
+   * NULL = 未記録（欠損値）→ 平均計算から除外される
+   * 0    = 実測値（絶食日など）→ 平均計算に含まれる
+   *
+   * 未記録由来の 0 は migration 20260316000001_backfill_zero_macros_to_null.sql で NULL に補正済み。
+   * 現行保存経路（MealLogger）は食事未入力時に calories: undefined を送り、DB には NULL が保存される。
+   */
+  it("calories = null（未記録）は平均から除外され、calories = 0（実測絶食日）は含まれる", () => {
+    const logs = [
+      makeLog("2026-03-01", { calories: null }), // 未記録 → 除外
+      makeLog("2026-03-02", { calories: 0 }),     // 実測 0（絶食日）→ 含む
+      makeLog("2026-03-03", { calories: 3000 }),  // 含む
+      makeLog("2026-03-04", { calories: null }), // 未記録 → 除外
+      makeLog("2026-03-05", { calories: 1000 }),  // 含む
+      makeLog("2026-03-06", { calories: null }), // 未記録 → 除外
+      makeLog("2026-03-07", { calories: 2000 }),  // 含む
+    ];
+    const kpi = calcMacroKpi(logs);
+    // 平均 = (0 + 3000 + 1000 + 2000) / 4 = 1500 (null 3件は除外、0 は含む)
+    expect(kpi.weekly.avgCalories).toBeCloseTo(1500, 1);
+  });
+
+  it("全て calories = null なら avgCalories = null を返す", () => {
+    const logs = Array.from({ length: 7 }, (_, i) =>
+      makeLog(`2026-03-0${i + 1}`, { calories: null })
+    );
+    const kpi = calcMacroKpi(logs);
+    expect(kpi.weekly.avgCalories).toBeNull();
+  });
 });
 
 describe("calcDailyMacro", () => {

--- a/supabase/migrations/20260316000001_backfill_zero_macros_to_null.sql
+++ b/supabase/migrations/20260316000001_backfill_zero_macros_to_null.sql
@@ -1,0 +1,39 @@
+-- 未記録由来の 0 データを NULL に補正する
+--
+-- 背景:
+--   旧保存経路（MealLogger + RPC 導入以前）では、食事記録を付けていない日の
+--   calories / protein / fat / carbs が NULL ではなく 0 で保存されていた。
+--   例: log_date = 2025-11-23, weight = 73.60, calories = 0, protein = 0.0, fat = 0.0, carbs = 0.0
+--
+-- 問題:
+--   0 は「実際に 0 kcal / 0g を摂取した日（絶食日）」という実測値として解釈される。
+--   未記録の 0 を実測値として扱うと以下のノイズが生じる:
+--     - enrich.py: tdee_estimated = 0 - weight_sma7_delta * 7200 → 大幅に過小な TDEE 推定
+--     - analyze.py: dropna で除外されず、XGBoost の特徴量に 0 カロリーの絶食日として混入
+--     - calcMacro.ts: avgCalories の平均にゼロ日が含まれ実際より低い値になる
+--
+-- 補正条件の根拠:
+--   calories / protein / fat / carbs が【全て同時に 0】の場合を「未記録由来」と判断する。
+--   4 列が全て 0 になるのは「何も食べなかった実測値」ではなく「記録なし」の強い指標。
+--   1 列でも非ゼロならば記録済みとして扱い補正しない。
+--
+-- 補正後の意味論:
+--   NULL = 未記録・不明（欠損値）
+--   0    = 実測値（絶食日など、今後の現行保存経路から保存されたもの）
+--
+-- 現行保存経路（MealLogger → save_daily_log_partial RPC）は:
+--   食事未入力 → calories: undefined → JSONB にキーなし → INSERT で NULL
+--   食事入力あり → calories: totals.calories (0 以上の実測値)
+-- のため、この migration 適用後は未記録 0 の再発生は防がれている。
+
+UPDATE daily_logs
+SET
+  calories = NULL,
+  protein  = NULL,
+  fat      = NULL,
+  carbs    = NULL
+WHERE
+  calories = 0
+  AND protein  = 0
+  AND fat      = 0
+  AND carbs    = 0;


### PR DESCRIPTION
## 概要

未記録の `calories`, `protein`, `fat`, `carbs` が旧保存経路で `0` として保存されていた問題を整理する。

## 変更内容

### `supabase/migrations/20260316000001_backfill_zero_macros_to_null.sql`
- 4列が全て 0 のレコードを NULL に補正するバックフィルを実行（DB 適用済み）

### `ml-pipeline/enrich.py`
- TDEE 計算コメントに calories の意味論（NULL=未記録/0=実測値）を明記

### `src/lib/utils/calcMacro.test.ts`
- NULL（未記録）が平均から除外され、0（絶食日実測値）は含まれることを固定するテストを追加

## 未記録と実測 0 の意味論整理

| 値 | 意味 | 平均計算 | TDEE推定 | analyze.py |
|----|------|---------|---------|------------|
| `NULL` | 未記録・不明（欠損） | 除外 | NaN → スキップ | dropna で除外 |
| `0` | 実測値（絶食日） | **含まれる** | `0 - delta * 7200` | 特徴量に含まれる |

## 新規保存経路（修正不要）

MealLogger → `save_daily_log_partial` RPC の現行経路は既に正しい:
- 食事未入力 → `calories: undefined` → JSONB にキーなし → DB で NULL
- 食事入力あり → `calories: totals.calories`（カートの実合計値）

## 既存データの補正

**補正条件:** `calories = 0 AND protein = 0 AND fat = 0 AND carbs = 0`（4列全て同時に 0）
- 4列全てが 0 = 「記録なし」の強い指標。1列でも非ゼロなら記録済みとして保持
- 今後は現行保存経路があるため再発しない

## analytics への影響

- `enrich.py`: 補正後は 0-calories 行が NULL になり NaN 扱い → TDEE 計算でスキップされ正しい推定が得られる
- `analyze.py`: `dropna(subset=["calories", ...])` が NULL を正しく除外（変更なし）
- `calcMacro.ts`: `avg()` が NULL を除外（変更なし）

## テスト

- 643 tests passed（既存 641 + 新規 2）
- 追加テスト:
  - `calories = null（未記録）は平均から除外され、calories = 0（実測絶食日）は含まれる`
  - `全て calories = null なら avgCalories = null を返す`

## 影響範囲

- 保存経路: 変更なし（すでに正しい）
- DB: migration 適用済み（全体0レコードが NULL に補正）
- enrich.py: コメント追加のみ（挙動変更なし）
- calcMacro.ts: 変更なし（NULL は元から正しく除外）

## 残課題

なし（Issue #72 のスコープ内で完結）

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)