### PR TITLE
feat: improve food add feedback and calendar readability

### DIFF
--- a/src/components/dashboard/MonthlyCalendar.tsx
+++ b/src/components/dashboard/MonthlyCalendar.tsx
@@ -12,12 +12,10 @@
  *
  *   情報の縦方向優先順位:
  *     1. 日付（補助・小・左上）
- *     2. 体重（主・太字）
- *     3. 体重前日差分（色付き）
- *     4. 摂取カロリー（値）
- *     5. カロリー差分（補助・別行）
- *     6. 特殊日タグ
- *     7. コンディションタグ（sm 以上）
+ *     2. 体重 + 前日差分（近接表示: 71.2kg (+0.3)）
+ *     3. カロリー + 差分（近接表示: 1984k (+65)）
+ *     4. 特殊日タグ
+ *     5. コンディションタグ（sm 以上）
  *
  * 土日祝:
  *   - 土曜: 日付テキスト text-sky-600 / セル bg-sky-50
@@ -133,63 +131,59 @@ function CalendarDayCell({ day, modifiers }: DayProps) {
           )}
         </div>
 
-        {/* ② 体重（主情報） */}
-        <div className="mt-1 flex items-baseline gap-0.5 leading-none">
+        {/* ② 体重 + 前日差分（近接表示: 71.2kg (+0.3)） */}
+        <div className="mt-1 flex items-baseline gap-0.5 leading-none flex-wrap">
           {data?.log.weight != null ? (
             <>
               <span className="text-xs sm:text-sm font-bold text-slate-800 leading-none">
                 {data.log.weight.toFixed(1)}
               </span>
               <span className="text-[9px] text-slate-400">kg</span>
+              {data?.weightDelta != null && (
+                <span className={`text-[9px] font-medium leading-none ${
+                  data.weightDelta > 0
+                    ? "text-rose-500"
+                    : data.weightDelta < 0
+                    ? "text-blue-500"
+                    : "text-slate-300"
+                }`}>
+                  ({data.weightDelta > 0 ? "+" : ""}{data.weightDelta.toFixed(1)})
+                </span>
+              )}
             </>
           ) : (
             <span className="text-[10px] leading-none text-slate-200">—</span>
           )}
         </div>
 
-        {/* ③ 体重前日差分 */}
-        {data?.weightDelta != null && (
-          <div className={`mt-0.5 text-[10px] font-medium leading-none ${
-            data.weightDelta > 0
-              ? "text-rose-500"
-              : data.weightDelta < 0
-              ? "text-blue-500"
-              : "text-slate-300"
-          }`}>
-            {data.weightDelta > 0 ? "+" : ""}{data.weightDelta.toFixed(1)}
-          </div>
-        )}
-
-        {/* ④ 摂取カロリー */}
+        {/* ③ カロリー + 差分（近接表示: 1984k (+65)） */}
         {data?.log.calories != null && (
-          <div className="mt-0.5 flex items-baseline gap-0.5 leading-none">
+          <div className="mt-0.5 flex items-baseline gap-0.5 leading-none flex-wrap">
             <span className="text-[10px] font-medium text-slate-600">
               {data.log.calories.toLocaleString()}
             </span>
             <span className="text-[8px] text-slate-400">k</span>
+            {data?.calDelta != null && (
+              <span className={`text-[9px] font-medium leading-none ${
+                data.calDelta > 0
+                  ? "text-blue-400"
+                  : data.calDelta < 0
+                  ? "text-rose-400"
+                  : "text-slate-300"
+              }`}>
+                ({data.calDelta > 0 ? "+" : ""}{data.calDelta})
+              </span>
+            )}
           </div>
         )}
 
-        {/* ⑤ カロリー差分（補助・別行） */}
-        {data?.calDelta != null && (
-          <div className={`text-[9px] font-medium leading-none ${
-            data.calDelta > 0
-              ? "text-blue-400"
-              : data.calDelta < 0
-              ? "text-rose-400"
-              : "text-slate-300"
-          }`}>
-            {data.calDelta > 0 ? "+" : ""}{data.calDelta}
-          </div>
-        )}
-
-        {/* ⑥ 特殊日タグ */}
+        {/* ④ 特殊日タグ */}
         {data?.dayTags && data.dayTags.length > 0 && (
           <div className="mt-0.5 flex flex-wrap gap-0.5">
             {data.dayTags.map((tag) => (
               <span
                 key={tag.key}
-                className={`rounded-full px-1 py-0 text-[8px] font-semibold leading-4 ${tag.colorClass}`}
+                className={`rounded-full px-1.5 py-0.5 text-[9px] font-semibold leading-none ${tag.colorClass}`}
               >
                 {tag.label}
               </span>
@@ -197,13 +191,13 @@ function CalendarDayCell({ day, modifiers }: DayProps) {
           </div>
         )}
 
-        {/* ⑦ コンディションタグ（sm 以上） */}
+        {/* ⑤ コンディションタグ（sm 以上） */}
         {data?.conditionTags && data.conditionTags.length > 0 && (
           <div className="mt-0.5 hidden flex-wrap gap-0.5 sm:flex">
             {data.conditionTags.map((tag) => (
               <span
                 key={tag.key}
-                className={`rounded-full px-1 py-0 text-[8px] font-semibold leading-4 ${tag.colorClass}`}
+                className={`rounded-full px-1.5 py-0.5 text-[9px] font-semibold leading-none ${tag.colorClass}`}
               >
                 {tag.label}
               </span>

--- a/src/components/meal/FoodPicker.tsx
+++ b/src/components/meal/FoodPicker.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useMemo } from "react";
-import { Search, Plus } from "lucide-react";
+import { Search, Plus, Check } from "lucide-react";
 import { useFoodList } from "@/lib/hooks/useFoodList";
 import { MenuPicker } from "./MenuPicker";
 import type { FoodMaster } from "@/lib/supabase/types";
@@ -19,6 +19,20 @@ export function FoodPicker({ onAdd, onAddSet }: FoodPickerProps) {
   const [query, setQuery] = useState("");
   const [tab, setTab] = useState<Tab>("single");
   const [category, setCategory] = useState<string>("すべて");
+  // 追加済み一時フィードバック: food.name → true の Set（1.2秒後に自動解除）
+  const [recentlyAdded, setRecentlyAdded] = useState<Set<string>>(new Set());
+
+  const handleAdd = (food: FoodMaster) => {
+    onAdd(food);
+    setRecentlyAdded((prev) => new Set([...prev, food.name]));
+    setTimeout(() => {
+      setRecentlyAdded((prev) => {
+        const next = new Set(prev);
+        next.delete(food.name);
+        return next;
+      });
+    }, 1200);
+  };
 
   // food_master に登録されているカテゴリを動的に取得
   const categories = useMemo(() => {
@@ -114,11 +128,15 @@ export function FoodPicker({ onAdd, onAddSet }: FoodPickerProps) {
                     </p>
                   </div>
                   <button
-                    onClick={() => onAdd(food)}
-                    className="ml-3 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-blue-500 text-white hover:bg-blue-600"
-                    aria-label={`${food.name}を追加`}
+                    onClick={() => handleAdd(food)}
+                    className={`ml-3 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full text-white transition-colors ${
+                      recentlyAdded.has(food.name)
+                        ? "bg-green-500"
+                        : "bg-blue-500 hover:bg-blue-600"
+                    }`}
+                    aria-label={recentlyAdded.has(food.name) ? `${food.name}を追加済み` : `${food.name}を追加`}
                   >
-                    <Plus size={14} />
+                    {recentlyAdded.has(food.name) ? <Check size={14} /> : <Plus size={14} />}
                   </button>
                 </li>
               ))}


### PR DESCRIPTION
## 概要

単品食品追加ボタンの操作フィードバック改善と、月間カレンダーの可読性改善をまとめて対応する。

## 変更内容

### `src/components/meal/FoodPicker.tsx`

- `recentlyAdded: Set<string>` state を追加
- `+` ボタン押下後 1.2 秒間、ボタンがグリーン + チェックアイコンに切り替わる
- 1.2 秒後に自動でブルー + プラスアイコンに戻る
- aria-label も `追加済み` に切り替わりアクセシビリティも改善

### `src/components/dashboard/MonthlyCalendar.tsx`

**差分の近接表示:**
- 体重と前日差分を 1 行にまとめた: `71.2kg (+0.3)`（従来は別行）
- カロリーと差分を 1 行にまとめた: `1984k (+65)`（従来は別行）
- セル内の行数が 2 行減り、タグ類に余白が生まれた

**バッジの視認性改善:**
- `text-[8px] leading-4 px-1 py-0` → `text-[9px] leading-none px-1.5 py-0.5`
- 特殊日タグ・コンディションタグ（トレーニング部位・仕事モード）両方に適用

## 確認内容

- `npx tsc --noEmit` → エラーなし
- `npm run build` → 全 9 ページ正常ビルド
- 保存ロジック・差分計算ロジック（`calendarUtils.ts`）は無変更

## 影響範囲

- `FoodPicker.tsx`（単品タブの追加ボタンのみ）
- `MonthlyCalendar.tsx`（表示のみ、データ取得・計算ロジックは無変更）

Closes #78