### PR TITLE
feat: strengthen monthly plan vs season comparison display (#136)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,7 +11,7 @@ import { calcWeeklyReview } from "@/lib/utils/calcWeeklyReview";
 import { calcMonthlyGoalProgress } from "@/lib/utils/calcMonthlyGoalProgress";
 import { toJstDateStr } from "@/lib/utils/date";
 import { buildMonthlyGoalPlan } from "@/lib/utils/monthlyGoalPlan";
-import { buildMonthlyGoalSummaryRows } from "@/lib/utils/monthlyGoalVisualization";
+import { buildMonthlyGoalSummaryRows, buildMonthlyGoalComparisonRows } from "@/lib/utils/monthlyGoalVisualization";
 import { fetchDailyLogs, fetchPredictions, fetchCareerLogsForDashboard } from "@/lib/queries/dailyLogs";
 import { fetchSettings } from "@/lib/queries/settings";
 import { fetchEnrichedLogs } from "@/lib/queries/analytics";
@@ -176,7 +176,10 @@ export default async function DashboardPage() {
 
   const monthlyGoalSummaryRows =
     monthlyGoalPlan?.isValid && monthlyGoalPlan.entries.length > 0
-      ? buildMonthlyGoalSummaryRows(monthlyGoalPlan, logs, today)
+      ? buildMonthlyGoalComparisonRows(
+          buildMonthlyGoalSummaryRows(monthlyGoalPlan, logs, today),
+          phase
+        )
       : [];
 
   return (

--- a/src/components/dashboard/LogsAndSummaryTabs.tsx
+++ b/src/components/dashboard/LogsAndSummaryTabs.tsx
@@ -7,15 +7,15 @@ import { MonthlyGoalTable } from "./MonthlyGoalTable";
 import { SeasonSummary } from "@/components/history/SeasonSummary";
 import type { DailyLog } from "@/lib/supabase/types";
 import type { MonthStats } from "@/components/history/SeasonSummary";
-import type { MonthlyGoalSummaryRow } from "@/lib/utils/monthlyGoalVisualization";
+import type { MonthlyGoalComparisonRow } from "@/lib/utils/monthlyGoalVisualization";
 
 interface LogsAndSummaryTabsProps {
   logs: DailyLog[];
   monthStats: MonthStats[];
   seasonMap?: Map<string, string>;
   currentSeason?: string | null;
-  /** 月次計画 vs 実績の比較行 (buildMonthlyGoalSummaryRows の結果) */
-  monthlyGoalSummaryRows?: MonthlyGoalSummaryRow[];
+  /** 月次計画 vs 実績の比較行 (buildMonthlyGoalComparisonRows の結果) */
+  monthlyGoalSummaryRows?: MonthlyGoalComparisonRow[];
   /** "Cut" | "Bulk" — MonthlyGoalTable の差分色分けに使用 */
   phase?: string;
 }

--- a/src/components/dashboard/MonthlyGoalTable.tsx
+++ b/src/components/dashboard/MonthlyGoalTable.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import type { MonthlyGoalSummaryRow } from "@/lib/utils/monthlyGoalVisualization";
+import type { MonthlyGoalComparisonRow, MonthlyPlanProgressState } from "@/lib/utils/monthlyGoalVisualization";
 
 interface MonthlyGoalTableProps {
-  rows: MonthlyGoalSummaryRow[];
+  rows: MonthlyGoalComparisonRow[];
   /** "Cut" | "Bulk" — 差分の色付け方向を決定する */
   phase: string;
 }
@@ -17,6 +17,33 @@ function diffColor(diffKg: number | null, isCut: boolean): string {
   if (Math.abs(diffKg) < 0.05) return "text-slate-500";
   const isBehind = isCut ? diffKg > 0 : diffKg < 0;
   return isBehind ? "text-rose-500" : "text-emerald-600";
+}
+
+/** progressState のバッジ表示 */
+function ProgressBadge({ state }: { state: MonthlyPlanProgressState }) {
+  if (state === "pending") {
+    return <span className="text-slate-300">—</span>;
+  }
+  if (state === "on_track") {
+    return (
+      <span className="rounded-full bg-slate-100 px-1.5 py-0.5 text-[9px] font-semibold text-slate-500">
+        計画内
+      </span>
+    );
+  }
+  if (state === "ahead") {
+    return (
+      <span className="rounded-full bg-emerald-50 px-1.5 py-0.5 text-[9px] font-semibold text-emerald-600">
+        先行
+      </span>
+    );
+  }
+  // "behind"
+  return (
+    <span className="rounded-full bg-rose-50 px-1.5 py-0.5 text-[9px] font-semibold text-rose-500">
+      遅れ
+    </span>
+  );
 }
 
 export function MonthlyGoalTable({ rows, phase }: MonthlyGoalTableProps) {
@@ -35,11 +62,15 @@ export function MonthlyGoalTable({ rows, phase }: MonthlyGoalTableProps) {
           <thead>
             <tr className="border-b border-slate-100 text-left">
               <th className="pb-2 pr-3 text-xs font-semibold uppercase tracking-wide text-slate-400">月</th>
-              <th className="pb-2 pr-3 text-right text-xs font-semibold uppercase tracking-wide text-slate-400">月初体重</th>
+              {/* 月初体重: sm 以上のみ表示 */}
+              <th className="hidden sm:table-cell pb-2 pr-3 text-right text-xs font-semibold uppercase tracking-wide text-slate-400">月初体重</th>
               <th className="pb-2 pr-3 text-right text-xs font-semibold uppercase tracking-wide text-slate-400">月末目標</th>
               <th className="pb-2 pr-3 text-right text-xs font-semibold uppercase tracking-wide text-slate-400">実績月末</th>
               <th className="pb-2 pr-3 text-right text-xs font-semibold uppercase tracking-wide text-slate-400">差分</th>
-              <th className="pb-2 text-right text-xs font-semibold uppercase tracking-wide text-slate-400">翌月必要</th>
+              <th className="pb-2 pr-3 text-center text-xs font-semibold uppercase tracking-wide text-slate-400">状態</th>
+              <th className="pb-2 pr-3 text-right text-xs font-semibold uppercase tracking-wide text-slate-400">累積ズレ</th>
+              {/* 翌月必要: sm 以上のみ表示 */}
+              <th className="hidden sm:table-cell pb-2 text-right text-xs font-semibold uppercase tracking-wide text-slate-400">翌月必要</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-slate-50">
@@ -58,8 +89,8 @@ export function MonthlyGoalTable({ rows, phase }: MonthlyGoalTableProps) {
                       </span>
                     )}
                   </td>
-                  {/* 月初体重 */}
-                  <td className="py-2 pr-3 text-right text-xs text-slate-500">
+                  {/* 月初体重 (sm 以上) */}
+                  <td className="hidden sm:table-cell py-2 pr-3 text-right text-xs text-slate-500">
                     {row.monthStartWeight !== null
                       ? `${row.monthStartWeight.toFixed(1)} kg`
                       : "—"}
@@ -89,8 +120,18 @@ export function MonthlyGoalTable({ rows, phase }: MonthlyGoalTableProps) {
                       ? `${row.diffKg > 0 ? "+" : ""}${row.diffKg.toFixed(2)}`
                       : "—"}
                   </td>
-                  {/* 翌月必要変化量 */}
-                  <td className="py-2 text-right text-xs tabular-nums text-slate-500">
+                  {/* 状態 */}
+                  <td className="py-2 pr-3 text-center text-xs">
+                    <ProgressBadge state={row.progressState} />
+                  </td>
+                  {/* 累積ズレ */}
+                  <td className={`py-2 pr-3 text-right text-xs tabular-nums ${diffColor(row.cumulativeGapKg, isCut)}`}>
+                    {row.cumulativeGapKg !== null
+                      ? `${row.cumulativeGapKg > 0 ? "+" : ""}${row.cumulativeGapKg.toFixed(2)}`
+                      : "—"}
+                  </td>
+                  {/* 翌月必要変化量 (sm 以上) */}
+                  <td className="hidden sm:table-cell py-2 text-right text-xs tabular-nums text-slate-500">
                     {row.nextRequiredDeltaKg !== null
                       ? `${row.nextRequiredDeltaKg > 0 ? "+" : ""}${row.nextRequiredDeltaKg.toFixed(1)} kg`
                       : "—"}

--- a/src/lib/utils/monthlyGoalVisualization.test.ts
+++ b/src/lib/utils/monthlyGoalVisualization.test.ts
@@ -9,6 +9,9 @@
 import {
   buildMonthlyGoalDateMap,
   buildMonthlyGoalSummaryRows,
+  classifyMonthlyPlanGap,
+  buildMonthlyGoalComparisonRows,
+  PLAN_GAP_THRESHOLD_KG,
 } from "./monthlyGoalVisualization";
 import type { MonthlyGoalSummaryRow } from "./monthlyGoalVisualization";
 import type { MonthlyGoalPlan } from "./monthlyGoalPlan";
@@ -399,5 +402,238 @@ describe("buildMonthlyGoalSummaryRows — buildMonthlyGoalPlan との統合", ()
     expect(plan.isValid).toBe(false);
     const rows = buildMonthlyGoalSummaryRows(plan, [], "2026-07-15");
     expect(rows).toHaveLength(0);
+  });
+});
+
+// ─── classifyMonthlyPlanGap ──────────────────────────────────────────────────
+
+describe("classifyMonthlyPlanGap", () => {
+  it("PLAN_GAP_THRESHOLD_KG が 0.2 kg", () => {
+    expect(PLAN_GAP_THRESHOLD_KG).toBe(0.2);
+  });
+
+  describe("pending ケース", () => {
+    it("diffKg = null → pending", () => {
+      expect(classifyMonthlyPlanGap(null, true, false, false)).toBe("pending");
+    });
+    it("isPartialActual = true → pending", () => {
+      expect(classifyMonthlyPlanGap(0.5, true, true, false)).toBe("pending");
+    });
+    it("isFutureMonth = true → pending", () => {
+      expect(classifyMonthlyPlanGap(0.5, true, false, true)).toBe("pending");
+    });
+  });
+
+  describe("on_track ケース (|diffKg| <= threshold)", () => {
+    it("diffKg = 0.0 → on_track", () => {
+      expect(classifyMonthlyPlanGap(0.0, true, false, false)).toBe("on_track");
+    });
+    it("diffKg = 0.2 → on_track (境界値)", () => {
+      expect(classifyMonthlyPlanGap(0.2, true, false, false)).toBe("on_track");
+    });
+    it("diffKg = -0.2 → on_track (境界値)", () => {
+      expect(classifyMonthlyPlanGap(-0.2, true, false, false)).toBe("on_track");
+    });
+  });
+
+  describe("Cut フェーズ", () => {
+    it("diffKg = -0.5 → ahead (目標より軽い)", () => {
+      expect(classifyMonthlyPlanGap(-0.5, true, false, false)).toBe("ahead");
+    });
+    it("diffKg = 0.5 → behind (目標より重い)", () => {
+      expect(classifyMonthlyPlanGap(0.5, true, false, false)).toBe("behind");
+    });
+    it("diffKg = 0.21 → behind (閾値超え)", () => {
+      expect(classifyMonthlyPlanGap(0.21, true, false, false)).toBe("behind");
+    });
+  });
+
+  describe("Bulk フェーズ", () => {
+    it("diffKg = 0.5 → ahead (目標より重い)", () => {
+      expect(classifyMonthlyPlanGap(0.5, false, false, false)).toBe("ahead");
+    });
+    it("diffKg = -0.5 → behind (目標より軽い)", () => {
+      expect(classifyMonthlyPlanGap(-0.5, false, false, false)).toBe("behind");
+    });
+  });
+});
+
+// ─── buildMonthlyGoalComparisonRows ─────────────────────────────────────────
+
+describe("buildMonthlyGoalComparisonRows — 基本動作", () => {
+  it("空配列を渡すと空配列を返す", () => {
+    expect(buildMonthlyGoalComparisonRows([], "Cut")).toHaveLength(0);
+  });
+
+  it("元の MonthlyGoalSummaryRow フィールドが保持される", () => {
+    const plan = makePlan([entry("2026-07", 73.8), entry("2026-08", 72.5)]);
+    const summaryRows = buildMonthlyGoalSummaryRows(plan, [], "2026-07-15");
+    const rows = buildMonthlyGoalComparisonRows(summaryRows, "Cut");
+    expect(rows[0]!.month).toBe("2026-07");
+    expect(rows[0]!.monthEndTarget).toBeCloseTo(73.8);
+    expect(rows[1]!.month).toBe("2026-08");
+  });
+
+  it("progressState フィールドが追加される", () => {
+    const plan = makePlan([entry("2026-07", 73.8)]);
+    const summaryRows = buildMonthlyGoalSummaryRows(plan, [], "2026-07-15");
+    const rows = buildMonthlyGoalComparisonRows(summaryRows, "Cut");
+    expect(rows[0]).toHaveProperty("progressState");
+  });
+
+  it("cumulativeGapKg フィールドが追加される", () => {
+    const plan = makePlan([entry("2026-07", 73.8)]);
+    const summaryRows = buildMonthlyGoalSummaryRows(plan, [], "2026-07-15");
+    const rows = buildMonthlyGoalComparisonRows(summaryRows, "Cut");
+    expect(rows[0]).toHaveProperty("cumulativeGapKg");
+  });
+});
+
+describe("buildMonthlyGoalComparisonRows — progressState", () => {
+  it("当月 (partial) → progressState = pending", () => {
+    const plan = makePlan([entry("2026-07", 73.8)]);
+    const logs = [log("2026-07-15", 74.0)];
+    const summaryRows = buildMonthlyGoalSummaryRows(plan, logs, "2026-07-15");
+    const rows = buildMonthlyGoalComparisonRows(summaryRows, "Cut");
+    expect(rows[0]!.progressState).toBe("pending");
+  });
+
+  it("未来月 → progressState = pending", () => {
+    const plan = makePlan([entry("2026-07", 73.8), entry("2026-08", 72.5)]);
+    const summaryRows = buildMonthlyGoalSummaryRows(plan, [], "2026-07-15");
+    const rows = buildMonthlyGoalComparisonRows(summaryRows, "Cut");
+    expect(rows[1]!.progressState).toBe("pending"); // 2026-08 は未来月
+  });
+
+  it("Cut 過去月: 実績 < 目標 → ahead", () => {
+    // today = 2026-08-01 → 2026-07 は過去月
+    // diff = 73.0 - 73.8 = -0.8 (目標より軽い = Cut で先行)
+    const plan = makePlan([entry("2026-07", 73.8), entry("2026-08", 72.5)]);
+    const logs = [log("2026-07-31", 73.0)];
+    const summaryRows = buildMonthlyGoalSummaryRows(plan, logs, "2026-08-01");
+    const rows = buildMonthlyGoalComparisonRows(summaryRows, "Cut");
+    expect(rows[0]!.progressState).toBe("ahead");
+  });
+
+  it("Cut 過去月: 実績 > 目標 → behind", () => {
+    // diff = 74.5 - 73.8 = 0.7 (目標より重い = Cut で遅れ)
+    const plan = makePlan([entry("2026-07", 73.8), entry("2026-08", 72.5)]);
+    const logs = [log("2026-07-31", 74.5)];
+    const summaryRows = buildMonthlyGoalSummaryRows(plan, logs, "2026-08-01");
+    const rows = buildMonthlyGoalComparisonRows(summaryRows, "Cut");
+    expect(rows[0]!.progressState).toBe("behind");
+  });
+
+  it("Cut 過去月: |diff| <= 0.2 → on_track", () => {
+    // diff = 73.9 - 73.8 = 0.1 (閾値内)
+    const plan = makePlan([entry("2026-07", 73.8), entry("2026-08", 72.5)]);
+    const logs = [log("2026-07-31", 73.9)];
+    const summaryRows = buildMonthlyGoalSummaryRows(plan, logs, "2026-08-01");
+    const rows = buildMonthlyGoalComparisonRows(summaryRows, "Cut");
+    expect(rows[0]!.progressState).toBe("on_track");
+  });
+
+  it("Bulk 過去月: 実績 > 目標 → ahead", () => {
+    // diff = 77.0 - 76.5 = 0.5 (目標より重い = Bulk で先行)
+    const plan = makePlan([entry("2026-07", 76.5, +1.5)]);
+    const logs = [log("2026-07-31", 77.0)];
+    const summaryRows = buildMonthlyGoalSummaryRows(plan, logs, "2026-08-01");
+    const rows = buildMonthlyGoalComparisonRows(summaryRows, "Bulk");
+    expect(rows[0]!.progressState).toBe("ahead");
+  });
+
+  it("Bulk 過去月: 実績 < 目標 → behind", () => {
+    // diff = 75.8 - 76.5 = -0.7 (目標より軽い = Bulk で遅れ)
+    const plan = makePlan([entry("2026-07", 76.5, +1.5)]);
+    const logs = [log("2026-07-31", 75.8)];
+    const summaryRows = buildMonthlyGoalSummaryRows(plan, logs, "2026-08-01");
+    const rows = buildMonthlyGoalComparisonRows(summaryRows, "Bulk");
+    expect(rows[0]!.progressState).toBe("behind");
+  });
+});
+
+describe("buildMonthlyGoalComparisonRows — cumulativeGapKg", () => {
+  it("当月 (partial) → cumulativeGapKg = null", () => {
+    const plan = makePlan([entry("2026-07", 73.8)]);
+    const logs = [log("2026-07-15", 74.0)];
+    const summaryRows = buildMonthlyGoalSummaryRows(plan, logs, "2026-07-15");
+    const rows = buildMonthlyGoalComparisonRows(summaryRows, "Cut");
+    expect(rows[0]!.cumulativeGapKg).toBeNull();
+  });
+
+  it("未来月 → cumulativeGapKg = null", () => {
+    const plan = makePlan([entry("2026-07", 73.8), entry("2026-08", 72.5)]);
+    const summaryRows = buildMonthlyGoalSummaryRows(plan, [], "2026-07-15");
+    const rows = buildMonthlyGoalComparisonRows(summaryRows, "Cut");
+    expect(rows[1]!.cumulativeGapKg).toBeNull();
+  });
+
+  it("過去月: データなし → cumulativeGapKg = null", () => {
+    const plan = makePlan([entry("2026-07", 73.8), entry("2026-08", 72.5)]);
+    const summaryRows = buildMonthlyGoalSummaryRows(plan, [], "2026-08-10");
+    const rows = buildMonthlyGoalComparisonRows(summaryRows, "Cut");
+    expect(rows[0]!.cumulativeGapKg).toBeNull();
+  });
+
+  it("過去月 1 ヶ月: diffKg = 0.2 → cumulativeGapKg = 0.2", () => {
+    // 74.0 - 73.8 = 0.2
+    const plan = makePlan([entry("2026-07", 73.8), entry("2026-08", 72.5)]);
+    const logs = [log("2026-07-31", 74.0)];
+    const summaryRows = buildMonthlyGoalSummaryRows(plan, logs, "2026-08-10");
+    const rows = buildMonthlyGoalComparisonRows(summaryRows, "Cut");
+    expect(rows[0]!.cumulativeGapKg).toBeCloseTo(0.2, 2);
+  });
+
+  it("過去月 2 ヶ月: 累積が正しく積算される", () => {
+    // today = 2026-09-01 → 2026-07, 2026-08 が過去月
+    const plan = makePlan([
+      entry("2026-07", 73.8, -1.2),
+      entry("2026-08", 72.5, -1.3),
+      entry("2026-09", 71.5, -1.0),
+    ]);
+    const logs = [
+      log("2026-07-31", 74.0), // diff = 74.0 - 73.8 = +0.2
+      log("2026-08-31", 73.0), // diff = 73.0 - 72.5 = +0.5
+    ];
+    const summaryRows = buildMonthlyGoalSummaryRows(plan, logs, "2026-09-01");
+    const rows = buildMonthlyGoalComparisonRows(summaryRows, "Cut");
+    expect(rows[0]!.cumulativeGapKg).toBeCloseTo(0.2, 2);  // month1 のみ
+    expect(rows[1]!.cumulativeGapKg).toBeCloseTo(0.7, 2);  // 0.2 + 0.5
+    expect(rows[2]!.cumulativeGapKg).toBeNull();            // 当月は null
+  });
+
+  it("データなし月を挟んでも後続月は累積を継続する", () => {
+    // today = 2026-09-01 → 2026-07 はデータなし、2026-08 はデータあり
+    const plan = makePlan([
+      entry("2026-07", 73.8, -1.2),
+      entry("2026-08", 72.5, -1.3),
+      entry("2026-09", 71.5, -1.0),
+    ]);
+    const logs = [
+      // 2026-07 のログはなし
+      log("2026-08-31", 73.0), // diff = 73.0 - 72.5 = +0.5
+    ];
+    const summaryRows = buildMonthlyGoalSummaryRows(plan, logs, "2026-09-01");
+    const rows = buildMonthlyGoalComparisonRows(summaryRows, "Cut");
+    expect(rows[0]!.cumulativeGapKg).toBeNull();           // データなし
+    expect(rows[1]!.cumulativeGapKg).toBeCloseTo(0.5, 2); // 0.5 (07 は null なので加算対象外)
+    expect(rows[2]!.cumulativeGapKg).toBeNull();           // 当月
+  });
+
+  it("負の diffKg (先行) は累積から引かれる", () => {
+    // today = 2026-09-01
+    const plan = makePlan([
+      entry("2026-07", 73.8, -1.2),
+      entry("2026-08", 72.5, -1.3),
+      entry("2026-09", 71.5, -1.0),
+    ]);
+    const logs = [
+      log("2026-07-31", 74.0), // diff = +0.2 (遅れ)
+      log("2026-08-31", 72.0), // diff = 72.0 - 72.5 = -0.5 (先行)
+    ];
+    const summaryRows = buildMonthlyGoalSummaryRows(plan, logs, "2026-09-01");
+    const rows = buildMonthlyGoalComparisonRows(summaryRows, "Cut");
+    expect(rows[0]!.cumulativeGapKg).toBeCloseTo(0.2, 2);   // +0.2
+    expect(rows[1]!.cumulativeGapKg).toBeCloseTo(-0.3, 2);  // 0.2 + (-0.5) = -0.3
   });
 });

--- a/src/lib/utils/monthlyGoalVisualization.ts
+++ b/src/lib/utils/monthlyGoalVisualization.ts
@@ -10,6 +10,15 @@
 
 import type { MonthlyGoalEntry, MonthlyGoalPlan } from "@/lib/utils/monthlyGoalPlan";
 
+// ─── 比較表示用定数 ────────────────────────────────────────────────────────────
+
+/**
+ * 月次計画の進捗判定閾値 (kg)。
+ * 差分の絶対値がこの値以内なら「計画内」とみなす。
+ * 月レベルの計画管理として 0.2 kg を許容範囲に設定。
+ */
+export const PLAN_GAP_THRESHOLD_KG = 0.2;
+
 // ─── 入力型 ──────────────────────────────────────────────────────────────────
 
 /** buildMonthlyGoalSummaryRows が必要とする最小限の log フィールド */
@@ -69,6 +78,40 @@ export interface MonthlyGoalSummaryRow {
    * 最終月または次月エントリーが存在しない場合は null。
    */
   nextRequiredDeltaKg: number | null;
+}
+
+// ─── 型定義 (比較表示) ────────────────────────────────────────────────────────
+
+/**
+ * 月次計画の進捗状態。
+ * - "ahead"    : 計画より先行 (Cut: 体重が目標より軽い / Bulk: 目標より重い)
+ * - "on_track" : 計画内 (±PLAN_GAP_THRESHOLD_KG 以内)
+ * - "behind"   : 計画より遅れ
+ * - "pending"  : 未確定 (当月 partial / 未来月 / データなし)
+ */
+export type MonthlyPlanProgressState =
+  | "ahead"
+  | "on_track"
+  | "behind"
+  | "pending";
+
+/**
+ * 月次計画 vs 実績の比較行。
+ * MonthlyGoalSummaryRow を extends し、状態・累積ズレを追加する。
+ */
+export interface MonthlyGoalComparisonRow extends MonthlyGoalSummaryRow {
+  /**
+   * 月ごとの進捗状態。
+   * diffKg = null / isPartialActual / isFutureMonth の場合は "pending"。
+   */
+  progressState: MonthlyPlanProgressState;
+  /**
+   * 過去完全実績月の diffKg の累積合計 (0.01 kg 丸め)。
+   * - 過去完全実績月かつ diffKg が non-null: 累積合計を返す
+   * - 過去完全実績月かつ diffKg が null (データなし): null を返す (累積に加算しない)
+   * - 当月 partial / 未来月: null
+   */
+  cumulativeGapKg: number | null;
 }
 
 // ─── プライベートヘルパー ─────────────────────────────────────────────────────
@@ -207,5 +250,72 @@ export function buildMonthlyGoalSummaryRows(
       diffKg,
       nextRequiredDeltaKg,
     };
+  });
+}
+
+// ─── 比較表示 adapter ─────────────────────────────────────────────────────────
+
+/**
+ * classifyMonthlyPlanGap
+ *
+ * diffKg から月ごとの進捗状態を分類する純粋関数。
+ *
+ * - diffKg = null / isPartialActual / isFutureMonth → "pending"
+ * - |diffKg| <= PLAN_GAP_THRESHOLD_KG → "on_track"
+ * - Cut:  diffKg < 0 → "ahead" (目標より軽い), diffKg > 0 → "behind"
+ * - Bulk: diffKg > 0 → "ahead" (目標より重い), diffKg < 0 → "behind"
+ */
+export function classifyMonthlyPlanGap(
+  diffKg: number | null,
+  isCut: boolean,
+  isPartialActual: boolean,
+  isFutureMonth: boolean
+): MonthlyPlanProgressState {
+  if (isPartialActual || isFutureMonth || diffKg === null) return "pending";
+  if (Math.abs(diffKg) <= PLAN_GAP_THRESHOLD_KG) return "on_track";
+  const isAhead = isCut ? diffKg < 0 : diffKg > 0;
+  return isAhead ? "ahead" : "behind";
+}
+
+/**
+ * buildMonthlyGoalComparisonRows
+ *
+ * MonthlyGoalSummaryRow[] に progressState と cumulativeGapKg を付与する adapter。
+ * UI 側でロジックを散らさないための selector 層。
+ *
+ * - progressState: Cut/Bulk を考慮した月ごとの状態分類
+ * - cumulativeGapKg: 過去完全実績月の diffKg の累積合計
+ *   - データなし月 (diffKg=null) は累積に加算しない。その月は null を返す。
+ *   - 当月 partial / 未来月は null
+ *
+ * @param rows  - buildMonthlyGoalSummaryRows の戻り値
+ * @param phase - "Cut" | "Bulk"
+ */
+export function buildMonthlyGoalComparisonRows(
+  rows: MonthlyGoalSummaryRow[],
+  phase: string
+): MonthlyGoalComparisonRow[] {
+  const isCut = phase !== "Bulk";
+  let runningSum = 0;
+
+  return rows.map((row) => {
+    const progressState = classifyMonthlyPlanGap(
+      row.diffKg,
+      isCut,
+      row.isPartialActual,
+      row.isFutureMonth
+    );
+
+    let cumulativeGapKg: number | null = null;
+    if (!row.isPartialActual && !row.isFutureMonth) {
+      if (row.diffKg !== null) {
+        runningSum += row.diffKg;
+        cumulativeGapKg = Math.round(runningSum * 100) / 100;
+      }
+      // diffKg === null: データなし。runningSum は変えず、null を返す。
+    }
+    // 当月 partial / 未来月: null のまま
+
+    return { ...row, progressState, cumulativeGapKg };
   });
 }


### PR DESCRIPTION
## Summary

- `monthlyGoalVisualization.ts` に `classifyMonthlyPlanGap()` と `buildMonthlyGoalComparisonRows()` adapter を追加
  - `progressState`: Cut/Bulk を考慮した月ごとの進捗状態 (先行/計画内/遅れ/未確定)
  - `cumulativeGapKg`: 過去完全実績月の diffKg 累積合計 (データ欠損月はスキップ、累積はリセットしない)
  - `PLAN_GAP_THRESHOLD_KG = 0.2` kg を許容範囲の定数として export
- `MonthlyGoalTable.tsx` に「状態」「累積ズレ」列を追加、「月初体重」「翌月必要」を mobile で非表示 (`hidden sm:table-cell`)
- `page.tsx` で `buildMonthlyGoalComparisonRows` を通して comparison rows を生成
- 30件のユニットテスト追加 (合計 821件)

## Test plan

- [ ] `node_modules/.bin/jest --no-coverage monthlyGoalVisualization` — 30件追加テスト全パス
- [ ] `npx tsc --noEmit` — 型エラーなし
- [ ] ダッシュボード「月別サマリー」タブで MonthlyGoalTable に「状態」「累積ズレ」列が表示される
- [ ] モバイル幅 (< sm) では「月初体重」「翌月必要」列が非表示
- [ ] Cut フェーズ: 体重が目標より軽い月に「先行」バッジ
- [ ] Bulk フェーズ: 体重が目標より重い月に「先行」バッジ

🤖 Generated with [Claude Code](https://claude.com/claude-code)