### PR TITLE
chore: clean up unused ESLint warnings

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,15 @@ import nextTs from "eslint-config-next/typescript";
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
+  // _ prefix は「意図的に未使用」を示す慣例。destructuring での key 除外パターン (_dropped 等) を許可する。
+  {
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
+    },
+  },
   // Override default ignores of eslint-config-next.
   globalIgnores([
     // Default ignores of eslint-config-next:

--- a/src/components/charts/FactorAnalysis.tsx
+++ b/src/components/charts/FactorAnalysis.tsx
@@ -352,7 +352,7 @@ export function FactorAnalysis({ data, updatedAt, meta, analyticsAvailability }:
           <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" horizontal={false} />
           <XAxis type="number" tick={{ fontSize: 11 }} unit="%" domain={[0, 100]} />
           <YAxis type="category" dataKey="name" tick={{ fontSize: 11 }} width={130} />
-          <Tooltip formatter={(v: TooltipValueType | undefined, _: number | string | undefined) => [`${v ?? ""}%`, "重要度（相対値）"]} />
+          <Tooltip formatter={(v: TooltipValueType | undefined) => [`${v ?? ""}%`, "重要度（相対値）"]} />
           <Bar dataKey="pct" radius={[0, 4, 4, 0]}>
             <LabelList dataKey="pct" position="right" formatter={(v: RenderableText) => `${v ?? ""}%`} style={{ fontSize: 11, fill: "#6b7280" }} />
             {chartData.map((_, i) => (

--- a/src/components/dashboard/GoalNavigator.tsx
+++ b/src/components/dashboard/GoalNavigator.tsx
@@ -172,7 +172,6 @@ export function GoalNavigator({
   metrics,
   phase,
   goalWeight,
-  contestDate,
   avgTdee,
 }: GoalNavigatorProps) {
   const isCut = phase !== "Bulk";

--- a/src/components/dashboard/KpiCards.tsx
+++ b/src/components/dashboard/KpiCards.tsx
@@ -54,7 +54,7 @@ function KpiCard({ label, value, unit, sub, icon, accent, iconColor, trendDir, t
   );
 }
 
-export function KpiCards({ logs, settings, avgTdee: _avgTdee }: KpiCardsProps) {
+export function KpiCards({ logs, settings }: KpiCardsProps) {
   const sorted = [...logs].sort((a, b) => a.log_date.localeCompare(b.log_date));
   const latest = sorted[sorted.length - 1];
 

--- a/src/components/settings/SettingsForm.tsx
+++ b/src/components/settings/SettingsForm.tsx
@@ -41,7 +41,6 @@ const MACRO_TARGET_FIELDS: Record<string, FieldMeta> = {
 
 const FIELD_KEYS = Object.keys(FIELDS);
 const MACRO_TARGET_KEYS = Object.keys(MACRO_TARGET_FIELDS);
-const ALL_FIELD_KEYS = [...FIELD_KEYS, ...MACRO_TARGET_KEYS];
 
 /** PFC由来kcal = P×4 + F×9 + C×4 。いずれか未入力なら null */
 function calcPfcDerivedKcal(values: Record<string, string>): number | null {


### PR DESCRIPTION
## 概要

`npm run lint` で出ていた 6 件の unused variable/arg warning を解消した。動作仕様・表示への影響なし。

## 変更内容

| ファイル | 変更内容 |
|---|---|
| `eslint.config.mjs` | `argsIgnorePattern`/`varsIgnorePattern: "^_"` を追加（`_` prefix 慣例を ESLint に認識させる） |
| `FactorAnalysis.tsx` | Tooltip formatter の不要な第2引数 `_` を削除 |
| `GoalNavigator.tsx` | props destructuring から未使用の `contestDate` を削除 |
| `KpiCards.tsx` | props destructuring から未使用の `avgTdee: _avgTdee` を削除 |
| `SettingsForm.tsx` | 未使用の定数 `ALL_FIELD_KEYS` を削除 |

## 解消した warning

```
FactorAnalysis.tsx:355   '_' is defined but never used
GoalNavigator.tsx:175    'contestDate' is defined but never used
KpiCards.tsx:57          '_avgTdee' is defined but never used
SettingsForm.tsx:44      'ALL_FIELD_KEYS' is assigned a value but never used
factorAnalysisUtils.test.ts:134  '_dropped' is assigned a value but never used
factorAnalysisUtils.test.ts:166  '_dropped' is assigned a value but never used
```

## 意図的に残したもの

- **`GoalNavigatorProps.contestDate` / `KpiCardsProps.avgTdee`**: Props 型と親の呼び出しはそのまま維持。今回のスコープは destructuring の lint warning 解消のみ。
- **`_dropped` in test**: `const { key: _dropped, ...rest } = obj` は TypeScript で特定キーを除いたオブジェクトを得る正当なパターン。ESLint config で `_` prefix を許可することで対処。

## 確認結果

- `npm run lint`: warning 0 件 ✓
- `npx tsc --noEmit`: エラーなし ✓
- `jest --no-coverage`: 648 tests passed ✓

## 影響範囲

ドキュメント・ロジックの変更なし。lint 設定と未使用コードの削除のみ。

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)