### PR TITLE
fix: clarify weekly review stale analytics copy

### DIFF
--- a/src/components/analytics/AnalyticsStatusNote.tsx
+++ b/src/components/analytics/AnalyticsStatusNote.tsx
@@ -2,7 +2,9 @@
  * AnalyticsStatusNote — analytics 依存値の stale / unavailable / error 補助注記
  *
  * - fresh:       何も表示しない
- * - stale:       「再計算前データ（最終更新: YYYY-MM-DD、N日前）」
+ * - stale:       「再計算前データ（最終更新: YYYY-MM-DD、最新ログより N 日遅れ）」
+ *                staleDays は「キャッシュ日と最新依存データ日の差」であり、
+ *                「今日から N 日前」ではない。文言はこの意味を正確に伝える。
  * - unavailable: 「未計算 — <unavailableLabel>」
  * - error:       「取得エラー — <errorLabel>」
  *
@@ -27,9 +29,11 @@ export function AnalyticsStatusNote({
 
   if (availability.status === "stale") {
     const dateStr = availability.lastUpdatedDate ?? "不明";
+    // staleDays は「キャッシュ日と最新依存データ日の差」。
+    // 「N日前」は「今日からN日前」と誤読されるため、比較基準を明示した文言にする。
     const dayStr =
       availability.staleDays !== null && availability.staleDays > 0
-        ? `、${availability.staleDays}日前`
+        ? `、最新ログより${availability.staleDays}日遅れ`
         : "";
     return (
       <span className="inline-block text-xs text-amber-600">


### PR DESCRIPTION
## 概要

ダッシュボード週次レビュー等の analytics stale 注記で、`staleDays` が「今日からN日前」と誤読されやすかった文言を、比較基準を明示した表現に修正する。

## 変更内容

**`src/components/analytics/AnalyticsStatusNote.tsx`**

```
Before: 再計算前データ（最終更新: 2026-03-15、1日前）
After:  再計算前データ（最終更新: 2026-03-15、最新ログより1日遅れ）
```

`dayStr` の生成を `${staleDays}日前` → `最新ログより${staleDays}日遅れ` に変更。

## 文言改善方針

`staleDays` の実際の意味は「analytics_cache の更新日と最新依存データ日（raw logs の MAX updated_at）との差（日数）」。
「N日前」は読み手が自然に「今日からN日前」と解釈するため意味軸がズレていた。
「最新ログより N 日遅れ」とすることで、何に対して遅れているかが明示される。

## 他利用箇所との整合

`AnalyticsStatusNote` は以下の3箇所で使用されており、全て同一コンポーネント経由のため今回の変更で一括対応済み:
- `WeeklyReviewCard`（エネルギーバランス）
- `TdeeKpiCard`
- `FactorAnalysis` ヘッダー

## テスト

stale 判定ロジック・`staleDays` 計算は変更なし。全テスト 648件 PASS。

## 影響範囲

`AnalyticsStatusNote.tsx` の表示文言のみ。判定ロジック・計算・他コンポーネントの変更なし。

Closes #84