### PR TITLE
chore: remove build dependency on next/font/google

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@supabase/supabase-js": "^2.98.0",
         "@types/japanese-holidays": "^1.0.3",
+        "geist": "^1.7.0",
         "japanese-holidays": "^1.0.10",
         "lucide-react": "^0.577.0",
         "next": "16.1.6",
@@ -6223,6 +6224,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/geist": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/geist/-/geist-1.7.0.tgz",
+      "integrity": "sha512-ZaoiZwkSf0DwwB1ncdLKp+ggAldqxl5L1+SXaNIBGkPAqcu+xjVJLxlf3/S8vLt9UHx1xu5fz3lbzKCj5iOVdQ==",
+      "license": "SIL OPEN FONT LICENSE",
+      "peerDependencies": {
+        "next": ">=13.2.0"
       }
     },
     "node_modules/generator-function": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.98.0",
     "@types/japanese-holidays": "^1.0.3",
+    "geist": "^1.7.0",
     "japanese-holidays": "^1.0.10",
     "lucide-react": "^0.577.0",
     "next": "16.1.6",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,17 +1,10 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+// next/font/google ではなく geist npm パッケージ（SIL Open Font License）を使用する。
+// build 時に外部フォント取得が不要となり、ネットワーク到達性に依存しない再現可能な build が実現できる。
+import { GeistSans } from "geist/font/sans";
+import { GeistMono } from "geist/font/mono";
 import "./globals.css";
 import { NavBar } from "@/components/ui/NavBar";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "Body Composition Tracker",
@@ -26,7 +19,7 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${GeistSans.variable} ${GeistMono.variable} antialiased`}
       >
         <NavBar />
         <div className="mx-auto max-w-screen-xl px-4">


### PR DESCRIPTION
## 概要

`next/font/google` は build 時に Google Fonts から外部取得するため、ネットワーク到達性に依存した不安定な build になっていた。`geist` npm パッケージ（SIL Open Font License）を使ったローカル配信に切り替え、外部依存を除去する。

## 変更内容

**`src/app/layout.tsx`**

```diff
- import { Geist, Geist_Mono } from "next/font/google";
+ import { GeistSans } from "geist/font/sans";
+ import { GeistMono }  from "geist/font/mono";

- const geistSans = Geist({ variable: "--font-geist-sans", subsets: ["latin"] });
- const geistMono = Geist_Mono({ variable: "--font-geist-mono", subsets: ["latin"] });

- className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+ className={`${GeistSans.variable} ${GeistMono.variable} antialiased`}
```

**`package.json` / `package-lock.json`**
- `geist@1.7.0` を dependencies に追加

## フォント方針

| 項目 | 変更前 | 変更後 |
|---|---|---|
| 配信元 | Google Fonts（build 時外部取得） | geist npm パッケージ（ローカル） |
| ライセンス | — | SIL Open Font License |
| フォント | Geist / Geist Mono | Geist / Geist Mono（同一） |
| CSS 変数名 | `--font-geist-sans` / `--font-geist-mono` | 変更なし |

## build 再現性改善

`geist` パッケージの woff2 ファイルは `node_modules` 内に含まれるため、`npm install` 後は外部ネットワーク接続なしで build が完了する。CI・閉域環境・オフラインビルドでも安定する。

## UI 影響確認

CSS 変数名が変わらないため、フォントの見た目・サイズ・ウェイトは変化なし。`npm run build` が正常完了し静的ページ 9件が生成されたことを確認。

## テスト

型チェック・`npm run build`・全テスト（648件）すべて PASS。

## 影響範囲

`src/app/layout.tsx` と `package.json` のみ。アプリロジック・スタイル・他コンポーネントの変更なし。

Closes #94