### PR TITLE
fix: resolve flatted dependabot alert for issue #125

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6124,9 +6124,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.4.tgz",
-      "integrity": "sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "recharts": "^3.8.0",
     "swr": "^2.4.1"
   },
+  "overrides": {
+    "flatted": "3.4.2"
+  },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",


### PR DESCRIPTION
## 概要

`flatted` の Prototype Pollution alert（Dependabot #15）を `npm overrides` で `3.4.2` に固定することで解消した。

## 変更内容

| ファイル | 変更内容 |
|---|---|
| `package.json` | `overrides.flatted: "3.4.2"` を追加 |
| `package-lock.json` | `flatted` 3.3.4 → 3.4.2 に更新 |

## 依存経路の確認結果

```
eslint@9.39.4
└── file-entry-cache@8.0.0
    └── flat-cache@4.0.1
        └── flatted@3.3.4  ← 脆弱 (<=3.4.1)
                           → 3.4.2  ← 修正版
```

- **間接依存**（`package.json` に直接記載なし）
- `flat-cache@4.0.1` は `flatted@^3.2.9` を許容しており、3.4.2 は範囲内

## 親依存更新を採用しなかった理由

- `eslint@9.x` は全バージョン（9.0.0 〜 9.39.4）で `file-entry-cache@^8.0.0` を使用
- `file-entry-cache@8.0.0` は `flat-cache@^4.0.0` を使用
- `flat-cache@4.x` は 4.0.1 が唯一のバージョン
- 以上より、eslint@9.x の範囲内でどのバージョンに上げても経路は変わらず、自動的に 3.4.2 を引き込む親依存は存在しない
- override が「最後の手段」ではなく、この構造では**最小差分の正解**

## 確認内容

- `npm install` → `changed 1 package, found 0 vulnerabilities` ✓
- `npm ls flatted` → `flatted@3.4.2 overridden` ✓
- `next build` → ✓ Compiled successfully ✓
- `jest --no-coverage` → 648 tests passed ✓

## 補足

GitHub 側の Dependabot alert はマージ後に自動解消される見込み（lockfile 上の `flatted` が 3.4.2 になるため）。

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)