### PR TITLE
chore: clean up legacy monthly_target at DB level (#134)

### DIFF
--- a/supabase/migrations/20260101000003_create_settings.sql
+++ b/supabase/migrations/20260101000003_create_settings.sql
@@ -4,11 +4,14 @@
 -- 数値は value_num、文字列は value_str に格納する。
 --
 -- 代表的な key 一覧（参考）:
---   target_weight   : 目標体重 (kg) — value_num
---   contest_date    : 大会日 (YYYY-MM-DD) — value_str
---   monthly_target  : 月次目標体重変化 (kg) — value_num
---   current_phase   : 現在フェーズ ("Cut" | "Maintain" | "Bulk") — value_str
---   current_season  : 現在シーズン名 — value_str
+--   goal_weight           : 目標体重 (kg) — value_num
+--   contest_date          : 大会日 (YYYY-MM-DD) — value_str
+--   monthly_plan_overrides: 月次目標 override リスト (JSON) — value_str  ← #101
+--   current_phase         : 現在フェーズ ("Cut" | "Bulk") — value_str
+--   current_season        : 現在シーズン名 — value_str
+--
+-- 廃止済み key:
+--   monthly_target : アプリ廃止 (#132)。DB 上の残存行は #134 migration で削除済み。
 
 CREATE TABLE IF NOT EXISTS settings (
   key       TEXT    PRIMARY KEY,

--- a/supabase/migrations/20260321000000_cleanup_legacy_monthly_target_setting.sql
+++ b/supabase/migrations/20260321000000_cleanup_legacy_monthly_target_setting.sql
@@ -1,0 +1,11 @@
+-- #134: legacy settings key 'monthly_target' の DB レベル整理
+--
+-- #132 でアプリケーション上の monthly_target 参照（UI / schema / domain / chart）は削除済み。
+-- 本 migration では、過去に保存された可能性のある DB 上の残存行を削除する。
+--
+-- 影響:
+--   - settings テーブルの key = 'monthly_target' の行を削除する（存在しなければ no-op）
+--   - アプリはすでにこのキーを読み書きしないため、動作に変化はない
+--   - 月次目標は buildMonthlyGoalPlan (#101) + monthly_plan_overrides (value_str) で管理する
+
+DELETE FROM settings WHERE key = 'monthly_target';


### PR DESCRIPTION
## 概要

#132 でアプリケーションレベルから廃止した `monthly_target` を、DB / migration / コメントレベルでも整理する。

## 残存箇所一覧

| 場所 | 内容 | 対応 |
|---|---|---|
| `supabase/migrations/20260101000003_create_settings.sql` | コメント欄に `monthly_target` を例示 | コメントを更新 |
| `settings` テーブル（本番 DB） | `key = 'monthly_target'` の行が過去に保存されている可能性 | migration で DELETE |
| `復活実装計画.md` | 歴史的な計画メモに記載 | 変更なし（歴史的ドキュメント） |

## 整理内容

1. **migration 追加**: `20260321000000_cleanup_legacy_monthly_target_setting.sql`
   - `DELETE FROM settings WHERE key = 'monthly_target'`
   - 行が存在しなければ no-op（冪等）
2. **create_settings.sql のコメント更新**:
   - 例示キー一覧から `monthly_target` を削除
   - `monthly_plan_overrides`（#101 で追加）を追記
   - 廃止済みキーとして注記を追加

## 今回残した箇所

- `復活実装計画.md` — 歴史的な設計ドキュメントのため変更なし

## migration 有無

あり。本番 DB に適用済み（`supabase db push` 完了）。

## 既存データへの影響

- `monthly_target` 行が存在した場合は削除される
- アプリはすでに (#132 以降) このキーを読み書きしないため、動作変化なし
- 月次目標は `buildMonthlyGoalPlan` + `monthly_plan_overrides` で管理

## テスト / 動作確認

- `node_modules/.bin/jest --no-coverage` — 784 tests passed
- `npx tsc --noEmit` — エラーなし
- `supabase db push` — migration 適用成功

Closes #134
🤖 Generated with [Claude Code](https://claude.com/claude-code)