### PR TITLE
feat: remove legacy monthly_target setting (#132)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ react-day-picker v9 ベースの月間カレンダー。当月をデフォルト
 
 ForecastChart（`src/components/charts/ForecastChart.tsx`）は 3 タブ（7日 / 31日 / 全体）で切替表示する。
 
-- **月次目標体重ライン**: 3 タブすべてに表示。`monthlyTarget` を ReferenceLine として描画
+- **月次目標ステップライン**: plan entries がある場合のみ表示。`buildMonthlyGoalPlan` の entries を `stepAfter` 折れ線で描画（月内フラット・月境界で段差）
 - **縦軸ラベル**: 整数表示（`Math.floor`）に統一
   - 7日タブ: 1 kg 刻み
   - 31日タブ: 2 kg 刻み

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -113,7 +113,6 @@ export default async function DashboardPage() {
     .at(-1)?.tdee_estimated ?? null;
 
   const goalWeight = settings.targetWeight ?? undefined;
-  const monthlyTarget = settings.monthlyTarget ?? undefined;
   const contestDate = settings.contestDate ?? undefined;
   const currentSeason = settings.currentSeason;
 
@@ -225,7 +224,6 @@ export default async function DashboardPage() {
               predictions={predictions}
               sma7={sma7}
               goalWeight={goalWeight}
-              monthlyTarget={monthlyTarget}
               contestDate={contestDate}
               monthlyGoalEntries={
                 monthlyGoalPlan?.isValid && monthlyGoalPlan.entries.length > 0

--- a/src/components/charts/ForecastChart.tsx
+++ b/src/components/charts/ForecastChart.tsx
@@ -23,7 +23,6 @@ interface ForecastChartProps {
   predictions: Prediction[];
   sma7: Array<{ date: string; value: number }>;
   goalWeight?: number;
-  monthlyTarget?: number;
   contestDate?: string;
   /** #101 の plan entries。渡すと月次目標ステップラインを描画し monthlyTarget は非表示になる */
   monthlyGoalEntries?: MonthlyGoalEntry[];
@@ -50,7 +49,6 @@ export function ForecastChart({
   predictions,
   sma7,
   goalWeight,
-  monthlyTarget,
   contestDate,
   monthlyGoalEntries,
 }: ForecastChartProps) {
@@ -121,8 +119,6 @@ export function ForecastChart({
     ...visibleForecast,
     ...visibleMonthlyGoalTargets,
     ...(goalWeight && rangeTab === "default" ? [goalWeight] : []),
-    // plan entries がない場合のフォールバック: monthlyTarget 単値
-    ...(!monthlyGoalDateMap.size && monthlyTarget && monthlyTarget > 0 ? [monthlyTarget] : []),
   ];
 
   // タブごとのパディング（7日は±1.5kg、31日は±2.5kg、全体は広め）
@@ -217,15 +213,6 @@ export function ForecastChart({
               stroke="#ef4444"
               strokeDasharray="4 2"
               label={{ value: "Goal", fontSize: 10, fill: "#ef4444" }}
-            />
-          )}
-          {/* monthlyTarget 参照線: plan entries がない場合のフォールバック */}
-          {!monthlyGoalDateMap.size && monthlyTarget && monthlyTarget > 0 && (
-            <ReferenceLine
-              y={monthlyTarget}
-              stroke="#f97316"
-              strokeDasharray="6 3"
-              label={{ value: "Monthly", fontSize: 10, fill: "#f97316" }}
             />
           )}
           <ReferenceLine

--- a/src/components/settings/SettingsForm.tsx
+++ b/src/components/settings/SettingsForm.tsx
@@ -29,7 +29,6 @@ const FIELDS: Record<string, FieldMeta> = {
   current_phase:     { label: "現在のフェーズ", type: "select", options: ["Cut", "Bulk"] },
   sex:               { label: "性別", type: "select", options: ["male", "female"], optionLabels: ["男性", "女性"] },
   goal_weight:       { label: "目標体重", unit: "kg", type: "number", placeholder: "58.5" },
-  monthly_target:    { label: "月次目標体重", unit: "kg", type: "number", placeholder: "62.0" },
   contest_date:      { label: "コンテスト日", type: "date" },
   activity_factor:   { label: "活動係数", unit: "1.2〜1.9", type: "number", placeholder: "1.55" },
   height_cm:         { label: "身長", unit: "cm", type: "number", placeholder: "170" },
@@ -116,7 +115,6 @@ export function SettingsForm({ initialSettings, currentWeight = null }: Settings
 
     const result = await saveSettings({
       goal_weight:             values["goal_weight"] ?? "",
-      monthly_target:          values["monthly_target"] ?? "",
       activity_factor:         values["activity_factor"] ?? "",
       height_cm:               values["height_cm"] ?? "",
       age:                     values["age"] ?? "",

--- a/src/lib/domain/settings.test.ts
+++ b/src/lib/domain/settings.test.ts
@@ -9,7 +9,6 @@ const fullRows = [
   { key: "current_phase",       value_num: null,   value_str: "Cut" },
   { key: "sex",                 value_num: null,   value_str: "male" },
   { key: "goal_weight",         value_num: 70.5,   value_str: null },
-  { key: "monthly_target",      value_num: 72.0,   value_str: null },
   { key: "target_calories_kcal",value_num: 2200,   value_str: null },
   { key: "target_protein_g",    value_num: 160,    value_str: null },
   { key: "target_fat_g",        value_num: 60,     value_str: null },
@@ -34,7 +33,6 @@ describe("mapToAppSettings — 正常系", () => {
     expect(result.currentPhase).toBe("Cut");
     expect(result.gender).toBe("male");
     expect(result.targetWeight).toBe(70.5);
-    expect(result.monthlyTarget).toBe(72.0);
     expect(result.goalCalories).toBe(2200);
     expect(result.proteinTarget).toBe(160);
     expect(result.fatTarget).toBe(60);
@@ -74,7 +72,6 @@ describe("mapToAppSettings — 欠損系", () => {
     expect(result.currentSeason).toBeNull();
     expect(result.currentPhase).toBeNull();
     expect(result.gender).toBeNull();
-    expect(result.monthlyTarget).toBeNull();
     expect(result.goalCalories).toBeNull();
     expect(result.proteinTarget).toBeNull();
     expect(result.fatTarget).toBeNull();

--- a/src/lib/domain/settings.ts
+++ b/src/lib/domain/settings.ts
@@ -26,8 +26,6 @@ export interface AppSettings {
   // 数値系 (value_num)
   /** 目標体重 (kg) */
   targetWeight: number | null;
-  /** 月次目標体重 (kg) */
-  monthlyTarget: number | null;
   /** 目標カロリー (kcal/day) — settingsSchema: target_calories_kcal */
   goalCalories: number | null;
   /** 目標タンパク質 (g/day) */
@@ -89,7 +87,6 @@ export function mapToAppSettings(rows: SettingsRow[]): AppSettings {
 
     // 数値系 — value_num を参照
     targetWeight:   getNum("goal_weight"),
-    monthlyTarget:  getNum("monthly_target"),
     goalCalories:   getNum("target_calories_kcal"),
     proteinTarget:  getNum("target_protein_g"),
     fatTarget:      getNum("target_fat_g"),

--- a/src/lib/schemas/settingsSchema.test.ts
+++ b/src/lib/schemas/settingsSchema.test.ts
@@ -221,8 +221,8 @@ describe("parseSettings — DB レコード構造", () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     const keys = result.records.map((r) => r.key);
-    // 数値系 9 キー + 文字列系 5 キー (monthly_plan_overrides 追加) = 14 キー
-    expect(keys).toHaveLength(14);
+    // 数値系 8 キー + 文字列系 5 キー = 13 キー
+    expect(keys).toHaveLength(13);
     expect(keys).toContain("goal_weight");
     expect(keys).toContain("contest_date");
     expect(keys).toContain("current_phase");

--- a/src/lib/schemas/settingsSchema.ts
+++ b/src/lib/schemas/settingsSchema.ts
@@ -11,7 +11,6 @@
 /** value_num に保存する数値系キー */
 export const NUMERIC_SETTING_KEYS = [
   "goal_weight",
-  "monthly_target",
   "activity_factor",
   "height_cm",
   "age",
@@ -47,7 +46,6 @@ export type SettingKey = NumericSettingKey | StringSettingKey;
 export interface SettingsInput {
   // 数値系 (文字列として渡し、schema 側で number に変換する)
   goal_weight?: string | null;
-  monthly_target?: string | null;
   activity_factor?: string | null;
   height_cm?: string | null;
   age?: string | null;
@@ -95,7 +93,6 @@ interface NumericRule {
 
 const NUMERIC_RULES: Record<NumericSettingKey, NumericRule> = {
   goal_weight:          { min: 20,  max: 200,  label: "目標体重" },
-  monthly_target:       { min: 20,  max: 200,  label: "月次目標体重" },
   activity_factor:      { min: 1.2, max: 2.5,  label: "活動係数" },
   height_cm:            { min: 100, max: 250,  label: "身長" },
   age:                  { min: 1,   max: 120,  label: "年齢" },


### PR DESCRIPTION
## Summary

- `monthly_target` を Settings UI / save payload / settingsSchema / AppSettings mapper からすべて削除
- `ForecastChart` の `monthlyTarget` prop とフォールバック `ReferenceLine` を削除
- `NUMERIC_SETTING_KEYS` 9 → 8、`parseSettings` 生成キー数 14 → 13
- テスト・README を対応して更新

## Scope

削除対象 (レガシー):
- `settings` テーブルの `monthly_target` キー（アプリレベル廃止。DB 物理削除は別途）
- `AppSettings.monthlyTarget`
- `ForecastChart.monthlyTarget` prop / fallback ReferenceLine

保持対象 (正規 #101〜#104 系):
- `calcMonthlyGoalProgress.ts` の `monthlyTargetWeight`（プラン由来）
- `monthlyGoalPlan.ts` の `MonthlyTargetSource`（内部型）

## Test plan

- [x] `node_modules/.bin/jest --no-coverage` — 784 tests passed
- [x] `npx tsc --noEmit` — エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)