### PR TITLE
feat: add monthly goal planning and redistribution logic

### DIFF
--- a/src/lib/utils/monthlyGoalPlan.test.ts
+++ b/src/lib/utils/monthlyGoalPlan.test.ts
@@ -233,6 +233,42 @@ describe("buildMonthlyGoalPlan", () => {
       );
     });
 
+    test("override の targetWeight が 0 → INVALID_OVERRIDE_WEIGHT", () => {
+      const plan = buildMonthlyGoalPlan(
+        makeInput({
+          overrides: [{ month: "2026-04", targetWeight: 0 }],
+        })
+      );
+      expect(plan.isValid).toBe(false);
+      expect(plan.errors.some((e) => e.code === "INVALID_OVERRIDE_WEIGHT")).toBe(
+        true
+      );
+    });
+
+    test("override の targetWeight が NaN → INVALID_OVERRIDE_WEIGHT", () => {
+      const plan = buildMonthlyGoalPlan(
+        makeInput({
+          overrides: [{ month: "2026-04", targetWeight: NaN }],
+        })
+      );
+      expect(plan.isValid).toBe(false);
+      expect(plan.errors.some((e) => e.code === "INVALID_OVERRIDE_WEIGHT")).toBe(
+        true
+      );
+    });
+
+    test("override の targetWeight が 300 超 → INVALID_OVERRIDE_WEIGHT", () => {
+      const plan = buildMonthlyGoalPlan(
+        makeInput({
+          overrides: [{ month: "2026-04", targetWeight: 301 }],
+        })
+      );
+      expect(plan.isValid).toBe(false);
+      expect(plan.errors.some((e) => e.code === "INVALID_OVERRIDE_WEIGHT")).toBe(
+        true
+      );
+    });
+
     test("override が計画期間外の月を指している → OVERRIDE_MONTH_OUT_OF_RANGE", () => {
       const plan = buildMonthlyGoalPlan(
         makeInput({
@@ -294,7 +330,8 @@ describe("redistributeMonthlyGoals", () => {
       baseEntries,
       "2026-03",
       77.0,
-      72.0
+      72.0,
+      78.0
     );
     expect(result[0]!.targetWeight).toBe(77.0);
     expect(result[0]!.source).toBe("manual");
@@ -311,7 +348,8 @@ describe("redistributeMonthlyGoals", () => {
       baseEntries,
       "2026-04",
       76.0,
-      72.0
+      72.0,
+      78.0
     );
     expect(result[0]!.targetWeight).toBe(76.5); // Mar 変わらず
     expect(result[1]!.targetWeight).toBe(76.0); // Apr manual
@@ -326,7 +364,8 @@ describe("redistributeMonthlyGoals", () => {
       baseEntries,
       "2026-05",
       74.0,
-      72.0
+      72.0,
+      78.0
     );
     expect(result[2]!.targetWeight).toBe(74.0);
     expect(result[2]!.source).toBe("manual");
@@ -340,7 +379,8 @@ describe("redistributeMonthlyGoals", () => {
       baseEntries,
       "2026-06",
       70.0,
-      72.0
+      72.0,
+      78.0
     );
     expect(result).toEqual(baseEntries);
   });
@@ -350,25 +390,24 @@ describe("redistributeMonthlyGoals", () => {
       baseEntries,
       "2026-09",
       75.0,
-      72.0
+      72.0,
+      78.0
     );
     expect(result).toEqual(baseEntries);
   });
 
   test("requiredDeltaKg が再配分後に正しく更新される", () => {
-    // Mar を 77.0 に編集 (prevWeight = 78.0 だが entries[0] の前は currentWeight)
-    // Mar.requiredDeltaKg = 77.0 - 76.5 ... ではなく、前エントリーとの差
-    // 先頭エントリーなので prevWeight は entries[-1] がないため自分自身の前が不明
-    // redistributeMonthlyGoals は editedIdx>0 の場合のみ prevWeight が前エントリー
-    // editedIdx=0 の場合は prevWeight = newTargetWeight (delta=0 になる設計)
+    // Mar を 77.0 に編集。先頭月なので prevWeight = currentWeight = 78.0
+    // Mar.requiredDeltaKg = 77.0 - 78.0 = -1.0
     const result = redistributeMonthlyGoals(
       baseEntries,
       "2026-03",
       77.0,
-      72.0
+      72.0,
+      78.0
     );
-    // editedIdx=0: prevWeight=77.0 (newTargetWeight), requiredDeltaKg=0
-    expect(result[0]!.requiredDeltaKg).toBe(0);
+    // editedIdx=0: prevWeight = currentWeight = 78.0, requiredDeltaKg = 77.0 - 78.0 = -1.0
+    expect(result[0]!.requiredDeltaKg).toBe(-1.0);
     // Apr: 75.3 - 77.0 = -1.7
     expect(result[1]!.requiredDeltaKg).toBeCloseTo(-1.7, 1);
   });
@@ -380,7 +419,8 @@ describe("redistributeMonthlyGoals", () => {
       baseEntries,
       "2026-04",
       76.0,
-      72.0
+      72.0,
+      78.0
     );
     expect(result[1]!.requiredDeltaKg).toBeCloseTo(-0.5, 2);
     // May: 74.0 - 76.0 = -2.0
@@ -395,7 +435,8 @@ describe("redistributeMonthlyGoals", () => {
       entriesWithActual,
       "2026-03",
       77.0,
-      72.0
+      72.0,
+      78.0
     );
     expect(result[1]!.actualWeight).toBe(74.8);
   });
@@ -725,7 +766,8 @@ describe("buildMonthlyGoalPlan + redistributeMonthlyGoals 統合", () => {
       plan.entries,
       "2026-04",
       76.0,
-      72.0
+      72.0,
+      78.0
     );
 
     expect(updated[0]!.targetWeight).toBe(76.5); // Mar: 変わらず

--- a/src/lib/utils/monthlyGoalPlan.ts
+++ b/src/lib/utils/monthlyGoalPlan.ts
@@ -109,6 +109,7 @@ export type MonthlyGoalErrorCode =
   | "INVALID_DEADLINE"            // goalDeadlineDate が不正な日付形式
   | "INVALID_CURRENT_WEIGHT"      // currentWeight が数値でない / 範囲外
   | "INVALID_GOAL_WEIGHT"         // finalGoalWeight が数値でない / 範囲外
+  | "INVALID_OVERRIDE_WEIGHT"     // overrides[].targetWeight が数値でない / 範囲外
   | "DEADLINE_IN_PAST"            // 期限月が currentMonth より過去
   | "NO_MONTHS"                   // 計画対象月が 0 件 (内部エラー)
   | "OVERRIDE_MONTH_OUT_OF_RANGE"; // override が計画期間外の月を指している
@@ -213,6 +214,16 @@ function validateInput(input: MonthlyGoalPlanInput): MonthlyGoalError[] {
     input.finalGoalWeight > 300
   ) {
     errors.push({ code: "INVALID_GOAL_WEIGHT" });
+  }
+
+  // overrides の targetWeight も個別に検証する。
+  // currentWeight / finalGoalWeight と同じ範囲制約を適用し、
+  // 不正値が計算に混入するのをロジック層で防ぐ。
+  const hasInvalidOverride = input.overrides.some(
+    (o) => !isFinite(o.targetWeight) || o.targetWeight <= 0 || o.targetWeight > 300
+  );
+  if (hasInvalidOverride) {
+    errors.push({ code: "INVALID_OVERRIDE_WEIGHT" });
   }
 
   if (errors.length > 0) return errors;
@@ -360,13 +371,15 @@ export function buildMonthlyGoalPlan(
  * @param editedMonth 編集した月 "YYYY-MM"
  * @param newTargetWeight 編集月の新しい月末目標体重 (kg)
  * @param finalGoalWeight 最終目標体重 (kg)
+ * @param currentWeight 現在体重 (kg)。先頭月編集時の requiredDeltaKg 基準に使用。
  * @returns 再配分後の新しいエントリーリスト。editedMonth が見つからない場合は元のリストをそのまま返す。
  */
 export function redistributeMonthlyGoals(
   entries: MonthlyGoalEntry[],
   editedMonth: string,
   newTargetWeight: number,
-  finalGoalWeight: number
+  finalGoalWeight: number,
+  currentWeight: number
 ): MonthlyGoalEntry[] {
   const editedIdx = entries.findIndex((e) => e.month === editedMonth);
   if (editedIdx === -1) return entries;
@@ -375,8 +388,10 @@ export function redistributeMonthlyGoals(
   if (editedIdx === entries.length - 1) return entries;
 
   const before = entries.slice(0, editedIdx);
+  // 先頭月 (editedIdx === 0) は currentWeight を基準とする。
+  // 「初月は currentWeight 比」という requiredDeltaKg の定義に合わせるため。
   const prevWeight =
-    editedIdx > 0 ? entries[editedIdx - 1]!.targetWeight : newTargetWeight;
+    editedIdx > 0 ? entries[editedIdx - 1]!.targetWeight : currentWeight;
 
   const editedEntry: MonthlyGoalEntry = {
     ...entries[editedIdx]!,


### PR DESCRIPTION
## 概要

月別目標体重管理機能の土台となる canonical logic を純粋関数として実装した。
UI・DB・既存設定はいっさい変更せず、#102〜#104 が参照するロジック層のみを確立する。

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `src/lib/utils/monthlyGoalPlan.ts` | 型定義 + 4 つの exported 関数 |
| `src/lib/utils/monthlyGoalPlan.test.ts` | 単体テスト 43 件 |

## 今回確定した仕様

### 月次目標の定義
- `targetWeight` = **その月末時点の目標体重**
- 月別サマリー・月末実績と対応づけやすく、月単位の計画として最も自然

### 計画の範囲
- `today` の YYYY-MM から `goalDeadlineDate` の YYYY-MM まで
- 過去月 (currentMonth より前) は計画に含めない
  - 過去実績は `monthlyActuals` として入力し、`actualWeight` フィールドに記録

### 再配分ルール
- override をアンカーとして、アンカー間を線形補間で均等配分
- 最終月は常に `finalGoalWeight`（override 不可）
- `redistributeMonthlyGoals` は編集月以降のすべてを再配分（既存 manual override も上書き）

### Warning 設計
| コード | 条件 | 閾値 |
|---|---|---|
| `HIGH_MONTHLY_DELTA` | `|requiredDeltaKg| > 2.0` | 2.0 kg/month ≈ 1.0 kg/2週 |
| `DEADLINE_TOO_CLOSE` | 計画月数 ≤ 1 | 1 ヶ月 |
| `ALREADY_AT_GOAL` | 現在体重が目標達成済み/超過 | ±0.2 kg (calcReadiness に準拠) |
| `WRONG_DIRECTION` | delta が最終目標と逆方向 | — |
| `MANUAL_GOAL_MISMATCH` | manual override あり & 最終月が finalGoalWeight と乖離 | 0.05 kg |

閾値はすべて定数化して理由をコメントに記載した。

## 実装上の判断

- **浮動小数点対策**: ALREADY_AT_GOAL の比較では `diff` を 0.01 kg で丸めてから閾値比較（72.0 − 71.8 = 0.2000000000000028 問題を回避）
- **Error vs Warning 分離**: 構築不可 → `MonthlyGoalError`、注意喚起 → `MonthlyGoalWarning`
- **`redistributeMonthlyGoals` は最終月を編集不可**: 最終月 = finalGoalWeight が canonical なため
- **過去月は計画範囲外**: 後続 Issue でチャート表示時に別途 monthlyActuals から取得する

## テスト (43 件)

- 正常系: 均等配分 / override あり / 複数 override / 1 ヶ月計画 / Bulk / 既達成
- 異常系: 不正日付 / 期限過去 / 不正体重 / override 範囲外
- redistribute: 先頭 / 中間 / 末尾-1 月 / 最終月 (変更なし) / 存在しない月 / delta 精度
- validate: 正常 / 期限不一致 / 最終重量乖離
- warnings: 各コード / 閾値境界 / 空配列

## 後続 Issue (#102〜#104) での利用想定

```typescript
import {
  buildMonthlyGoalPlan,
  redistributeMonthlyGoals,
  validateMonthlyGoalPlan,
  getMonthlyGoalWarnings,
  type MonthlyGoalPlanInput,
  type MonthlyGoalPlan,
  type MonthlyGoalEntry,
  type MonthlyGoalOverride,
  type MonthlyGoalWarning,
  MAX_SAFE_MONTHLY_DELTA_KG,
} from "@/lib/utils/monthlyGoalPlan";
```

- **#102** (Settings UI): `overrides` の保存形式を決めて `buildMonthlyGoalPlan` に渡す
- **#103** (Dashboard): `buildMonthlyGoalPlan` の結果を GoalNavigator / KpiCards に渡す
- **#104** (Chart): `entries` を ForecastChart のオーバーレイとして描画する

## 残課題 (別 Issue 推奨)

- `monthlyPlan overrides` の DB 保存形式未定 (#102 スコープ)
- `monthlyActuals` の集計ロジック (daily_logs から月末体重を取得する query) 未実装 (#103 スコープ)
- `actual_fixed` (過去月の実績固定エントリー) の表示は #104 で設計
- `AppSettings` への `monthlyPlanOverrides` フィールド追加は #102 で行う

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)