### PR TITLE
feat: add manual refresh button to forecast accuracy page

### DIFF
--- a/src/app/forecast-accuracy/actions.ts
+++ b/src/app/forecast-accuracy/actions.ts
@@ -1,0 +1,13 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+/**
+ * 保存済みバックテスト結果を即時反映するための再検証アクション。
+ *
+ * backtest の再実行ではなく、ISR キャッシュの再検証のみを行う。
+ * 通常運用は revalidate = 3600 で十分だが、バッチ実行直後の確認時に利用する。
+ */
+export async function revalidateForecastAccuracy(): Promise<void> {
+  revalidatePath("/forecast-accuracy");
+}

--- a/src/app/forecast-accuracy/page.tsx
+++ b/src/app/forecast-accuracy/page.tsx
@@ -1,5 +1,6 @@
 import { BacktestResults } from "@/components/charts/BacktestResults";
 import { BacktestComparison } from "@/components/charts/BacktestComparison";
+import { ForecastAccuracyRefreshButton } from "@/components/charts/ForecastAccuracyRefreshButton";
 import { BarChart2 } from "lucide-react";
 import { fetchLatestRuns, fetchMetrics } from "@/lib/queries/backtest";
 
@@ -17,6 +18,7 @@ export default async function ForecastAccuracyPage() {
         <div className="flex items-center gap-2 mb-6">
           <BarChart2 size={20} className="text-blue-600" />
           <h1 className="text-xl font-bold text-gray-800">予測精度評価</h1>
+          <ForecastAccuracyRefreshButton />
         </div>
         <div className="rounded-xl border border-dashed border-slate-300 bg-white p-10 text-center">
           <p className="text-sm font-medium text-slate-500">
@@ -52,9 +54,8 @@ export default async function ForecastAccuracyPage() {
       <div className="flex items-center gap-2 mb-6">
         <BarChart2 size={20} className="text-blue-600" />
         <h1 className="text-xl font-bold text-gray-800">予測精度評価</h1>
-        <span className="ml-auto text-xs text-slate-400">
-          データは週次バッチで更新されます
-        </span>
+        <span className="text-xs text-slate-400">データは週次バッチで更新されます</span>
+        <ForecastAccuracyRefreshButton />
       </div>
 
       <div className="space-y-6">

--- a/src/components/charts/ForecastAccuracyRefreshButton.tsx
+++ b/src/components/charts/ForecastAccuracyRefreshButton.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { RefreshCw } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { revalidateForecastAccuracy } from "@/app/forecast-accuracy/actions";
+
+/**
+ * 保存済みバックテスト結果を即時反映するボタン。
+ *
+ * 動作:
+ *   1. Server Action で revalidatePath("/forecast-accuracy") を実行
+ *   2. router.refresh() でクライアントキャッシュをクリアして再レンダリング
+ *
+ * これは backtest の再実行ではなく、表示の再検証のみ。
+ */
+export function ForecastAccuracyRefreshButton() {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [done, setDone] = useState(false);
+
+  function handleRefresh() {
+    startTransition(async () => {
+      await revalidateForecastAccuracy();
+      router.refresh();
+      setDone(true);
+      setTimeout(() => setDone(false), 3000);
+    });
+  }
+
+  return (
+    <div className="ml-auto flex items-center gap-2">
+      {done && (
+        <span className="text-xs text-emerald-600 font-medium">✓ 表示を更新しました</span>
+      )}
+      <button
+        onClick={handleRefresh}
+        disabled={isPending}
+        title="保存済みのバックテスト結果を再反映します（再計算ではありません）"
+        className="flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs text-slate-600 hover:bg-slate-50 disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        <RefreshCw size={13} className={isPending ? "animate-spin" : ""} />
+        {isPending ? "更新中..." : "表示を更新"}
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要

`/forecast-accuracy` ページに手動更新ボタンを追加。backtest 実行直後に保存済み結果を即時反映できるようにする。

## 変更内容

### 手動更新ボタンの追加

`ForecastAccuracyRefreshButton` Client Component を新規追加し、ページヘッダーに配置。

- データあり・データなしの両分岐のヘッダーに `<ForecastAccuracyRefreshButton />` を追加
- ボタン押下中はスピナーアイコン + 「更新中...」表示で disable
- 完了後 3 秒間「✓ 表示を更新しました」を表示
- `title` 属性で「保存済みのバックテスト結果を再反映します（再計算ではありません）」と明示

### 再表示処理

`src/app/forecast-accuracy/actions.ts` に Server Action を新規追加。

```
revalidateForecastAccuracy() → revalidatePath("/forecast-accuracy")
```

クライアント側は `useTransition` でアクション完了を待ち、その後 `router.refresh()` でクライアントキャッシュをクリアして再レンダリング。

### ISR キャッシュ戦略を維持

`revalidate = 3600` は変更なし。手動更新ボタンはオンデマンドでキャッシュを無効化するだけで、通常運用の戦略には影響しない。

## 確認内容

- `npx tsc --noEmit` → エラーなし
- `jest --no-coverage` → 643 tests passed

## 影響範囲

- `/forecast-accuracy` ページのみ
- 新規ファイル 2 件（actions.ts / ForecastAccuracyRefreshButton.tsx）
- 既存コンポーネント・クエリ・ISR 設定への変更なし

## 残課題・別 Issue 候補

なし

Closes #80