### PR TITLE
feat: add monthly goal progress to GoalNavigator (#103)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,8 @@ import { WeeklyReviewCard } from "@/components/dashboard/WeeklyReviewCard";
 import { calcDataQuality } from "@/lib/utils/calcDataQuality";
 import { calcReadiness } from "@/lib/utils/calcReadiness";
 import { calcWeeklyReview } from "@/lib/utils/calcWeeklyReview";
+import { calcMonthlyGoalProgress } from "@/lib/utils/calcMonthlyGoalProgress";
+import { toJstDateStr } from "@/lib/utils/date";
 import { fetchDailyLogs, fetchPredictions, fetchCareerLogsForDashboard } from "@/lib/queries/dailyLogs";
 import { fetchSettings } from "@/lib/queries/settings";
 import { fetchEnrichedLogs } from "@/lib/queries/analytics";
@@ -144,6 +146,17 @@ export default async function DashboardPage() {
     phase,
   });
 
+  // 今月目標に対する進捗。GoalNavigator の refWeight と同一の比較値を使う。
+  const comparisonWeight = readinessMetrics.weight_7d_avg ?? readinessMetrics.current_weight;
+  const monthlyGoalProgress = calcMonthlyGoalProgress({
+    contestDate: contestDate ?? null,
+    targetWeight: goalWeight ?? null,
+    monthlyPlanOverrides: settings.monthlyPlanOverrides,
+    comparisonWeight,
+    today: toJstDateStr(),
+    phase,
+  });
+
   return (
     <DashboardLayout>
       {/* Read error banners — graceful degradation: コンテンツはブロックしない */}
@@ -179,6 +192,7 @@ export default async function DashboardPage() {
             goalWeight={goalWeight ?? null}
             contestDate={contestDate ?? null}
             avgTdee={latestTdee}
+            monthlyGoalProgress={monthlyGoalProgress}
           />
           <WeeklyReviewCard data={weeklyReview} phase={phase} enrichedAvailability={enrichedAvailability} />
           <DataQualityBadge report={qualityReport} />

--- a/src/components/dashboard/GoalNavigator.tsx
+++ b/src/components/dashboard/GoalNavigator.tsx
@@ -24,9 +24,11 @@ import {
   CheckCircle2,
   CircleDot,
   HelpCircle,
+  CalendarDays,
 } from "lucide-react";
 import type { ReadinessMetrics } from "@/lib/utils/calcReadiness";
 import { calcGoalStatus, calcKcalCorrection } from "@/lib/utils/calcReadiness";
+import type { MonthlyGoalProgress } from "@/lib/utils/calcMonthlyGoalProgress";
 
 interface GoalNavigatorProps {
   metrics: ReadinessMetrics;
@@ -36,6 +38,8 @@ interface GoalNavigatorProps {
   contestDate: string | null;
   /** 直近の推定 TDEE (kcal). 表示参考値として利用 */
   avgTdee: number | null;
+  /** 今月目標に対する進捗 (calcMonthlyGoalProgress の結果) */
+  monthlyGoalProgress: MonthlyGoalProgress;
 }
 
 // ─── ステータス表示マップ ──────────────────────────────────────────────────
@@ -77,6 +81,16 @@ const STATUS_CONFIG = {
     bg: "bg-slate-50 border-slate-200",
     icon: HelpCircle,
   },
+} as const;
+
+// ─── 今月目標進捗 状態表示マップ ─────────────────────────────────────────────
+
+const MONTHLY_STATE_CONFIG = {
+  achieved:           { label: "今月達成済", color: "text-emerald-600", bg: "bg-emerald-50 border-emerald-200" },
+  on_track:           { label: "計画内",     color: "text-emerald-600", bg: "bg-emerald-50 border-emerald-200" },
+  slightly_behind:    { label: "やや遅れ",   color: "text-amber-600",   bg: "bg-amber-50 border-amber-200"   },
+  replan_recommended: { label: "再計画推奨", color: "text-rose-600",    bg: "bg-rose-50 border-rose-200"     },
+  unavailable:        { label: "データ不足", color: "text-slate-400",   bg: "bg-slate-50 border-slate-200"   },
 } as const;
 
 // ─── ヘルパー関数 ────────────────────────────────────────────────────────────
@@ -173,6 +187,7 @@ export function GoalNavigator({
   phase,
   goalWeight,
   avgTdee,
+  monthlyGoalProgress,
 }: GoalNavigatorProps) {
   const isCut = phase !== "Bulk";
 
@@ -411,6 +426,78 @@ export function GoalNavigator({
           </div>
         </div>
       </div>
+
+      {/* ── 今月目標進捗 ── */}
+      {monthlyGoalProgress.state !== "unavailable" && (
+        <div className="border-t border-slate-100 px-5 py-3">
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5">
+            {/* セクションラベル + 状態バッジ */}
+            <div className="flex items-center gap-2 shrink-0">
+              <CalendarDays size={12} className="text-slate-400" />
+              <span className="text-[11px] font-bold uppercase tracking-widest text-slate-400">
+                今月目標進捗
+              </span>
+              <span
+                className={`rounded-full border px-2 py-0.5 text-[10px] font-bold ${
+                  MONTHLY_STATE_CONFIG[monthlyGoalProgress.state].color
+                } ${MONTHLY_STATE_CONFIG[monthlyGoalProgress.state].bg}`}
+              >
+                {MONTHLY_STATE_CONFIG[monthlyGoalProgress.state].label}
+              </span>
+            </div>
+
+            {/* 今月末目標 */}
+            <span className="text-xs text-slate-500">
+              今月末目標:{" "}
+              <span className="font-semibold text-slate-700 tabular-nums">
+                {monthlyGoalProgress.monthlyTargetWeight?.toFixed(1) ?? "—"} kg
+              </span>
+            </span>
+
+            {/* 差分 */}
+            {monthlyGoalProgress.deltaKg !== null && (
+              <span className="text-xs text-slate-500">
+                差分:{" "}
+                <span
+                  className={`font-semibold tabular-nums ${
+                    monthlyGoalProgress.state === "achieved"
+                      ? "text-emerald-600"
+                      : Math.abs(monthlyGoalProgress.deltaKg) < 0.5
+                      ? "text-slate-700"
+                      : isCut && monthlyGoalProgress.deltaKg > 0
+                      ? "text-rose-600"
+                      : !isCut && monthlyGoalProgress.deltaKg < 0
+                      ? "text-amber-600"
+                      : "text-slate-700"
+                  }`}
+                >
+                  {monthlyGoalProgress.deltaKg > 0 ? "+" : ""}
+                  {monthlyGoalProgress.deltaKg.toFixed(2)} kg
+                </span>
+              </span>
+            )}
+
+            {/* 残必要ペース */}
+            {monthlyGoalProgress.requiredPaceKgPerWeek !== null && (
+              <span className="text-xs text-slate-500">
+                残必要ペース:{" "}
+                <span className="font-semibold tabular-nums text-slate-700">
+                  {monthlyGoalProgress.requiredPaceKgPerWeek > 0 ? "+" : ""}
+                  {monthlyGoalProgress.requiredPaceKgPerWeek.toFixed(2)} kg/週
+                </span>
+                <span className="ml-1 text-[10px] text-slate-400">
+                  (残{monthlyGoalProgress.daysToMonthEnd}日)
+                </span>
+              </span>
+            )}
+
+            {/* 警告あり補足 */}
+            {monthlyGoalProgress.hasWarnings && (
+              <span className="text-[10px] text-amber-500">⚠ 計画に警告あり</span>
+            )}
+          </div>
+        </div>
+      )}
 
       {/* ── フッター注記 ── */}
       <div className="border-t border-slate-50 bg-slate-50 px-5 py-2 text-[11px] text-slate-400">

--- a/src/lib/utils/calcMonthlyGoalProgress.test.ts
+++ b/src/lib/utils/calcMonthlyGoalProgress.test.ts
@@ -1,0 +1,359 @@
+/**
+ * calcMonthlyGoalProgress.test.ts
+ *
+ * calcMonthlyGoalProgress / getMonthEndDate / calcDaysToMonthEnd の unit tests。
+ * buildMonthlyGoalPlan は real 実装をそのまま呼ぶ (mock なし)。
+ *
+ * 固定 today: "2026-07-15"
+ * 単月プラン: contestDate = "2026-07-31"
+ *   → plan.entries[0] = { month: "2026-07", targetWeight: finalGoalWeight }
+ *   → daysToMonthEnd = 16, weeksToMonthEnd = 16/7 ≈ 2.286
+ */
+
+import {
+  calcMonthlyGoalProgress,
+  getMonthEndDate,
+  calcDaysToMonthEnd,
+  MONTHLY_ON_TRACK_PACE_KG_WEEK,
+  MONTHLY_REPLAN_PACE_KG_WEEK,
+} from "./calcMonthlyGoalProgress";
+
+// ─── 定数確認 ─────────────────────────────────────────────────────────────────
+
+describe("定数", () => {
+  it("MONTHLY_ON_TRACK_PACE_KG_WEEK は 0.5", () => {
+    expect(MONTHLY_ON_TRACK_PACE_KG_WEEK).toBe(0.5);
+  });
+
+  it("MONTHLY_REPLAN_PACE_KG_WEEK は 1.0 (MAX_SAFE_MONTHLY_DELTA_KG / 2)", () => {
+    expect(MONTHLY_REPLAN_PACE_KG_WEEK).toBe(1.0);
+  });
+});
+
+// ─── getMonthEndDate ─────────────────────────────────────────────────────────
+
+describe("getMonthEndDate", () => {
+  it("1月 → 31日", () => {
+    expect(getMonthEndDate("2026-01-15")).toBe("2026-01-31");
+  });
+
+  it("2月 (平年) → 28日", () => {
+    expect(getMonthEndDate("2026-02-10")).toBe("2026-02-28");
+  });
+
+  it("2月 (うるう年) → 29日", () => {
+    expect(getMonthEndDate("2024-02-10")).toBe("2024-02-29");
+  });
+
+  it("4月 → 30日", () => {
+    expect(getMonthEndDate("2026-04-01")).toBe("2026-04-30");
+  });
+
+  it("7月 → 31日", () => {
+    expect(getMonthEndDate("2026-07-15")).toBe("2026-07-31");
+  });
+
+  it("12月 → 31日", () => {
+    expect(getMonthEndDate("2026-12-01")).toBe("2026-12-31");
+  });
+
+  it("不正な形式 → null", () => {
+    expect(getMonthEndDate("2026/07/15")).toBeNull();
+  });
+
+  it("月が 0 → null", () => {
+    expect(getMonthEndDate("2026-00-01")).toBeNull();
+  });
+
+  it("月が 13 → null", () => {
+    expect(getMonthEndDate("2026-13-01")).toBeNull();
+  });
+});
+
+// ─── calcDaysToMonthEnd ──────────────────────────────────────────────────────
+
+describe("calcDaysToMonthEnd", () => {
+  it("月中 → 残り日数が正", () => {
+    // 2026-07-15 → 月末 2026-07-31: 16日
+    const days = calcDaysToMonthEnd("2026-07-15");
+    expect(days).toBe(16);
+  });
+
+  it("月末当日 → 0", () => {
+    expect(calcDaysToMonthEnd("2026-07-31")).toBe(0);
+  });
+
+  it("月初 → 30", () => {
+    // 2026-07-01 → 2026-07-31: 30日
+    expect(calcDaysToMonthEnd("2026-07-01")).toBe(30);
+  });
+
+  it("不正な日付 → null", () => {
+    expect(calcDaysToMonthEnd("bad-date")).toBeNull();
+  });
+});
+
+// ─── calcMonthlyGoalProgress — unavailable (前提条件欠損) ───────────────────
+
+describe("calcMonthlyGoalProgress — unavailable (前提条件欠損)", () => {
+  const BASE = {
+    contestDate: "2026-07-31",
+    targetWeight: 73.8,
+    monthlyPlanOverrides: null,
+    comparisonWeight: 75.0,
+    today: "2026-07-15",
+    phase: "Cut",
+  };
+
+  it("contestDate が null → hasData: false, state: unavailable", () => {
+    const result = calcMonthlyGoalProgress({ ...BASE, contestDate: null });
+    expect(result.hasData).toBe(false);
+    expect(result.state).toBe("unavailable");
+    expect(result.monthlyTargetWeight).toBeNull();
+    expect(result.deltaKg).toBeNull();
+  });
+
+  it("targetWeight が null → hasData: false, state: unavailable", () => {
+    const result = calcMonthlyGoalProgress({ ...BASE, targetWeight: null });
+    expect(result.hasData).toBe(false);
+    expect(result.state).toBe("unavailable");
+  });
+
+  it("comparisonWeight が null → hasData: false, state: unavailable", () => {
+    const result = calcMonthlyGoalProgress({ ...BASE, comparisonWeight: null });
+    expect(result.hasData).toBe(false);
+    expect(result.state).toBe("unavailable");
+  });
+
+  it("contestDate が過去 → plan 無効 → hasData: false, state: unavailable", () => {
+    const result = calcMonthlyGoalProgress({ ...BASE, contestDate: "2025-01-01" });
+    expect(result.hasData).toBe(false);
+    expect(result.state).toBe("unavailable");
+  });
+
+  it("unavailable 時も comparisonWeight は保持される", () => {
+    const result = calcMonthlyGoalProgress({ ...BASE, contestDate: null });
+    expect(result.comparisonWeight).toBe(75.0);
+  });
+});
+
+// ─── calcMonthlyGoalProgress — 今月目標の表示 ────────────────────────────────
+
+describe("calcMonthlyGoalProgress — 今月目標の表示", () => {
+  /**
+   * 単月プラン (contestDate = 今月末):
+   *   plan.entries = [{ month: "2026-07", targetWeight: 73.8 }]
+   *   daysToMonthEnd = 16, weeksToMonthEnd = 16/7 ≈ 2.286
+   */
+  const BASE = {
+    contestDate: "2026-07-31",
+    targetWeight: 73.8,
+    monthlyPlanOverrides: null,
+    comparisonWeight: 74.9,
+    today: "2026-07-15",
+    phase: "Cut",
+  };
+
+  it("hasData: true が返る", () => {
+    const result = calcMonthlyGoalProgress(BASE);
+    expect(result.hasData).toBe(true);
+  });
+
+  it("monthlyTargetWeight は finalGoalWeight と一致する (単月プラン)", () => {
+    const result = calcMonthlyGoalProgress(BASE);
+    expect(result.monthlyTargetWeight).toBeCloseTo(73.8, 1);
+  });
+
+  it("comparisonWeight は入力値がそのまま返る", () => {
+    const result = calcMonthlyGoalProgress(BASE);
+    expect(result.comparisonWeight).toBe(74.9);
+  });
+
+  it("deltaKg = comparisonWeight - monthlyTargetWeight (0.01 単位で丸め)", () => {
+    // 74.9 - 73.8 = 1.1
+    const result = calcMonthlyGoalProgress(BASE);
+    expect(result.deltaKg).toBeCloseTo(1.1, 2);
+  });
+
+  it("daysToMonthEnd は今日から月末までの日数", () => {
+    // 2026-07-15 → 2026-07-31: 16日
+    const result = calcMonthlyGoalProgress(BASE);
+    expect(result.daysToMonthEnd).toBe(16);
+  });
+
+  it("weeksToMonthEnd は daysToMonthEnd / 7", () => {
+    const result = calcMonthlyGoalProgress(BASE);
+    expect(result.weeksToMonthEnd).toBeCloseTo(16 / 7, 4);
+  });
+
+  it("requiredPaceKgPerWeek は -deltaKg / weeksToMonthEnd (0.01 丸め)", () => {
+    // -1.1 / (16/7) ≈ -0.48
+    const result = calcMonthlyGoalProgress(BASE);
+    expect(result.requiredPaceKgPerWeek).toBeCloseTo(-0.48, 1);
+  });
+});
+
+// ─── calcMonthlyGoalProgress — 状態判定 (Cut) ───────────────────────────────
+
+describe("calcMonthlyGoalProgress — 状態判定 (Cut)", () => {
+  /**
+   * 共通条件:
+   *   today = "2026-07-15", contestDate = "2026-07-31"
+   *   targetWeight (= monthlyTargetWeight) = 73.8
+   *   daysToMonthEnd = 16, weeksToMonthEnd ≈ 2.286
+   */
+  function make(comparisonWeight: number) {
+    return calcMonthlyGoalProgress({
+      contestDate: "2026-07-31",
+      targetWeight: 73.8,
+      monthlyPlanOverrides: null,
+      comparisonWeight,
+      today: "2026-07-15",
+      phase: "Cut",
+    });
+  }
+
+  it("achieved: comparisonWeight が目標を下回っている (deltaKg = -0.8 ≤ 0.2)", () => {
+    // 73.0 - 73.8 = -0.8 → achieved
+    const result = make(73.0);
+    expect(result.state).toBe("achieved");
+  });
+
+  it("achieved: comparisonWeight が目標と誤差範囲内 (deltaKg = +0.1 ≤ 0.2)", () => {
+    // 73.9 - 73.8 = 0.1 → achieved
+    const result = make(73.9);
+    expect(result.state).toBe("achieved");
+  });
+
+  it("on_track: absPace ≤ 0.5 kg/週 (deltaKg ≈ 1.1, absPace ≈ 0.48)", () => {
+    // 74.9 - 73.8 = 1.1 → requiredPace ≈ -0.48 → on_track
+    const result = make(74.9);
+    expect(result.state).toBe("on_track");
+  });
+
+  it("slightly_behind: 0.5 < absPace ≤ 1.0 kg/週 (deltaKg ≈ 1.7, absPace ≈ 0.74)", () => {
+    // 75.5 - 73.8 = 1.7 → requiredPace ≈ -0.74 → slightly_behind
+    const result = make(75.5);
+    expect(result.state).toBe("slightly_behind");
+  });
+
+  it("replan_recommended: absPace > 1.0 kg/週 (deltaKg = 3.2, absPace ≈ 1.4)", () => {
+    // 77.0 - 73.8 = 3.2 → requiredPace ≈ -1.4 → replan_recommended
+    const result = make(77.0);
+    expect(result.state).toBe("replan_recommended");
+  });
+});
+
+// ─── calcMonthlyGoalProgress — 状態判定 (Bulk) ──────────────────────────────
+
+describe("calcMonthlyGoalProgress — 状態判定 (Bulk)", () => {
+  function make(comparisonWeight: number) {
+    return calcMonthlyGoalProgress({
+      contestDate: "2026-07-31",
+      targetWeight: 73.8,
+      monthlyPlanOverrides: null,
+      comparisonWeight,
+      today: "2026-07-15",
+      phase: "Bulk",
+    });
+  }
+
+  it("achieved: comparisonWeight が目標を上回っている (deltaKg = +0.2 ≥ -0.2)", () => {
+    // 74.0 - 73.8 = 0.2 → Bulk achieved
+    const result = make(74.0);
+    expect(result.state).toBe("achieved");
+  });
+
+  it("on_track: Bulk でも absPace ≤ 0.5 なら on_track", () => {
+    // 72.7 - 73.8 = -1.1 → Bulk requiredPace = +0.48 → on_track
+    const result = make(72.7);
+    expect(result.state).toBe("on_track");
+  });
+
+  it("replan_recommended: Bulk で大幅遅れ (deltaKg = -3.2, absPace ≈ 1.4)", () => {
+    // 70.6 - 73.8 = -3.2 → Bulk requiredPace ≈ +1.4 → replan_recommended
+    const result = make(70.6);
+    expect(result.state).toBe("replan_recommended");
+  });
+});
+
+// ─── calcMonthlyGoalProgress — 月末当日 ─────────────────────────────────────
+
+describe("calcMonthlyGoalProgress — 月末当日 (daysToMonthEnd = 0)", () => {
+  it("月末当日で未達なら weeksToMonthEnd = null → replan_recommended", () => {
+    const result = calcMonthlyGoalProgress({
+      contestDate: "2026-07-31",
+      targetWeight: 73.8,
+      monthlyPlanOverrides: null,
+      comparisonWeight: 75.0, // 未達
+      today: "2026-07-31",   // 月末当日
+      phase: "Cut",
+    });
+    expect(result.daysToMonthEnd).toBe(0);
+    expect(result.weeksToMonthEnd).toBeNull();
+    expect(result.requiredPaceKgPerWeek).toBeNull();
+    expect(result.state).toBe("replan_recommended");
+  });
+
+  it("月末当日で達成済みなら achieved", () => {
+    const result = calcMonthlyGoalProgress({
+      contestDate: "2026-07-31",
+      targetWeight: 73.8,
+      monthlyPlanOverrides: null,
+      comparisonWeight: 73.5, // 達成済み
+      today: "2026-07-31",
+      phase: "Cut",
+    });
+    expect(result.state).toBe("achieved");
+  });
+});
+
+// ─── calcMonthlyGoalProgress — hasWarnings ───────────────────────────────────
+
+describe("calcMonthlyGoalProgress — hasWarnings", () => {
+  it("contestDate が今月末 → DEADLINE_TOO_CLOSE 警告あり → hasWarnings: true", () => {
+    const result = calcMonthlyGoalProgress({
+      contestDate: "2026-07-31",
+      targetWeight: 73.8,
+      monthlyPlanOverrides: null,
+      comparisonWeight: 75.0,
+      today: "2026-07-15",
+      phase: "Cut",
+    });
+    expect(result.hasWarnings).toBe(true);
+  });
+
+  it("余裕のある計画 → hasWarnings: false", () => {
+    // 6ヶ月, 月間変化 ≈ -0.33 kg → 警告なし
+    const result = calcMonthlyGoalProgress({
+      contestDate: "2026-12-31",
+      targetWeight: 73.0,
+      monthlyPlanOverrides: null,
+      comparisonWeight: 75.0,
+      today: "2026-07-15",
+      phase: "Cut",
+    });
+    expect(result.hasWarnings).toBe(false);
+  });
+});
+
+// ─── calcMonthlyGoalProgress — 多月プランで今月エントリーが取れる ─────────────
+
+describe("calcMonthlyGoalProgress — 多月プラン", () => {
+  it("今月エントリーが正しく取得されて hasData: true", () => {
+    // 5ヶ月 (Jul〜Nov): Jul エントリーの targetWeight は finalGoalWeight に向けた補間値
+    const result = calcMonthlyGoalProgress({
+      contestDate: "2026-11-30",
+      targetWeight: 70.0,
+      monthlyPlanOverrides: null,
+      comparisonWeight: 75.0,
+      today: "2026-07-15",
+      phase: "Cut",
+    });
+    expect(result.hasData).toBe(true);
+    // 今月目標は現在体重 (75.0) と最終目標 (70.0) の間のどこか
+    expect(result.monthlyTargetWeight).not.toBeNull();
+    expect(result.monthlyTargetWeight!).toBeGreaterThan(70.0);
+    expect(result.monthlyTargetWeight!).toBeLessThanOrEqual(75.0);
+  });
+});

--- a/src/lib/utils/calcMonthlyGoalProgress.ts
+++ b/src/lib/utils/calcMonthlyGoalProgress.ts
@@ -1,0 +1,244 @@
+/**
+ * calcMonthlyGoalProgress.ts
+ *
+ * Dashboard / GoalNavigator の「今月目標進捗」表示用 selector。
+ *
+ * #101 の buildMonthlyGoalPlan を使って今月のエントリーを取得し、
+ * 現在値との差・月末までの残必要ペース・状態判定を計算する純粋関数群。
+ *
+ * UI 側で月次ロジックを再実装しないための canonical interface として設計する。
+ */
+
+import {
+  buildMonthlyGoalPlan,
+  MAX_SAFE_MONTHLY_DELTA_KG,
+} from "@/lib/utils/monthlyGoalPlan";
+import type { MonthlyGoalOverride } from "@/lib/utils/monthlyGoalPlan";
+import { calcDaysLeft } from "@/lib/utils/date";
+
+// ─── 閾値定数 ─────────────────────────────────────────────────────────────────
+
+/**
+ * 月末残必要ペース (kg/週) の "on_track" 判定閾値。
+ * 絶対値がこれ以下なら計画内と判定する。
+ * 0.5 kg/週 ≈ 月間 2 kg 上限の週次換算の半分。
+ */
+export const MONTHLY_ON_TRACK_PACE_KG_WEEK = 0.5;
+
+/**
+ * 月末残必要ペース (kg/週) の "replan_recommended" 閾値。
+ * 絶対値がこれを超えると再計画推奨と判定する。
+ * MAX_SAFE_MONTHLY_DELTA_KG / 2 = 1.0 kg/週 (月間 2 kg / 2 週換算)。
+ */
+export const MONTHLY_REPLAN_PACE_KG_WEEK: number = MAX_SAFE_MONTHLY_DELTA_KG / 2;
+
+// ─── 型定義 ──────────────────────────────────────────────────────────────────
+
+/**
+ * 今月目標に対する進捗状態。
+ *
+ * - achieved          : 現在値が今月目標を達成済み (±0.2 kg 許容)
+ * - on_track          : 計画内 (残ペース絶対値 ≤ 0.5 kg/週)
+ * - slightly_behind   : やや遅れ (残ペース絶対値 0.5〜1.0 kg/週)
+ * - replan_recommended: 再計画推奨 (残ペース絶対値 > 1.0 kg/週 or 残り時間なし)
+ * - unavailable       : データ不足でプランを構築できない
+ */
+export type MonthlyProgressState =
+  | "achieved"
+  | "on_track"
+  | "slightly_behind"
+  | "replan_recommended"
+  | "unavailable";
+
+/** 今月目標進捗の計算結果 */
+export interface MonthlyGoalProgress {
+  /** true = プランを構築でき、各フィールドが有効 */
+  hasData: boolean;
+  /** 今月末の目標体重 (kg) */
+  monthlyTargetWeight: number | null;
+  /**
+   * 比較値 (kg)。7日平均 優先、なければ最新体重。
+   * GoalNavigator の refWeight と同一の値を渡すこと。
+   */
+  comparisonWeight: number | null;
+  /**
+   * 差分 (kg) = comparisonWeight − monthlyTargetWeight。
+   * Cut: 正 = 遅れ (目標より重い)、負 = 先行 (目標を下回っている)
+   * Bulk: 負 = 遅れ (目標より軽い)、正 = 先行 (目標を上回っている)
+   */
+  deltaKg: number | null;
+  /** 今日から月末までの残り日数 (今日が月末なら 0) */
+  daysToMonthEnd: number | null;
+  /** 月末までの残り週数 (小数)。0 以下の場合は null */
+  weeksToMonthEnd: number | null;
+  /**
+   * 月末までに必要な週あたりペース (kg/週)。
+   * Cut: 負値が目標方向、Bulk: 正値が目標方向。
+   * null = 残り時間 0 または計算不能。
+   */
+  requiredPaceKgPerWeek: number | null;
+  /** 状態判定 */
+  state: MonthlyProgressState;
+  /** 今月の計画に warning が 1 件以上あるか */
+  hasWarnings: boolean;
+}
+
+// ─── プライベートヘルパー ─────────────────────────────────────────────────────
+
+/** year, month (1-indexed) の月の日数を返す */
+function daysInMonth(year: number, month: number): number {
+  if (month === 2) {
+    return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0) ? 29 : 28;
+  }
+  return [4, 6, 9, 11].includes(month) ? 30 : 31;
+}
+
+/**
+ * today (YYYY-MM-DD) の月末日を "YYYY-MM-DD" で返す。
+ * today の形式が不正な場合は null を返す。
+ */
+export function getMonthEndDate(today: string): string | null {
+  const matched = today.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!matched) return null;
+  const year = parseInt(matched[1]!, 10);
+  const month = parseInt(matched[2]!, 10);
+  if (month < 1 || month > 12) return null;
+  const lastDay = daysInMonth(year, month);
+  return `${matched[1]}-${matched[2]}-${String(lastDay).padStart(2, "0")}`;
+}
+
+/**
+ * today から月末までの残り日数を返す。
+ * 今日が月末の場合は 0。不正な日付なら null。
+ */
+export function calcDaysToMonthEnd(today: string): number | null {
+  const monthEnd = getMonthEndDate(today);
+  if (!monthEnd) return null;
+  return calcDaysLeft(today, monthEnd);
+}
+
+/**
+ * 今月目標に対する状態を判定する。
+ *
+ * @param deltaKg - comparisonWeight − monthlyTargetWeight
+ * @param requiredPaceKgPerWeek - 残必要ペース。null = 残り時間なし
+ * @param isCut - Cut フェーズかどうか
+ */
+function calcMonthlyProgressState(
+  deltaKg: number,
+  requiredPaceKgPerWeek: number | null,
+  isCut: boolean
+): MonthlyProgressState {
+  // 達成済み判定: Cut では delta ≤ +0.2 (目標以下 or 誤差範囲内)、Bulk では delta ≥ -0.2
+  const GOAL_TOLERANCE = 0.2;
+  const isAchieved = isCut ? deltaKg <= GOAL_TOLERANCE : deltaKg >= -GOAL_TOLERANCE;
+  if (isAchieved) return "achieved";
+
+  // 残り時間なし (月末当日など)
+  if (requiredPaceKgPerWeek === null) return "replan_recommended";
+
+  const absPace = Math.abs(requiredPaceKgPerWeek);
+  if (absPace <= MONTHLY_ON_TRACK_PACE_KG_WEEK) return "on_track";
+  if (absPace <= MONTHLY_REPLAN_PACE_KG_WEEK) return "slightly_behind";
+  return "replan_recommended";
+}
+
+// ─── メイン計算関数 ──────────────────────────────────────────────────────────
+
+/**
+ * 今月目標に対する進捗を計算する。
+ *
+ * - #101 の buildMonthlyGoalPlan を使って月次プランを構築し、今月エントリーを取得する
+ * - comparisonWeight には GoalNavigator の refWeight (7日平均優先) と同じ値を渡すこと
+ * - 計画が構築できない場合は hasData: false の fallback を返す (クラッシュしない)
+ *
+ * @param input.contestDate        - 大会・目標期限 (settings.contestDate)
+ * @param input.targetWeight       - 最終目標体重 (settings.targetWeight)
+ * @param input.monthlyPlanOverrides - 月次 override リスト (settings.monthlyPlanOverrides)
+ * @param input.comparisonWeight   - 比較値 (weight_7d_avg ?? current_weight)
+ * @param input.today              - 今日の JST 日付 (toJstDateStr() の値)
+ * @param input.phase              - "Cut" | "Bulk"
+ */
+export function calcMonthlyGoalProgress(input: {
+  contestDate: string | null;
+  targetWeight: number | null;
+  monthlyPlanOverrides: MonthlyGoalOverride[] | null;
+  comparisonWeight: number | null;
+  today: string;
+  phase: string;
+}): MonthlyGoalProgress {
+  const { contestDate, targetWeight, monthlyPlanOverrides, comparisonWeight, today, phase } = input;
+
+  const unavailable: MonthlyGoalProgress = {
+    hasData: false,
+    monthlyTargetWeight: null,
+    comparisonWeight,
+    deltaKg: null,
+    daysToMonthEnd: null,
+    weeksToMonthEnd: null,
+    requiredPaceKgPerWeek: null,
+    state: "unavailable",
+    hasWarnings: false,
+  };
+
+  // 前提条件チェック (いずれか欠損 → 計算不能)
+  if (!contestDate || targetWeight === null || comparisonWeight === null) {
+    return unavailable;
+  }
+
+  // buildMonthlyGoalPlan は currentWeight を起点として使う。
+  // GoalNavigator と同じ refWeight (7日平均優先) を渡すことでプランの起点を統一する。
+  const plan = buildMonthlyGoalPlan({
+    currentWeight: comparisonWeight,
+    today,
+    finalGoalWeight: targetWeight,
+    goalDeadlineDate: contestDate,
+    monthlyActuals: [],
+    overrides: monthlyPlanOverrides ?? [],
+  });
+
+  // プランが無効 (DEADLINE_IN_PAST 等) → fallback
+  if (!plan.isValid || plan.entries.length === 0) {
+    return unavailable;
+  }
+
+  // 今月のエントリーを取得 (プランは todayMonth から始まるため必ず entries[0])
+  const todayMonth = today.slice(0, 7);
+  const currentEntry = plan.entries.find((e) => e.month === todayMonth);
+  if (!currentEntry) {
+    return unavailable;
+  }
+
+  const monthlyTargetWeight = currentEntry.targetWeight;
+
+  // 差分 (FP 安全化: 0.01 kg 単位で丸める)
+  const deltaKg = Math.round((comparisonWeight - monthlyTargetWeight) * 100) / 100;
+
+  // 月末までの残り日数・週数
+  const daysToMonthEnd = calcDaysToMonthEnd(today);
+  const weeksToMonthEnd =
+    daysToMonthEnd !== null && daysToMonthEnd > 0 ? daysToMonthEnd / 7 : null;
+
+  // 残必要ペース (kg/週)
+  // Cut: deltaKg > 0 → -deltaKg/weeks < 0 (減量方向 = 正しい方向)
+  // Bulk: deltaKg < 0 → -deltaKg/weeks > 0 (増量方向 = 正しい方向)
+  const requiredPaceKgPerWeek =
+    weeksToMonthEnd !== null
+      ? Math.round((-deltaKg / weeksToMonthEnd) * 100) / 100
+      : null;
+
+  const isCut = phase !== "Bulk";
+  const state = calcMonthlyProgressState(deltaKg, requiredPaceKgPerWeek, isCut);
+
+  return {
+    hasData: true,
+    monthlyTargetWeight,
+    comparisonWeight,
+    deltaKg,
+    daysToMonthEnd,
+    weeksToMonthEnd,
+    requiredPaceKgPerWeek,
+    state,
+    hasWarnings: plan.warnings.length > 0,
+  };
+}


### PR DESCRIPTION
## Summary

- **`calcMonthlyGoalProgress.ts`** — 純粋関数。`buildMonthlyGoalPlan` (#101 canonical logic) を使って今月末目標・差分・残必要ペース・状態を計算
- **`GoalNavigator.tsx`** — 3列レイアウト下部に「今月目標進捗」セクションを追加（状態バッジ・今月末目標・差分・残必要ペース・警告有無）
- **`page.tsx`** — `calcMonthlyGoalProgress` を呼び出し、GoalNavigator へ渡す

### 状態判定閾値
| 状態 | 条件 |
|------|------|
| `achieved` | 達成済み (Cut: deltaKg ≤ +0.2 / Bulk: deltaKg ≥ -0.2) |
| `on_track` | 残必要ペース \|x\| ≤ 0.5 kg/週 |
| `slightly_behind` | 残必要ペース 0.5 < \|x\| ≤ 1.0 kg/週 |
| `replan_recommended` | 残必要ペース > 1.0 kg/週 または月末当日未達 |
| `unavailable` | contestDate / targetWeight / comparisonWeight 欠損 または計画無効 |

## Test plan

- [x] `calcMonthlyGoalProgress.test.ts` — 40件 (定数・ヘルパー関数・unavailable前提条件・各状態Cut/Bulk・月末当日・hasWarnings・多月プラン)
- [x] `node_modules/.bin/jest --no-coverage` — 747件全通過
- [x] `npx tsc --noEmit` — 型エラーなし
- [x] `next build` — ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)