### PR TITLE
feat: unify weight trend metric to 14-calendar-day regression

### DIFF
--- a/src/components/dashboard/KpiCards.tsx
+++ b/src/components/dashboard/KpiCards.tsx
@@ -60,16 +60,6 @@ export function KpiCards({ logs, settings, avgTdee: _avgTdee }: KpiCardsProps) {
 
   // --- 現在体重（最新の生体重。目標到達予定の計算には使わない）---
   const currentWeight = latest?.weight ?? null;
-  const weightData = sorted.slice(-14)
-    .filter((d) => d.weight !== null)
-    .map((d) => ({ date: d.log_date, weight: d.weight! }));
-  const trend = calcWeightTrend(weightData);
-  const slopePerWeek = trend.slope * 7;
-  const trendDir: "up" | "down" | "flat" =
-    Math.abs(slopePerWeek) < 0.05 ? "flat" : slopePerWeek > 0 ? "up" : "down";
-  const trendLabel = Math.abs(slopePerWeek) < 0.05
-    ? "横ばい"
-    : `${slopePerWeek > 0 ? "+" : ""}${slopePerWeek.toFixed(2)} kg/週`;
 
   // --- 基準日 (todayStr) ---
   // 以降の全暦日計算で共通して使う。JST 固定で UTC サーバー上でもズレない。
@@ -107,6 +97,14 @@ export function KpiCards({ logs, settings, avgTdee: _avgTdee }: KpiCardsProps) {
     .filter((p): p is { date: string; weight: number } => p.weight !== null);
   const slopePerDay14 = trend14Data.length >= 2 ? calcWeightTrend(trend14Data).slope : null;
 
+  // 週あたり変化率: 14暦日回帰 slope × 7 — 週次レビューの weekly_rate_kg と同一ロジック
+  const slopePerWeek = slopePerDay14 !== null ? slopePerDay14 * 7 : null;
+  const trendDir: "up" | "down" | "flat" =
+    slopePerWeek === null || Math.abs(slopePerWeek) < 0.05 ? "flat" : slopePerWeek > 0 ? "up" : "down";
+  const trendLabel = slopePerWeek === null || Math.abs(slopePerWeek) < 0.05
+    ? "横ばい"
+    : `${slopePerWeek > 0 ? "+" : ""}${slopePerWeek.toFixed(2)} kg/週`;
+
   const goalReachResult = calcGoalReachDate(weight_7d_avg, slopePerDay14, goalWeight, todayStr);
   const goalReachDate = goalReachResult.date;
   const goalReachLabel = goalReachResult.label;
@@ -118,11 +116,11 @@ export function KpiCards({ logs, settings, avgTdee: _avgTdee }: KpiCardsProps) {
         label="現在体重"
         value={currentWeight !== null ? currentWeight.toFixed(1) : "—"}
         unit="kg"
-        sub={weightData.length >= 2 ? trendLabel : undefined}
+        sub={slopePerWeek !== null ? trendLabel : undefined}
         icon={<Weight size={18} />}
         accent="bg-blue-50"
         iconColor="text-blue-600"
-        trendDir={weightData.length >= 2 ? trendDir : undefined}
+        trendDir={slopePerWeek !== null ? trendDir : undefined}
         trendPositive="down"
       />
 


### PR DESCRIPTION
## 概要

ダッシュボード KPI「現在体重」下の `kg/週` 表示を、**14件回帰ベース**から**14暦日線形回帰ベース**へ変更し、週次レビューの `14日トレンド` と同一ロジックに統一する。

## 変更内容

### `src/components/dashboard/KpiCards.tsx`

**Before**
```
sorted.slice(-14) で直近14件の体重記録を取得
→ calcWeightTrend(weightData) で線形回帰
→ slope × 7 で kg/週 を表示
```

**After**
```
dateRangeStr(d14Start, todayStr) で直近14暦日の体重記録を取得
→ calcWeightTrend(trend14Data).slope で線形回帰 (slopePerDay14)
→ slopePerDay14 × 7 で kg/週 を表示
```

- `sorted.slice(-14)` に基づく `weightData` / `trend` の計算を削除
- 既存の `trend14Data` / `slopePerDay14`（目標到達予定日計算でも使用）を KPI 表示にも再利用
- `calcReadiness.ts` の `weekly_rate_kg` と完全に同一の計算パスを共有

## KPI と週次レビューの指標統一

| 画面 | 変更前 | 変更後 |
|------|--------|--------|
| KPI 現在体重 | 直近14**件**回帰 slope × 7 | 直近14**暦日**回帰 slope × 7 |
| 週次レビュー 14日トレンド | 直近14暦日回帰 slope × 7 | 直近14暦日回帰 slope × 7（変更なし）|

両者が同じ計算ロジックを参照するため、KPI と週次レビューで `kg/週` の意味が一致する。

## 14暦日回帰へ統一した理由

- 記録件数ベースは記録頻度によって実際の日数がぶれる（14件 ≠ 14日）
- 週次レビュー設計がすでに暦日ベースを採用しており整合性を保てる
- 「このアプリの体重トレンドは14暦日回帰で見る」と一貫して説明できる

## テスト

既存の全テスト（643件）がパス。今回の変更は `KpiCards.tsx` 内の計算変数のリファクタのみで、新たな外部 utility の追加や既存テスト対象ロジックの変更はなし。

## 影響範囲

- `KpiCards.tsx` のみ変更（1ファイル）
- 前週比（`weight_change_7d`）は `calcReadiness.ts` 経由の週次レビュー側で引き続き補助指標として表示
- 目標到達予定日の計算ロジックは変更なし（元々 `slopePerDay14` を使用）

Closes #86