### PR TITLE
feat: make weekly weight change messaging phase-aware for cut and bulk

### DIFF
--- a/src/app/macro/page.tsx
+++ b/src/app/macro/page.tsx
@@ -11,15 +11,16 @@ import {
 } from "@/lib/utils/calcMacro";
 import type { MacroTargets } from "@/lib/utils/calcMacro";
 import { fetchDailyLogs } from "@/lib/queries/dailyLogs";
-import { fetchMacroTargets } from "@/lib/queries/settings";
+import { fetchMacroTargets, fetchSettings } from "@/lib/queries/settings";
 import { fetchFactorAnalysis } from "@/lib/queries/analytics";
 
 export const revalidate = 3600;
 
 export default async function MacroPage() {
-  const [logsResult, targetsResult] = await Promise.all([
+  const [logsResult, targetsResult, settingsResult] = await Promise.all([
     fetchDailyLogs(),
     fetchMacroTargets(),
+    fetchSettings(),
   ]);
 
   if (logsResult.kind === "error") {
@@ -52,6 +53,7 @@ export default async function MacroPage() {
   const factorResult = await fetchFactorAnalysis(latestRawLogUpdatedAt);
 
   const { calTarget, ...targets }: MacroTargets & { calTarget: number | null } = targetsResult;
+  const currentPhase = settingsResult.kind === "ok" ? settingsResult.data.currentPhase : null;
   const kpi = calcMacroKpi(logs);
   const dailyData = calcDailyMacro(logs, 60);
   const diff = calcMacroDiff(kpi.weekly, targets);
@@ -62,7 +64,7 @@ export default async function MacroPage() {
       <h1 className="mb-6 text-xl font-bold text-gray-800">栄養分析</h1>
       <div className="space-y-6">
         {/* 上段: kcal / PFC 目標差分・前週比サマリー */}
-        <MacroKpiCards kpi={kpi} targets={targets} diff={diff} />
+        <MacroKpiCards kpi={kpi} targets={targets} diff={diff} phase={currentPhase} />
 
         {/* 中段: 今週の PFC kcal 比率 */}
         <MacroPfcSummary ratio={pfcRatio} />

--- a/src/components/macro/MacroKpiCards.tsx
+++ b/src/components/macro/MacroKpiCards.tsx
@@ -7,6 +7,49 @@ interface MacroKpiCardsProps {
   kpi:     MacroKpiData;
   targets: MacroTargets;
   diff:    MacroDiff;
+  /** "Cut" | "Bulk" | null. null 時は Cut として扱う */
+  phase?:  string | null;
+}
+
+// ─── 週次体重変化の評価 ────────────────────────────────────────────────────────
+
+interface PaceInfo {
+  label: string;
+  /** カード内の短い注意喚起文 */
+  note:  string;
+  /** Tailwind text カラークラス */
+  color: string;
+}
+
+/**
+ * weightChangeRate (% / 週) と phase に応じた表示情報を返す。
+ *
+ * 判定帯域は Cut / Bulk 共通:
+ *   < -1.5% | -1.5〜-1.0% | -1.0〜-0.5% | -0.5〜-0.1%
+ *   | -0.1〜+0.1% | +0.1〜+0.5% | >= +0.5%
+ *
+ * ラベルと注意喚起文だけ phase で切り替える。
+ * Cut では減量ペースの適否・筋量維持リスクを、
+ * Bulk では増量ペースの適否・脂肪増加リスクを伝える。
+ */
+function getPaceInfo(rate: number, isBulk: boolean): PaceInfo {
+  if (isBulk) {
+    if (rate < -1.5) return { label: "減少しすぎています",  note: "増量方針から外れている可能性があります",     color: "text-rose-500"    };
+    if (rate < -1.0) return { label: "減少傾向です",        note: "摂取量不足の可能性があります",               color: "text-rose-500"    };
+    if (rate < -0.5) return { label: "やや減少しています",  note: "増量にはやや不足気味です",                   color: "text-amber-500"   };
+    if (rate < -0.1) return { label: "やや緩やかです",      note: "もう少し増量幅を出せる可能性があります",     color: "text-amber-500"   };
+    if (rate < +0.1) return { label: "横ばいです",          note: "維持寄りで、増量としては控えめです",         color: "text-amber-500"   };
+    if (rate < +0.5) return { label: "適正ペースです",      note: "良いペースで進んでいます",                   color: "text-emerald-600" };
+    return             { label: "増量が速すぎます",         note: "脂肪増加が大きくなる可能性があります",       color: "text-rose-500"    };
+  }
+  // Cut（デフォルト）
+  if (rate < -1.5) return { label: "減量が速すぎます",    note: "筋量維持や回復に影響する可能性があります",   color: "text-rose-500"    };
+  if (rate < -1.0) return { label: "やや速めです",        note: "コンディション低下に注意してください",       color: "text-amber-500"   };
+  if (rate < -0.5) return { label: "適正ペースです",      note: "良いペースで進んでいます",                   color: "text-emerald-600" };
+  if (rate < -0.1) return { label: "やや緩やかです",      note: "もう少し減量幅を出せる可能性があります",     color: "text-amber-500"   };
+  if (rate < +0.1) return { label: "横ばいです",          note: "摂取量または活動量の調整余地があります",     color: "text-amber-500"   };
+  if (rate < +0.5) return { label: "やや増加しています",  note: "減量方針から少し外れている可能性があります", color: "text-rose-500"    };
+  return             { label: "増加しています",           note: "摂取量や特殊日の影響を確認してください",     color: "text-rose-500"    };
 }
 
 function DiffBadge({ value, unit }: { value: number | null; unit: string }) {
@@ -24,17 +67,13 @@ function WeekDelta({ curr, prev, unit }: { curr: number | null; prev: number | n
   return <span className={`text-xs ${color}`}>前週比 {sign}{d.toLocaleString()} {unit}</span>;
 }
 
-export function MacroKpiCards({ kpi, targets, diff }: MacroKpiCardsProps) {
+export function MacroKpiCards({ kpi, targets, diff, phase }: MacroKpiCardsProps) {
   const { weekly, prevWeekly, weightChangeRate } = kpi;
+  const isBulk = phase === "Bulk";
 
-  let paceLabel = "—";
-  let paceColor = "text-gray-400";
-  if (weightChangeRate !== null) {
-    if (weightChangeRate < -1.5)      { paceLabel = "速すぎ ⚠️";     paceColor = "text-rose-500"; }
-    else if (weightChangeRate < -0.5) { paceLabel = "理想ペース 🎯"; paceColor = "text-emerald-600"; }
-    else if (weightChangeRate < 0.5)  { paceLabel = "緩やか 🐢";     paceColor = "text-amber-500"; }
-    else                              { paceLabel = "増加中";         paceColor = "text-rose-500"; }
-  }
+  const pace = weightChangeRate !== null
+    ? getPaceInfo(weightChangeRate, isBulk)
+    : null;
 
   const macros: { key: keyof MacroTargets; label: string; actual: number | null; prevActual: number | null; unit: string }[] = [
     { key: "protein", label: "タンパク質", actual: weekly.avgProtein,  prevActual: prevWeekly.avgProtein,  unit: "g" },
@@ -79,11 +118,11 @@ export function MacroKpiCards({ kpi, targets, diff }: MacroKpiCardsProps) {
         <div className="rounded-2xl border border-gray-100 bg-white p-5 shadow-sm">
           <div className="flex items-center justify-between">
             <p className="text-sm font-medium text-gray-500">週次体重変化</p>
-            {weightChangeRate !== null ? (
-              weightChangeRate < 0
-                ? <TrendingDown size={20} className="text-emerald-500" />
-                : weightChangeRate > 0
-                ? <TrendingUp size={20} className="text-rose-500" />
+            {pace !== null ? (
+              weightChangeRate! < 0
+                ? <TrendingDown size={20} className={pace.color} />
+                : weightChangeRate! > 0
+                ? <TrendingUp size={20} className={pace.color} />
                 : <Minus size={20} className="text-gray-300" />
             ) : <Minus size={20} className="text-gray-300" />}
           </div>
@@ -92,7 +131,14 @@ export function MacroKpiCards({ kpi, targets, diff }: MacroKpiCardsProps) {
               ? `${weightChangeRate > 0 ? "+" : ""}${weightChangeRate.toFixed(2)}%`
               : "—"}
           </p>
-          <p className={`mt-1 text-sm font-medium ${paceColor}`}>{paceLabel}</p>
+          {pace !== null ? (
+            <>
+              <p className={`mt-1 text-sm font-medium ${pace.color}`}>{pace.label}</p>
+              <p className="mt-0.5 text-xs text-slate-500">{pace.note}</p>
+            </>
+          ) : (
+            <p className="mt-1 text-sm font-medium text-gray-400">—</p>
+          )}
           <p className="mt-2 text-xs text-slate-400">直近7記録日 vs 前7記録日 の平均体重比</p>
         </div>
       </div>


### PR DESCRIPTION
## 概要

Macro 画面の「週次体重変化」カードを、Cut / Bulk どちらの phase でも自然に解釈できる表示へ見直す。

## 変更内容

### `src/components/macro/MacroKpiCards.tsx`

- `getPaceInfo(rate, isBulk)` ヘルパーを追加
  - `weightChangeRate` の判定帯域は Cut / Bulk **共通 7 段階**を維持
  - ラベル・注意喚起文・カラーだけを phase で切り替える
- カードに注意喚起文（`pace.note`）を追加表示
- アイコン色を `pace.color` に統一し、phase の意味論と揃える
- `phase?: string | null` prop を追加（未指定時は Cut として動作）

### `src/app/macro/page.tsx`

- `fetchSettings()` を並列取得に追加し `currentPhase` を抽出
- `<MacroKpiCards>` に `phase={currentPhase}` を渡す

## 共通判定帯域（7段階）

| 帯域 | Cut ラベル | Bulk ラベル |
|------|-----------|------------|
| `< -1.5%` | 減量が速すぎます | 減少しすぎています |
| `-1.5〜-1.0%` | やや速めです | 減少傾向です |
| `-1.0〜-0.5%` | **適正ペースです** ✅ | やや減少しています |
| `-0.5〜-0.1%` | やや緩やかです | やや緩やかです |
| `-0.1〜+0.1%` | 横ばいです | 横ばいです |
| `+0.1〜+0.5%` | やや増加しています | **適正ペースです** ✅ |
| `>= +0.5%` | 増加しています | 増量が速すぎます |

## Cut / Bulk 文言切替

- **Cut**: 筋量維持リスク・コンディション低下リスクを注記
- **Bulk**: 脂肪増加リスク・摂取量不足リスクを注記
- phase 未設定（null）は Cut として扱う（後退互換）

## `weightChangeRate` 算出ロジック

`calcMacro.ts` の計算ロジックは**変更なし**。直近 7 記録日 vs 前 7 記録日の平均体重比（%）のまま。

## 確認内容

- `npx tsc --noEmit` → エラーなし
- `npx jest --no-coverage` → 643 tests passed

## 影響範囲

- `MacroKpiCards.tsx`（表示ロジック）
- `macro/page.tsx`（`fetchSettings()` 追加・phase 渡し）
- `calcMacro.ts` は変更なし

Closes #88