### PR TITLE
fix: restore NeuralProphet daily backtest under PyTorch 2.6

### DIFF
--- a/ml-pipeline/backtest.py
+++ b/ml-pipeline/backtest.py
@@ -193,14 +193,45 @@ def make_neuralprophet_predictor(config: BacktestConfig) -> Callable:
     CLI で --np-epochs を変えれば再学習コストを調整できる。
     """
     np_epochs = config.np_epochs
+    _pytorch26_patched = False  # torch.load patch を一度だけ適用するためのフラグ
 
     def _predict(train: pd.DataFrame, horizon: int) -> Optional[float]:
         """NeuralProphet: 学習データで再訓練し horizon 日先を予測する。
 
         訓練失敗時は None を返し、その起点をスキップする。
+
+        torch 2.6+ の weights_only=True デフォルト変更への対応:
+          predict.py と同じ torch.load patch を適用する。
+          このプロセス内で生成した checkpoint のみ読み込む (trusted) ため
+          weights_only=False は安全。patch は初回呼び出し時に一度だけ適用する
+          (複数起点で繰り返し呼ばれるため、二重 wrap による連鎖を防ぐ)。
         """
+        nonlocal _pytorch26_patched
         try:
+            import torch as _torch  # noqa: PLC0415
             from neuralprophet import NeuralProphet  # noqa: PLC0415
+
+            # torch 2.6+ changed weights_only default to True, which breaks
+            # NeuralProphet's checkpoint restore (Unsupported global:
+            # neuralprophet.configure.ConfigSeasonality).
+            # This pipeline only loads checkpoints it wrote itself (trusted),
+            # so overriding weights_only=False is safe here.
+            if not _pytorch26_patched and (
+                tuple(int(x) for x in _torch.__version__.split(".")[:2]) >= (2, 6)
+            ):
+                _orig_load = _torch.load
+
+                def _trusted_load(
+                    f, map_location=None, pickle_module=None, weights_only=None,
+                    mmap=None, **kw
+                ):
+                    return _orig_load(f, map_location=map_location, weights_only=False, **kw)
+
+                _torch.load = _trusted_load
+                _pytorch26_patched = True
+                log.debug(
+                    "PyTorch 2.6+ 互換 patch を適用 (backtest, weights_only=False)"
+                )
 
             df_np = train[["log_date", "weight"]].rename(
                 columns={"log_date": "ds", "weight": "y"}
@@ -460,7 +491,7 @@ def save_results(
         for horizon, records in horizon_data.items():
             if not records:
                 log.warning(
-                    "  %s h=%dd: 有効な予測なし。データ不足の可能性。スキップ。",
+                    "  %s h=%dd: 有効な予測なし (モデル失敗またはデータ不足)。スキップ。",
                     model_name, horizon,
                 )
                 continue
@@ -533,7 +564,7 @@ def log_summary(results: BacktestResults, config: BacktestConfig) -> None:
         for horizon in config.horizons:
             records = results[model_name].get(horizon, [])
             if not records:
-                log.info("  %-20s h=%2dd  データ不足のためスキップ", model_name, horizon)
+                log.info("  %-20s h=%2dd  有効な予測なし (モデル失敗またはデータ不足)", model_name, horizon)
                 continue
             errors  = [r[0] for r in records]
             actuals = [r[1] for r in records]

--- a/ml-pipeline/test_backtest.py
+++ b/ml-pipeline/test_backtest.py
@@ -27,6 +27,7 @@ from backtest import (
     compute_actual_sma7,
     compute_metrics,
     log_summary,
+    make_neuralprophet_predictor,
     predict_linear,
     predict_ma7,
     predict_naive,
@@ -375,3 +376,98 @@ class TestBaselinePredictors:
         pred = predict_linear(train, 7)
         # 最後の点は 70 + 0.1 * 29 = 72.9、7日後は 72.9 + 0.1 * 7 = 73.6
         assert abs(pred - 73.6) < 0.1  # 線形回帰の誤差を許容
+
+
+# ── NeuralProphet PyTorch 2.6+ patch ──────────────────────────────────────────
+
+class TestNeuralProphetPyTorchPatch:
+    """make_neuralprophet_predictor の PyTorch 2.6+ weights_only 互換 patch を検証する。
+
+    torch / neuralprophet は CI 環境に存在しないため sys.modules をモックして検証する。
+    """
+
+    def _make_mock_modules(self, torch_version: str):
+        """torch / neuralprophet のモックを返す。"""
+        import sys
+        from unittest.mock import MagicMock
+
+        mock_torch = MagicMock()
+        mock_torch.__version__ = torch_version
+        original_load = MagicMock(name="original_load")
+        mock_torch.load = original_load
+
+        mock_np_instance = MagicMock()
+        # forecast["yhat1"].iloc[-1] が float を返すよう設定
+        forecast_df = pd.DataFrame({"yhat1": [74.0] * 10})
+        mock_np_instance.predict.return_value = forecast_df
+        mock_np_instance.make_future_dataframe.return_value = pd.DataFrame({"ds": []})
+
+        mock_neuralprophet = MagicMock()
+        mock_neuralprophet.NeuralProphet.return_value = mock_np_instance
+
+        return mock_torch, mock_neuralprophet, original_load
+
+    def test_torch_load_patched_for_torch26(self):
+        """torch >= 2.6 では torch.load が weights_only=False patch に差し替えられること。"""
+        import sys
+        from unittest.mock import patch as mock_patch
+
+        mock_torch, mock_neuralprophet, original_load = self._make_mock_modules("2.6.0")
+        config = BacktestConfig(np_epochs=1)
+        predict_fn = make_neuralprophet_predictor(config)
+        train = make_df(35)
+
+        with mock_patch.dict(sys.modules, {
+            "torch": mock_torch,
+            "neuralprophet": mock_neuralprophet,
+        }):
+            predict_fn(train, 7)
+
+        assert mock_torch.load is not original_load, (
+            "torch >= 2.6 では torch.load は weights_only=False patch に差し替えられるべき"
+        )
+
+    def test_torch_load_not_patched_for_torch25(self):
+        """torch < 2.6 では torch.load が変更されないこと。"""
+        import sys
+        from unittest.mock import patch as mock_patch
+
+        mock_torch, mock_neuralprophet, original_load = self._make_mock_modules("2.5.1")
+        config = BacktestConfig(np_epochs=1)
+        predict_fn = make_neuralprophet_predictor(config)
+        train = make_df(35)
+
+        with mock_patch.dict(sys.modules, {
+            "torch": mock_torch,
+            "neuralprophet": mock_neuralprophet,
+        }):
+            predict_fn(train, 7)
+
+        assert mock_torch.load is original_load, (
+            "torch < 2.6 では torch.load は変更されるべきでない"
+        )
+
+    def test_patch_applied_only_once(self):
+        """複数回呼ばれても patch は一度だけ適用されること (二重 wrap 防止)。"""
+        import sys
+        from unittest.mock import patch as mock_patch
+
+        mock_torch, mock_neuralprophet, original_load = self._make_mock_modules("2.6.0")
+        config = BacktestConfig(np_epochs=1)
+        predict_fn = make_neuralprophet_predictor(config)
+        train = make_df(35)
+
+        with mock_patch.dict(sys.modules, {
+            "torch": mock_torch,
+            "neuralprophet": mock_neuralprophet,
+        }):
+            predict_fn(train, 7)
+            patched_load_after_first = mock_torch.load  # patch 適用後の load
+
+            predict_fn(train, 14)
+            patched_load_after_second = mock_torch.load  # 2回目呼び出し後
+
+        # 2回目呼び出しで torch.load がさらに差し替えられていないこと
+        assert patched_load_after_first is patched_load_after_second, (
+            "patch は一度だけ適用されるべき (二重 wrap になっていないこと)"
+        )


### PR DESCRIPTION
## 概要

NeuralProphet の daily backtest が PyTorch 2.6 系の `weights_only=True` デフォルト変更により失敗し、`forecast_backtest_metrics` に D+7/D+14/D+30 の行が保存されない問題を修正する。

## 変更内容

### `ml-pipeline/backtest.py`
- `make_neuralprophet_predictor` 内の `_predict` クロージャに、`predict.py` と同じ PyTorch 2.6+ 互換 patch を追加
  - torch >= 2.6 検出時に `torch.load` を `weights_only=False` で呼ぶラッパーに差し替える
  - 複数起点で繰り返し呼ばれる構造のため `_pytorch26_patched` フラグで二重 wrap を防止
- "データ不足の可能性" というログ文言をより正確な "モデル失敗またはデータ不足" に変更 (`save_results` / `log_summary` 両方)

### `ml-pipeline/test_backtest.py`
- `TestNeuralProphetPyTorchPatch` クラスを追加 (3件)
  - torch >= 2.6 では `torch.load` が patch されること
  - torch < 2.6 では `torch.load` が変更されないこと
  - 複数回呼び出しで patch が一度だけ適用されること (二重 wrap 防止)
  - torch / neuralprophet は CI に存在しないため `sys.modules` mock で検証

## PyTorch 2.6 互換対応

PyTorch 2.6 から `torch.load()` のデフォルトが `weights_only=True` に変更された。NeuralProphet は checkpoint に `neuralprophet.configure.ConfigSeasonality` 等の独自クラスを含むため、`weights_only=True` では `Unsupported global` エラーで読み込みに失敗する。

`predict.py` は既に `run_model()` 内でこの patch を適用していたが、`backtest.py` には適用されていなかった。本 PR はその差分を埋める。

## NeuralProphet daily metrics 復旧

patch 適用により、weekly backtest 実行時に NeuralProphet の D+7/D+14/D+30 valid predictions が生成されるようになり、`forecast_backtest_metrics` に metric rows が保存される。予測精度評価画面の NeuralProphet 単日欄が `—` から数値表示に戻る。

## ログ改善

`save_results` / `log_summary` の "データ不足の可能性" という文言を "モデル失敗またはデータ不足" に変更。checkpoint 読み込み失敗がデータ不足と誤解されるのを防ぐ。

## テスト

```
36 passed in 0.67s  (33 既存 + 3 新規)
```

## 影響範囲

- `backtest.py` のみ。`predict.py` / `analyze.py` / `enrich.py` は変更なし
- ベースラインモデル (Naive / MovingAverage7d / LinearTrend30d) の動作に影響なし

Closes #74