### PR TITLE
feat: hydrate existing log values when editing past dates

### DIFF
--- a/src/components/meal/MealLogger.test.ts
+++ b/src/components/meal/MealLogger.test.ts
@@ -2,11 +2,14 @@ import { computeHasContent } from "./MealLogger";
 
 const base = {
   weight: "" as string | null,
+  weightTouched: false,
   cartItems: [] as Parameters<typeof computeHasContent>[0]["cartItems"],
   cartEverHadItems: false,
   note: "" as string | null,
+  noteTouched: false,
   touchedTags: new Set<import("@/lib/utils/dayTags").DayTag>(),
   sleepHours: "" as string | null,
+  sleepHoursTouched: false,
   hadBowelMovementTouched: false,
   trainingTypeTouched: false,
   workModeTouched: false,
@@ -18,9 +21,22 @@ describe("computeHasContent", () => {
     expect(computeHasContent({ ...base })).toBe(false);
   });
 
-  // ── 体重・食事・メモ（通常入力） ──
-  it("体重が入力されている場合は true", () => {
-    expect(computeHasContent({ ...base, weight: "65.5" })).toBe(true);
+  // ── hydrate のみ（touched なし）の場合 ──
+  it("hydrate で weight が表示されているだけ（touched=false）の場合は false", () => {
+    expect(computeHasContent({ ...base, weight: "65.5", weightTouched: false })).toBe(false);
+  });
+
+  it("hydrate で note が表示されているだけ（touched=false）の場合は false", () => {
+    expect(computeHasContent({ ...base, note: "調子良い", noteTouched: false })).toBe(false);
+  });
+
+  it("hydrate で sleepHours が表示されているだけ（touched=false）の場合は false", () => {
+    expect(computeHasContent({ ...base, sleepHours: "7.5", sleepHoursTouched: false })).toBe(false);
+  });
+
+  // ── 体重・食事・メモ（ユーザー操作あり） ──
+  it("体重が入力されている（touched=true）場合は true", () => {
+    expect(computeHasContent({ ...base, weight: "65.5", weightTouched: true })).toBe(true);
   });
 
   it("カートにアイテムがある場合は true", () => {
@@ -28,21 +44,30 @@ describe("computeHasContent", () => {
     expect(computeHasContent({ ...base, cartItems: [item] })).toBe(true);
   });
 
-  it("メモが入力されている場合は true", () => {
-    expect(computeHasContent({ ...base, note: "調子良い" })).toBe(true);
+  it("メモが入力されている（touched=true）場合は true", () => {
+    expect(computeHasContent({ ...base, note: "調子良い", noteTouched: true })).toBe(true);
   });
 
   // ── 明示的クリア（null 状態） ──
-  it("weight が null（明示クリア）のとき true", () => {
-    expect(computeHasContent({ ...base, weight: null })).toBe(true);
+  it("weight が null（明示クリア）かつ touched=true のとき true", () => {
+    expect(computeHasContent({ ...base, weight: null, weightTouched: true })).toBe(true);
   });
 
-  it("note が null（明示クリア）のとき true", () => {
-    expect(computeHasContent({ ...base, note: null })).toBe(true);
+  it("weight が null でも touched=false のとき false（hydrate 後の未操作クリア状態）", () => {
+    // このケースは通常 UI では発生しないが、念のため検証
+    expect(computeHasContent({ ...base, weight: null, weightTouched: false })).toBe(false);
   });
 
-  it("sleepHours が null（明示クリア）のとき true", () => {
-    expect(computeHasContent({ ...base, sleepHours: null })).toBe(true);
+  it("note が null（明示クリア）かつ touched=true のとき true", () => {
+    expect(computeHasContent({ ...base, note: null, noteTouched: true })).toBe(true);
+  });
+
+  it("sleepHours が null（明示クリア）かつ touched=true のとき true", () => {
+    expect(computeHasContent({ ...base, sleepHours: null, sleepHoursTouched: true })).toBe(true);
+  });
+
+  it("sleepHours が入力されている（touched=true）場合は true", () => {
+    expect(computeHasContent({ ...base, sleepHours: "7.5", sleepHoursTouched: true })).toBe(true);
   });
 
   it("cartEverHadItems=true（カートを追加後に空にした）のとき true", () => {
@@ -70,10 +95,6 @@ describe("computeHasContent", () => {
   });
 
   // ── コンディション系 ──
-  it("睡眠時間が入力されている場合は true", () => {
-    expect(computeHasContent({ ...base, sleepHours: "7.5" })).toBe(true);
-  });
-
   it("hadBowelMovementTouched が true（ボタン操作あり）の場合は true", () => {
     expect(computeHasContent({ ...base, hadBowelMovementTouched: true })).toBe(true);
   });
@@ -96,12 +117,18 @@ describe("computeHasContent", () => {
     expect(computeHasContent({ ...base, touchedTags })).toBe(true);
   });
 
-  it("タグ変更 + 体重入力の複合でも true", () => {
+  it("タグ変更 + 体重入力（touched=true）の複合でも true", () => {
     const touchedTags = new Set<import("@/lib/utils/dayTags").DayTag>(["is_cheat_day"]);
-    expect(computeHasContent({ ...base, weight: "64.0", touchedTags })).toBe(true);
+    expect(computeHasContent({ ...base, weight: "64.0", weightTouched: true, touchedTags })).toBe(true);
   });
 
   it("weight null かつ cartEverHadItems=true の複合でも true", () => {
-    expect(computeHasContent({ ...base, weight: null, cartEverHadItems: true })).toBe(true);
+    expect(computeHasContent({ ...base, weight: null, weightTouched: true, cartEverHadItems: true })).toBe(true);
+  });
+
+  // ── hydrate 後に過去日タグを触った場合 ──
+  it("hydrate で weight が表示されているがタグだけ変更した場合は true", () => {
+    const touchedTags = new Set<import("@/lib/utils/dayTags").DayTag>(["is_cheat_day"]);
+    expect(computeHasContent({ ...base, weight: "70.5", weightTouched: false, touchedTags })).toBe(true);
   });
 });

--- a/src/components/meal/MealLogger.tsx
+++ b/src/components/meal/MealLogger.tsx
@@ -6,7 +6,7 @@ import { saveDailyLog } from "@/app/actions/saveDailyLog";
 import { FoodPicker } from "./FoodPicker";
 import { Cart, calcCartTotals } from "./Cart";
 import type { CartItem } from "./Cart";
-import type { FoodMaster } from "@/lib/supabase/types";
+import type { FoodMaster, DailyLog } from "@/lib/supabase/types";
 import { toJstDateStr } from "@/lib/utils/date";
 import {
   type DayTag,
@@ -23,6 +23,7 @@ import {
   type TrainingType,
   type WorkMode,
 } from "@/lib/utils/trainingType";
+import { useDailyLogs } from "@/lib/hooks/useDailyLogs";
 
 type SaveStatus = "idle" | "saving" | "saved" | "error";
 
@@ -33,11 +34,14 @@ function todayStr() {
 /** hasContent 判定のための純粋関数（テスト容易性のために抽出） */
 export interface HasContentInput {
   weight: string | null;          // null = 明示的クリア予定
+  weightTouched: boolean;         // ユーザーが weight を操作したか（hydrate のみでは false）
   cartItems: CartItem[];
   cartEverHadItems: boolean;      // カートに一度でもアイテムが追加されたか
   note: string | null;            // null = 明示的クリア予定
+  noteTouched: boolean;           // ユーザーが note を操作したか
   touchedTags: Set<DayTag>;
   sleepHours: string | null;      // null = 明示的クリア予定
+  sleepHoursTouched: boolean;     // ユーザーが sleepHours を操作したか
   hadBowelMovementTouched: boolean; // ボタンを一度でも操作したか
   trainingTypeTouched: boolean;
   workModeTouched: boolean;
@@ -45,13 +49,15 @@ export interface HasContentInput {
 
 export function computeHasContent(input: HasContentInput): boolean {
   return (
-    // null !== "" → true なので、明示的クリア状態も「保存すべき内容あり」として扱う
-    input.weight !== "" ||
+    // touched フラグで「ユーザーが操作した」ことを判定する。
+    // hydrate のみの場合は touched=false のため hasContent=false になり、
+    // 保存ボタンが有効にならず、不要な更新も送信されない。
+    input.weightTouched ||
     input.cartItems.length > 0 ||
     input.cartEverHadItems ||       // カートを空にした場合も null 送信のため有効化
-    input.note !== "" ||
+    input.noteTouched ||
     input.touchedTags.size > 0 ||
-    input.sleepHours !== "" ||
+    input.sleepHoursTouched ||
     input.hadBowelMovementTouched || // touched なら null 送信も含め有効化
     input.trainingTypeTouched ||
     input.workModeTouched
@@ -63,11 +69,20 @@ interface MealLoggerProps {
 }
 
 export function MealLogger({ sidebar = false }: MealLoggerProps) {
+  // 既存ログ（SWR キャッシュ。日付変更時の hydrate に使用）
+  const { data: logs, mutate: mutateLogs } = useDailyLogs();
+
+  // hydrate 元のログ（null = 新規入力）
+  const [hydratedLog, setHydratedLog] = useState<DailyLog | null>(null);
+
   // ── 既存フィールド ──
   const [date, setDate] = useState(todayStr);
   // string | null: "" = 未入力, "70.5" = 入力値, null = 明示的クリア予定（null 送信）
   const [weight, setWeight] = useState<string | null>("");
+  // weightTouched=true → ユーザーが weight を操作した（hydrate のみでは false）
+  const [weightTouched, setWeightTouched] = useState(false);
   const [note, setNote] = useState<string | null>("");
+  const [noteTouched, setNoteTouched] = useState(false);
   const [cartItems, setCartItems] = useState<CartItem[]>([]);
   // カートに一度でもアイテムが追加されたか（空カートでも null 送信させるためのフラグ）
   const [cartEverHadItems, setCartEverHadItems] = useState(false);
@@ -80,6 +95,7 @@ export function MealLogger({ sidebar = false }: MealLoggerProps) {
   // ── Phase 2.5 新規フィールド ──
   // string | null: "" = 未入力, "7.5" = 入力値, null = 明示的クリア予定
   const [sleepHours, setSleepHours] = useState<string | null>("");
+  const [sleepHoursTouched, setSleepHoursTouched] = useState(false);
   // had_bowel_movement: null=未記録（未選択）, true=便通あり, false=便通なし
   // hadBowelMovementTouched=true のとき: null→null 送信（明示クリア=未記録），true/false→値送信
   // hadBowelMovementTouched=false のとき: undefined 送信（既存値を保持）
@@ -91,6 +107,60 @@ export function MealLogger({ sidebar = false }: MealLoggerProps) {
   // work_mode: 同上
   const [workMode, setWorkMode] = useState<WorkMode | null>(null);
   const [workModeTouched, setWorkModeTouched] = useState(false);
+
+  /**
+   * 日付変更時にフォームを hydrate または空リセットする。
+   * hydrate = 既存値の「初期表示」であり、touched フラグは立てない。
+   * つまり hydrate 後に Save しても、ユーザーが操作していないフィールドは
+   * payload に含まれず、partial update の安全性を維持する。
+   */
+  function hydrateForm(newDate: string) {
+    const existingLog = logs?.find((l) => l.log_date === newDate) ?? null;
+    setHydratedLog(existingLog);
+
+    // touched フラグをすべてリセット（hydrate は「未編集」として扱う）
+    setWeightTouched(false);
+    setNoteTouched(false);
+    setSleepHoursTouched(false);
+    setHadBowelMovementTouched(false);
+    setTrainingTypeTouched(false);
+    setWorkModeTouched(false);
+    setTouchedTags(new Set());
+
+    // カートはマクロ値から復元不可のためリセット
+    setCartItems([]);
+    setCartEverHadItems(false);
+
+    if (existingLog) {
+      // 既存値をフォームへ表示（touched は立てない）
+      setWeight(existingLog.weight !== null ? String(existingLog.weight) : "");
+      setNote(existingLog.note ?? "");
+      setSleepHours(existingLog.sleep_hours !== null ? String(existingLog.sleep_hours) : "");
+      setHadBowelMovement(existingLog.had_bowel_movement ?? null);
+      setTrainingType((existingLog.training_type as TrainingType) ?? null);
+      setWorkMode((existingLog.work_mode as WorkMode) ?? null);
+      setTags({
+        is_cheat_day:  existingLog.is_cheat_day  ?? false,
+        is_refeed_day: existingLog.is_refeed_day ?? false,
+        is_eating_out: existingLog.is_eating_out ?? false,
+        is_travel_day: existingLog.is_travel_day ?? false,
+      });
+    } else {
+      // 新規日付: 空フォームにリセット
+      setWeight("");
+      setNote("");
+      setSleepHours("");
+      setHadBowelMovement(null);
+      setTrainingType(null);
+      setWorkMode(null);
+      setTags(emptyTagState());
+    }
+  }
+
+  function handleDateChange(newDate: string) {
+    setDate(newDate);
+    hydrateForm(newDate);
+  }
 
   function toggleTag(tag: DayTag) {
     setTags((prev) => ({ ...prev, [tag]: !(prev as Record<DayTag, boolean>)[tag] }));
@@ -148,17 +218,24 @@ export function MealLogger({ sidebar = false }: MealLoggerProps) {
 
     const result = await saveDailyLog({
       log_date: date,
-      // null = 明示的クリア（null 送信）/ "" = 未入力（undefined 送信、既存値保持）
-      weight:   weight === null   ? null   : (weight   !== "" ? parseFloat(weight)   : undefined),
+      // touched=true かつユーザーが操作した場合のみ送信。
+      // touched=false (hydrate のみ) は undefined → 既存値を保持。
+      weight:   weightTouched
+        ? (weight === null   ? null   : (weight   !== "" ? parseFloat(weight)   : undefined))
+        : undefined,
       // カートに一度でも追加後に空にした → null 送信（マクロをクリア）
       calories: cartItems.length > 0 ? totals.calories : (cartEverHadItems ? null : undefined),
       protein:  cartItems.length > 0 ? totals.protein  : (cartEverHadItems ? null : undefined),
       fat:      cartItems.length > 0 ? totals.fat      : (cartEverHadItems ? null : undefined),
       carbs:    cartItems.length > 0 ? totals.carbs    : (cartEverHadItems ? null : undefined),
-      note:     note === null     ? null   : (note     !== "" ? note                 : undefined),
+      note:     noteTouched
+        ? (note === null     ? null   : (note     !== "" ? note                 : undefined))
+        : undefined,
       ...tagPayload,
       // Phase 2.5 新規フィールド
-      sleep_hours:        sleepHours === null ? null : (sleepHours !== "" ? parseFloat(sleepHours) : undefined),
+      sleep_hours: sleepHoursTouched
+        ? (sleepHours === null ? null : (sleepHours !== "" ? parseFloat(sleepHours) : undefined))
+        : undefined,
       // ルール: touched=true → hadBowelMovement の値をそのまま送信
       //           null  = 明示クリア（未記録に戻す）
       //           true  = 便通あり
@@ -176,27 +253,35 @@ export function MealLogger({ sidebar = false }: MealLoggerProps) {
       setTimeout(() => { setStatus("idle"); setErrorMessage(""); }, 5000);
     } else {
       setStatus("saved");
-      // フォームをリセット
+      // フォームをリセット（保存後は空フォームに戻す）
+      setHydratedLog(null);
       setCartItems([]);
       setCartEverHadItems(false);
-      setNote("");
       setWeight("");
+      setWeightTouched(false);
+      setNote("");
+      setNoteTouched(false);
       setTags(emptyTagState());
       setTouchedTags(new Set());
       setSleepHours("");
+      setSleepHoursTouched(false);
       setHadBowelMovement(null);
       setHadBowelMovementTouched(false);
       setTrainingType(null);
       setTrainingTypeTouched(false);
       setWorkMode(null);
       setWorkModeTouched(false);
+      // SWR キャッシュを更新して次回 hydrate に最新ログを反映させる
+      void mutateLogs();
       setTimeout(() => setStatus("idle"), 2000);
     }
   }
 
   const hasContent = computeHasContent({
-    weight, cartItems, cartEverHadItems, note, touchedTags,
-    sleepHours, hadBowelMovementTouched, trainingTypeTouched, workModeTouched,
+    weight, weightTouched, cartItems, cartEverHadItems,
+    note, noteTouched, touchedTags,
+    sleepHours, sleepHoursTouched,
+    hadBowelMovementTouched, trainingTypeTouched, workModeTouched,
   });
 
   const inputCls =
@@ -218,7 +303,13 @@ export function MealLogger({ sidebar = false }: MealLoggerProps) {
       <div className={`grid gap-3 ${sidebar ? "grid-cols-1" : "grid-cols-1 sm:grid-cols-3"}`}>
         <div>
           <label className="mb-1.5 block text-xs font-semibold uppercase tracking-wide text-slate-400">日付</label>
-          <input type="date" value={date} onChange={(e) => setDate(e.target.value)} className={inputCls} />
+          <input type="date" value={date} onChange={(e) => handleDateChange(e.target.value)} className={inputCls} />
+          {/* 既存ログあり / 新規入力 バッジ */}
+          {hydratedLog ? (
+            <p className="mt-1 text-xs font-medium text-amber-600">既存ログあり — 差分のみ編集できます</p>
+          ) : (
+            <p className="mt-1 text-xs text-slate-400">新規入力</p>
+          )}
         </div>
         <div>
           <label className="mb-1.5 block text-xs font-semibold uppercase tracking-wide text-slate-400">体重 (kg)</label>
@@ -227,16 +318,25 @@ export function MealLogger({ sidebar = false }: MealLoggerProps) {
               <input type="number" disabled placeholder="削除予定" className={`${inputClearedCls} pr-8`} />
             ) : (
               <input type="number" step="0.1" min="0" placeholder="70.5" value={weight}
-                onChange={(e) => setWeight(e.target.value)} className={`${inputCls} ${weight !== "" ? "pr-8" : ""}`} />
+                onChange={(e) => { setWeight(e.target.value); setWeightTouched(true); }}
+                className={`${inputCls} ${weight !== "" ? "pr-8" : ""}`} />
             )}
             {weight !== "" && weight !== null && (
-              <button type="button" onClick={() => setWeight(null)} title="null 保存（クリア）"
+              <button type="button" onClick={() => { setWeight(null); setWeightTouched(true); }} title="null 保存（クリア）"
                 className="absolute right-2.5 top-1/2 -translate-y-1/2 text-slate-300 hover:text-rose-400 transition-colors">
                 <X size={13} />
               </button>
             )}
             {weight === null && (
-              <button type="button" onClick={() => setWeight("")} title="クリアを取り消す"
+              <button type="button"
+                onClick={() => {
+                  // 既存ログがある場合は hydrated 値に戻す。なければ空フォームに戻す。
+                  setWeight(hydratedLog?.weight !== null && hydratedLog?.weight !== undefined
+                    ? String(hydratedLog.weight)
+                    : "");
+                  setWeightTouched(false);
+                }}
+                title="クリアを取り消す"
                 className="absolute right-2.5 top-1/2 -translate-y-1/2 text-rose-400 hover:text-slate-500 transition-colors">
                 <Undo2 size={13} />
               </button>
@@ -250,16 +350,22 @@ export function MealLogger({ sidebar = false }: MealLoggerProps) {
               <input type="text" disabled placeholder="削除予定" className={`${inputClearedCls} pr-8`} />
             ) : (
               <input type="text" placeholder="任意" value={note}
-                onChange={(e) => setNote(e.target.value)} className={`${inputCls} ${note !== "" ? "pr-8" : ""}`} />
+                onChange={(e) => { setNote(e.target.value); setNoteTouched(true); }}
+                className={`${inputCls} ${note !== "" ? "pr-8" : ""}`} />
             )}
             {note !== "" && note !== null && (
-              <button type="button" onClick={() => setNote(null)} title="null 保存（クリア）"
+              <button type="button" onClick={() => { setNote(null); setNoteTouched(true); }} title="null 保存（クリア）"
                 className="absolute right-2.5 top-1/2 -translate-y-1/2 text-slate-300 hover:text-rose-400 transition-colors">
                 <X size={13} />
               </button>
             )}
             {note === null && (
-              <button type="button" onClick={() => setNote("")} title="クリアを取り消す"
+              <button type="button"
+                onClick={() => {
+                  setNote(hydratedLog?.note ?? "");
+                  setNoteTouched(false);
+                }}
+                title="クリアを取り消す"
                 className="absolute right-2.5 top-1/2 -translate-y-1/2 text-rose-400 hover:text-slate-500 transition-colors">
                 <Undo2 size={13} />
               </button>
@@ -267,6 +373,18 @@ export function MealLogger({ sidebar = false }: MealLoggerProps) {
           </div>
         </div>
       </div>
+
+      {/* 既存ログのマクロ表示（カートで復元不可なため参照用に表示） */}
+      {hydratedLog && (hydratedLog.calories !== null || hydratedLog.protein !== null) && (
+        <div className="rounded-xl border border-amber-100 bg-amber-50 px-3 py-2 text-xs text-amber-700">
+          <span className="font-semibold">記録済みマクロ:</span>{" "}
+          {hydratedLog.calories !== null && <span>{hydratedLog.calories} kcal</span>}
+          {hydratedLog.protein  !== null && <span> / P {hydratedLog.protein}g</span>}
+          {hydratedLog.fat      !== null && <span> / F {hydratedLog.fat}g</span>}
+          {hydratedLog.carbs    !== null && <span> / C {hydratedLog.carbs}g</span>}
+          <span className="ml-1 text-amber-500">（更新する場合はカートから追加）</span>
+        </div>
+      )}
 
       {/* 特殊日タグ (is_cheat_day / is_refeed_day / is_eating_out / is_travel_day) */}
       <div>
@@ -302,17 +420,24 @@ export function MealLogger({ sidebar = false }: MealLoggerProps) {
               ) : (
                 <input type="number" step="0.5" min="0" max="24" placeholder="7.5"
                   value={sleepHours}
-                  onChange={(e) => setSleepHours(e.target.value)}
+                  onChange={(e) => { setSleepHours(e.target.value); setSleepHoursTouched(true); }}
                   className={`${inputCls} ${sleepHours !== "" ? "pr-8" : ""}`} />
               )}
               {sleepHours !== "" && sleepHours !== null && (
-                <button type="button" onClick={() => setSleepHours(null)} title="null 保存（クリア）"
+                <button type="button" onClick={() => { setSleepHours(null); setSleepHoursTouched(true); }} title="null 保存（クリア）"
                   className="absolute right-2.5 top-1/2 -translate-y-1/2 text-slate-300 hover:text-rose-400 transition-colors">
                   <X size={13} />
                 </button>
               )}
               {sleepHours === null && (
-                <button type="button" onClick={() => setSleepHours("")} title="クリアを取り消す"
+                <button type="button"
+                  onClick={() => {
+                    setSleepHours(hydratedLog?.sleep_hours !== null && hydratedLog?.sleep_hours !== undefined
+                      ? String(hydratedLog.sleep_hours)
+                      : "");
+                    setSleepHoursTouched(false);
+                  }}
+                  title="クリアを取り消す"
                   className="absolute right-2.5 top-1/2 -translate-y-1/2 text-rose-400 hover:text-slate-500 transition-colors">
                   <Undo2 size={13} />
                 </button>


### PR DESCRIPTION
## 概要

過去日を選択したとき、その日の既存ログをフォームへ hydrate して編集 UX を改善する。
- ユーザーが「何が既に入力済みか」を画面上で把握できるようにする
- partial update の安全性は維持したまま

## 変更内容

### `MealLogger.tsx`
- `useDailyLogs` を使って SWR キャッシュから既存ログを取得
- `hydrateForm(date)` を追加：日付変更時に既存ログの値をフォームへセット、ログなし時は空リセット
- `weightTouched` / `noteTouched` / `sleepHoursTouched` フラグを追加（各テキスト入力の「ユーザー操作済み」追跡）
- `HasContentInput` に 3 フラグを追加し、`computeHasContent` を touched ベースの判定に変更
- Undo ボタンで hydrated 値に戻すと touched が false に戻る
- 日付欄下に「既存ログあり — 差分のみ編集できます」/ 「新規入力」バッジを表示
- 既存マクロ（カートで復元不可）を amber のパネルで参照表示
- 保存後に `mutateLogs()` して SWR キャッシュを更新

### `MealLogger.test.ts`
- `base` に 3 フラグ追加（デフォルト `false`）
- hydrate シナリオ（touched=false で hasContent=false）のテストを追加
- 既存テストを touched フラグ導入に合わせて更新
- 合計 25 件（全 PASS）

## hydrate 方針

- `hydrateForm()` で既存値を state にセットするが、**touched フラグは一切立てない**
- touched フラグが false のフィールドはペイロードに `undefined` を送信 → 既存値を保持
- ユーザーが値を変更したとき初めて touched=true となり、次回保存でそのフィールドが更新される
- これにより「表示の分かりやすさ」と「partial update の安全性」を両立

## touched 管理との整合

| フィールド | 以前 | 今回 |
|---|---|---|
| weight | `weight !== ""` で hasContent 判定 | `weightTouched` フラグで判定 |
| note | `note !== ""` で hasContent 判定 | `noteTouched` フラグで判定 |
| sleepHours | `sleepHours !== ""` で hasContent 判定 | `sleepHoursTouched` フラグで判定 |
| trainingType / workMode / hadBowelMovement / tags | 既存 touched フラグ | 変更なし |

## テスト

```
Tests: 648 passed, 648 total
```

型チェック: エラーなし

## 影響範囲

- `MealLogger.tsx` のみ（DashboardLayout / page.tsx は変更なし）
- `computeHasContent` の引数インターフェースが変更（`weightTouched` / `noteTouched` / `sleepHoursTouched` 追加）
- 保存ロジック・partial update 仕様の変更なし

## 残課題（別 Issue）

- マクロ（calories/P/F/C）の hydrate は現状「参照表示のみ」。カートで編集する形のため、
  既存値を完全に復元して編集するには別途 UI 設計が必要（スコープ外）
- 保存後の日付はそのまま残るが、フォームは空リセットされる。
  「保存後に今日の日付に戻す」かは UX 判断として別 Issue で議論可

Closes #97