### PR TITLE
feat: support future-month manual overrides in monthly goal plan (#135)

### DIFF
--- a/src/components/settings/MonthlyGoalPlanSection.integration.test.tsx
+++ b/src/components/settings/MonthlyGoalPlanSection.integration.test.tsx
@@ -3,14 +3,16 @@
  *
  * テスト戦略:
  * - today を固定値 "2026-03-20" でプロップとして渡す (toJstDateStr() のモック不要)
- * - buildMonthlyGoalPlan / redistributeMonthlyGoals は実装ごとテストする
+ * - buildMonthlyGoalPlan は実装ごとテストする
  * - lucide-react アイコンはシンプルな span に差し替える
  *
  * 検証内容:
  * 1. 前提条件未設定時にエラーメッセージが表示される
  * 2. 有効な設定時に月別テーブルが表示される
  * 3. 月を編集してコミットすると onOverridesChange が呼ばれる
- * 4. 警告メッセージが表示される
+ * 4. 複数月 override が両方保持される (anchor が保たれる)
+ * 5. 手動月の「解除」ボタンで override が削除される
+ * 6. 警告メッセージが表示される
  */
 
 // @jest-environment jest-environment-jsdom
@@ -171,9 +173,9 @@ describe("MonthlyGoalPlanSection — 月別テーブル表示", () => {
   });
 });
 
-// ─── シナリオ 3: インライン編集と再配分 ────────────────────────────────────
+// ─── シナリオ 3: インライン編集 ─────────────────────────────────────────────
 
-describe("MonthlyGoalPlanSection — インライン編集と再配分", () => {
+describe("MonthlyGoalPlanSection — インライン編集", () => {
   it("月を編集して blur すると onOverridesChange が呼ばれる", async () => {
     const onOverridesChange = jest.fn();
 
@@ -263,9 +265,195 @@ describe("MonthlyGoalPlanSection — インライン編集と再配分", () => {
       expect(parseFloat(apr.value)).toBeCloseTo(72.0, 1);
     });
   });
+
+  it("将来月 (2026-05) も編集可能で onOverridesChange が呼ばれる", async () => {
+    const onOverridesChange = jest.fn();
+
+    render(
+      <ControlledSection
+        goalWeight={70}
+        contestDate="2026-06-30"
+        currentWeight={75}
+        onOverridesChange={onOverridesChange}
+      />
+    );
+
+    const input = screen.getByRole("spinbutton", { name: "2026年5月 目標体重" });
+    fireEvent.change(input, { target: { value: "71" } });
+    fireEvent.blur(input);
+
+    await waitFor(() => {
+      expect(onOverridesChange).toHaveBeenCalledTimes(1);
+    });
+
+    const called = onOverridesChange.mock.calls[0][0] as MonthlyGoalOverride[];
+    expect(called.some((o) => o.month === "2026-05" && o.targetWeight === 71)).toBe(true);
+  });
 });
 
-// ─── シナリオ 4: 警告表示 ───────────────────────────────────────────────────
+// ─── シナリオ 4: 複数月 override (anchor 保持) ───────────────────────────────
+
+describe("MonthlyGoalPlanSection — 複数月 override", () => {
+  it("2ヶ月に manual を設定しても両方の override が保持される", async () => {
+    const onOverridesChange = jest.fn();
+
+    render(
+      <ControlledSection
+        goalWeight={70}
+        contestDate="2026-06-30"
+        currentWeight={75}
+        onOverridesChange={onOverridesChange}
+      />
+    );
+
+    // 1回目: 2026-03 を 73 kg に設定
+    const mar = screen.getByRole("spinbutton", { name: "2026年3月 目標体重" });
+    fireEvent.change(mar, { target: { value: "73" } });
+    fireEvent.blur(mar);
+
+    await waitFor(() => expect(onOverridesChange).toHaveBeenCalledTimes(1));
+
+    // 2回目: 2026-05 を 71 kg に設定
+    const may = screen.getByRole("spinbutton", { name: "2026年5月 目標体重" });
+    fireEvent.change(may, { target: { value: "71" } });
+    fireEvent.blur(may);
+
+    await waitFor(() => expect(onOverridesChange).toHaveBeenCalledTimes(2));
+
+    // 最後の呼び出しで両方の override が含まれている
+    const lastCall = onOverridesChange.mock.calls[1][0] as MonthlyGoalOverride[];
+    expect(lastCall.some((o) => o.month === "2026-03" && o.targetWeight === 73)).toBe(true);
+    expect(lastCall.some((o) => o.month === "2026-05" && o.targetWeight === 71)).toBe(true);
+  });
+
+  it("ある月を再編集しても他の月の override は保持される", async () => {
+    const onOverridesChange = jest.fn();
+
+    render(
+      <ControlledSection
+        goalWeight={70}
+        contestDate="2026-06-30"
+        currentWeight={75}
+        // 2026-03 を 73, 2026-05 を 71 で初期化
+        initialOverrides={[
+          { month: "2026-03", targetWeight: 73 },
+          { month: "2026-05", targetWeight: 71 },
+        ]}
+        onOverridesChange={onOverridesChange}
+      />
+    );
+
+    // 2026-03 を 72 に変更
+    const mar = screen.getByRole("spinbutton", { name: "2026年3月 目標体重" });
+    fireEvent.change(mar, { target: { value: "72" } });
+    fireEvent.blur(mar);
+
+    await waitFor(() => expect(onOverridesChange).toHaveBeenCalledTimes(1));
+
+    const called = onOverridesChange.mock.calls[0][0] as MonthlyGoalOverride[];
+    // 2026-03 が更新されている
+    expect(called.some((o) => o.month === "2026-03" && o.targetWeight === 72)).toBe(true);
+    // 2026-05 は変わっていない
+    expect(called.some((o) => o.month === "2026-05" && o.targetWeight === 71)).toBe(true);
+  });
+
+  it("複数 override がある場合、手動月に「手動」バッジが複数表示される", async () => {
+    render(
+      <ControlledSection
+        goalWeight={70}
+        contestDate="2026-06-30"
+        currentWeight={75}
+        initialOverrides={[
+          { month: "2026-03", targetWeight: 73 },
+          { month: "2026-05", targetWeight: 71 },
+        ]}
+      />
+    );
+
+    const manualBadges = screen.getAllByText("手動");
+    expect(manualBadges).toHaveLength(2);
+  });
+});
+
+// ─── シナリオ 5: override 解除 ──────────────────────────────────────────────
+
+describe("MonthlyGoalPlanSection — override 解除", () => {
+  it("「解除」ボタンを押すと onOverridesChange が呼ばれ override が削除される", async () => {
+    const onOverridesChange = jest.fn();
+
+    render(
+      <ControlledSection
+        goalWeight={70}
+        contestDate="2026-06-30"
+        currentWeight={75}
+        initialOverrides={[{ month: "2026-03", targetWeight: 73 }]}
+        onOverridesChange={onOverridesChange}
+      />
+    );
+
+    // 「手動」バッジの下の「解除」ボタンを押す
+    const resetBtn = screen.getByRole("button", { name: "2026年3月 手動設定を解除" });
+    fireEvent.click(resetBtn);
+
+    await waitFor(() => expect(onOverridesChange).toHaveBeenCalledTimes(1));
+
+    const called = onOverridesChange.mock.calls[0][0] as MonthlyGoalOverride[];
+    // override が空になる
+    expect(called).toHaveLength(0);
+  });
+
+  it("解除後は「手動」バッジが消え「自動」バッジに戻る", async () => {
+    render(
+      <ControlledSection
+        goalWeight={70}
+        contestDate="2026-06-30"
+        currentWeight={75}
+        initialOverrides={[{ month: "2026-03", targetWeight: 73 }]}
+      />
+    );
+
+    // 解除前: 「手動」バッジが存在する
+    expect(screen.getByText("手動")).toBeInTheDocument();
+
+    const resetBtn = screen.getByRole("button", { name: "2026年3月 手動設定を解除" });
+    fireEvent.click(resetBtn);
+
+    // 解除後: 「手動」バッジが消え、3月が「自動」に戻る
+    await waitFor(() => {
+      expect(screen.queryByText("手動")).not.toBeInTheDocument();
+    });
+  });
+
+  it("一方の override を解除しても他方の override は残る", async () => {
+    const onOverridesChange = jest.fn();
+
+    render(
+      <ControlledSection
+        goalWeight={70}
+        contestDate="2026-06-30"
+        currentWeight={75}
+        initialOverrides={[
+          { month: "2026-03", targetWeight: 73 },
+          { month: "2026-05", targetWeight: 71 },
+        ]}
+        onOverridesChange={onOverridesChange}
+      />
+    );
+
+    // 2026-03 のみ解除
+    const resetBtn = screen.getByRole("button", { name: "2026年3月 手動設定を解除" });
+    fireEvent.click(resetBtn);
+
+    await waitFor(() => expect(onOverridesChange).toHaveBeenCalledTimes(1));
+
+    const called = onOverridesChange.mock.calls[0][0] as MonthlyGoalOverride[];
+    // 2026-05 は残っている
+    expect(called).toHaveLength(1);
+    expect(called[0]).toMatchObject({ month: "2026-05", targetWeight: 71 });
+  });
+});
+
+// ─── シナリオ 6: 警告表示 ───────────────────────────────────────────────────
 
 describe("MonthlyGoalPlanSection — 警告表示", () => {
   it("DEADLINE_TOO_CLOSE 警告が表示される (今月のみの期間)", () => {

--- a/src/components/settings/MonthlyGoalPlanSection.tsx
+++ b/src/components/settings/MonthlyGoalPlanSection.tsx
@@ -6,8 +6,11 @@
  * Settings 画面に埋め込む月次目標体重計画の表示・編集セクション。
  *
  * - buildMonthlyGoalPlan (#101 ロジック) でプランを表示
- * - 各月 (最終月以外) の目標体重をインライン編集可
- * - 編集時に redistributeMonthlyGoals で翌月以降をリアルタイム再配分
+ * - 当月・将来月 (最終月以外) の目標体重をインライン編集可
+ * - 編集時は override 配列を upsert し、buildMonthlyGoalPlan で全体を再構築する
+ *   (UI 側で再配分ロジックを持たない。redistributeMonthlyGoals は使用しない)
+ * - 複数月 override (anchor) を同時に持てる
+ * - 手動月に「解除」ボタンを表示し、解除するとその月が auto に戻る
  * - 警告・エラーを表示
  *
  * 今日の日付は today プロップから受け取る (テスト容易性のため)。
@@ -15,13 +18,9 @@
 
 import { useState, useMemo, useEffect } from "react";
 import { AlertTriangle, Info } from "lucide-react";
-import {
-  buildMonthlyGoalPlan,
-  redistributeMonthlyGoals,
-} from "@/lib/utils/monthlyGoalPlan";
+import { buildMonthlyGoalPlan } from "@/lib/utils/monthlyGoalPlan";
 import type {
   MonthlyGoalOverride,
-  MonthlyGoalEntry,
   MonthlyGoalErrorCode,
   MonthlyGoalWarningCode,
   MonthlyGoalWarning,
@@ -79,6 +78,19 @@ function fmtMonth(ym: string): string {
 function fmtDelta(kg: number): string {
   if (kg > 0) return `+${kg.toFixed(1)}`;
   return kg.toFixed(1);
+}
+
+/**
+ * overrides 配列に override を upsert する (同月があれば更新、なければ追加)。
+ * 既存の他月の override はすべて保持する。
+ */
+function upsertOverride(
+  overrides: MonthlyGoalOverride[],
+  override: MonthlyGoalOverride
+): MonthlyGoalOverride[] {
+  const idx = overrides.findIndex((o) => o.month === override.month);
+  if (idx === -1) return [...overrides, override];
+  return overrides.map((o, i) => (i === idx ? override : o));
 }
 
 // ─── スタイル定数 ─────────────────────────────────────────────────────────────
@@ -172,6 +184,7 @@ function PlanContent({
   onOverridesChange,
 }: PlanContentProps) {
   // プランを overrides + 他パラメータから算出
+  // override 配列が source of truth。buildMonthlyGoalPlan が全体を再構築する。
   const plan = useMemo(
     () =>
       buildMonthlyGoalPlan({
@@ -231,6 +244,11 @@ function PlanContent({
     setInputValues((prev) => ({ ...prev, [month]: val }));
   }
 
+  /**
+   * 月の編集をコミットする。
+   * override 配列に upsert し、親に通知する。
+   * buildMonthlyGoalPlan が全体を再構築するため、他月の manual override は保持される。
+   */
   function handleCommit(month: string) {
     const raw = inputValues[month] ?? "";
     const parsed = parseFloat(raw);
@@ -247,23 +265,18 @@ function PlanContent({
       return;
     }
 
-    const newEntries = redistributeMonthlyGoals(
-      plan.entries,
-      month,
-      parsed,
-      goalWeight,
-      currentWeight
-    );
+    // override 配列に upsert する (他月の override はすべて保持)
+    const newOverrides = upsertOverride(overrides, { month, targetWeight: parsed });
+    onOverridesChange(newOverrides);
+    // inputValues は planSignature 変化で useEffect により再同期される
+  }
 
-    // 再配分後の manual エントリーを overrides として親に通知
-    const newOverrides: MonthlyGoalOverride[] = newEntries
-      .filter((e): e is MonthlyGoalEntry & { source: "manual" } => e.source === "manual")
-      .map((e) => ({ month: e.month, targetWeight: e.targetWeight }));
-
-    // インプット値を再配分後の値に同期
-    setInputValues(
-      Object.fromEntries(newEntries.map((e) => [e.month, e.targetWeight.toFixed(1)]))
-    );
+  /**
+   * 月の手動 override を解除する。
+   * override 配列からその月を削除し、buildMonthlyGoalPlan が auto に戻す。
+   */
+  function handleReset(month: string) {
+    const newOverrides = overrides.filter((o) => o.month !== month);
     onOverridesChange(newOverrides);
   }
 
@@ -285,6 +298,7 @@ function PlanContent({
             {plan.entries.map((entry, idx) => {
               const isLast = idx === plan.entries.length - 1;
               const isCurrent = entry.month === today_month;
+              const isManual = entry.source === "manual";
 
               return (
                 <tr
@@ -357,10 +371,20 @@ function PlanContent({
                       <span className="rounded-full bg-teal-50 px-2 py-0.5 text-[10px] font-semibold text-teal-600">
                         終点
                       </span>
-                    ) : entry.source === "manual" ? (
-                      <span className="rounded-full bg-blue-50 px-2 py-0.5 text-[10px] font-semibold text-blue-600">
-                        手動
-                      </span>
+                    ) : isManual ? (
+                      <div className="flex flex-col items-center gap-0.5">
+                        <span className="rounded-full bg-blue-50 px-2 py-0.5 text-[10px] font-semibold text-blue-600">
+                          手動
+                        </span>
+                        <button
+                          type="button"
+                          onClick={() => handleReset(entry.month)}
+                          className="text-[9px] text-slate-400 underline hover:text-rose-500"
+                          aria-label={`${fmtMonth(entry.month)} 手動設定を解除`}
+                        >
+                          解除
+                        </button>
+                      </div>
                     ) : (
                       <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-semibold text-slate-400">
                         自動
@@ -400,7 +424,7 @@ function PlanContent({
 
       {/* 補足説明 */}
       <p className="mt-2 text-xs text-slate-400">
-        目標体重欄を編集して Enter / フォーカスアウトすると翌月以降が再配分されます。設定画面上部の「保存」で確定します。
+        目標体重欄を編集して Enter / フォーカスアウトで確定。複数月を手動設定すると各月が anchor として扱われ、間の月が自動配分されます。「解除」で自動に戻せます。設定画面上部の「保存」で確定します。
       </p>
     </div>
   );


### PR DESCRIPTION
## 概要

Settings の月次計画テーブルで、将来月にも manual override を設定できるようにする。複数月を同時に anchor として持てる UX を実現。

## 複数月 override 仕様

- override を「アンカー」として扱い、アンカー間を `buildMonthlyGoalPlan` (#101) が線形補間する
- ある月を編集しても **他月の manual override はすべて保持される**
- override を解除すると、その月は auto (均等再配分) に戻る
- 最終月は常に `finalGoalWeight` で編集不可
- 過去月は `buildMonthlyGoalPlan` の entries に含まれないため自然に編集不可

## UI / UX 仕様

| 状態 | 表示 |
|---|---|
| 自動月 | 「自動」バッジ (slate) |
| 手動月 | 「手動」バッジ (blue) + 「解除」ボタン |
| 最終月 | 「終点」バッジ (teal)、入力不可 |

- 将来月の入力欄は当月と同様に編集可能
- 「解除」ボタン押下で override が削除され自動配分に戻る
- 複数月に manual を置くと「手動」バッジが複数表示される

## 変更内容

**`MonthlyGoalPlanSection.tsx`**
- `redistributeMonthlyGoals` の使用を削除
- `handleCommit` → override 配列への upsert + `onOverridesChange` に変更
- `handleReset` を追加
- `upsertOverride` ヘルパーを追加
- 種別列に手動月の「解除」ボタンを追加

**`MonthlyGoalPlanSection.integration.test.tsx`**
- 7 件のテストを追加 (合計 20 件)

## 保存仕様

- 保存対象は引き続き `monthly_plan_overrides` (override 配列の JSON)
- preview 結果は保存しない
- `goal_weight` / `contest_date` / `monthly_plan_overrides` から毎回 `buildMonthlyGoalPlan` で導出

## テスト

- `node_modules/.bin/jest --no-coverage` — 791 tests passed (784 + 7 新規)
- `npx tsc --noEmit` — エラーなし

Closes #135
🤖 Generated with [Claude Code](https://claude.com/claude-code)