### PR TITLE
fix: unify numeric input parsing with strict parser

### DIFF
--- a/src/components/foods/FoodTable.tsx
+++ b/src/components/foods/FoodTable.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo, useTransition } from "react";
 import { Trash2, Plus, Search, ChevronUp, ChevronDown, ChevronsUpDown } from "lucide-react";
 import { createClient } from "@/lib/supabase/client";
 import type { FoodMaster } from "@/lib/supabase/types";
+import { parseStrictNumber } from "@/lib/utils/parseNumber";
 
 interface FoodTableProps {
   initialFoods: FoodMaster[];
@@ -103,14 +104,17 @@ export function FoodTable({ initialFoods }: FoodTableProps) {
       fat: "F (g)",
       carbs: "C (g)",
     };
+    const parsedNums: Record<string, number> = {};
     for (const field of numFields) {
-      if (form[field].trim() === "") {
-        return setError(`${labelMap[field]} は必須です`);
+      const v = parseStrictNumber(form[field], { min: 0 });
+      if (v === null) {
+        return setError(
+          form[field].trim() === ""
+            ? `${labelMap[field]} は必須です`
+            : `${labelMap[field]} には 0 以上の数値を入力してください`
+        );
       }
-      const v = parseFloat(form[field]);
-      if (isNaN(v) || v < 0) {
-        return setError(`${labelMap[field]} には 0 以上の数値を入力してください`);
-      }
+      parsedNums[field] = v;
     }
 
     setIsSaving(true);
@@ -118,10 +122,10 @@ export function FoodTable({ initialFoods }: FoodTableProps) {
 
     const payload: FoodMaster = {
       name: form.name.trim(),
-      calories: parseFloat(form.calories),
-      protein: parseFloat(form.protein),
-      fat: parseFloat(form.fat),
-      carbs: parseFloat(form.carbs),
+      calories: parsedNums["calories"]!,
+      protein: parsedNums["protein"]!,
+      fat: parsedNums["fat"]!,
+      carbs: parsedNums["carbs"]!,
       category: form.category.trim() || null,
     };
     const supabase = createClient();

--- a/src/components/meal/MealLogger.tsx
+++ b/src/components/meal/MealLogger.tsx
@@ -24,6 +24,7 @@ import {
   type WorkMode,
 } from "@/lib/utils/trainingType";
 import { useDailyLogs } from "@/lib/hooks/useDailyLogs";
+import { parseStrictNumber } from "@/lib/utils/parseNumber";
 
 type SaveStatus = "idle" | "saving" | "saved" | "error";
 
@@ -221,7 +222,7 @@ export function MealLogger({ sidebar = false }: MealLoggerProps) {
       // touched=true かつユーザーが操作した場合のみ送信。
       // touched=false (hydrate のみ) は undefined → 既存値を保持。
       weight:   weightTouched
-        ? (weight === null   ? null   : (weight   !== "" ? parseFloat(weight)   : undefined))
+        ? (weight === null   ? null   : parseStrictNumber(weight)   ?? undefined)
         : undefined,
       // カートに一度でも追加後に空にした → null 送信（マクロをクリア）
       calories: cartItems.length > 0 ? totals.calories : (cartEverHadItems ? null : undefined),
@@ -234,7 +235,7 @@ export function MealLogger({ sidebar = false }: MealLoggerProps) {
       ...tagPayload,
       // Phase 2.5 新規フィールド
       sleep_hours: sleepHoursTouched
-        ? (sleepHours === null ? null : (sleepHours !== "" ? parseFloat(sleepHours) : undefined))
+        ? (sleepHours === null ? null : parseStrictNumber(sleepHours) ?? undefined)
         : undefined,
       // ルール: touched=true → hadBowelMovement の値をそのまま送信
       //           null  = 明示クリア（未記録に戻す）

--- a/src/components/settings/MonthlyGoalPlanSection.tsx
+++ b/src/components/settings/MonthlyGoalPlanSection.tsx
@@ -19,6 +19,7 @@
 import { useState, useMemo, useEffect } from "react";
 import { AlertTriangle, Info } from "lucide-react";
 import { buildMonthlyGoalPlan } from "@/lib/utils/monthlyGoalPlan";
+import { parseStrictNumber } from "@/lib/utils/parseNumber";
 import type {
   MonthlyGoalOverride,
   MonthlyGoalErrorCode,
@@ -251,9 +252,9 @@ function PlanContent({
    */
   function handleCommit(month: string) {
     const raw = inputValues[month] ?? "";
-    const parsed = parseFloat(raw);
+    const parsed = parseStrictNumber(raw);
 
-    if (!isFinite(parsed) || parsed <= 0 || parsed > 300) {
+    if (parsed === null || parsed <= 0 || parsed > 300) {
       // 不正値: 元の plan 値に戻す
       const entry = plan.entries.find((e) => e.month === month);
       if (entry) {

--- a/src/components/settings/normalizeSettingField.ts
+++ b/src/components/settings/normalizeSettingField.ts
@@ -5,6 +5,8 @@
  * コンポーネントから独立しているためユニットテストが容易。
  */
 
+import { parseStrictNumber } from "@/lib/utils/parseNumber";
+
 export type FieldType = "number" | "text" | "date" | "select";
 
 export interface NormalizedUpsert {
@@ -35,9 +37,8 @@ export function normalizeSettingField(
 
   // text / select フィールド: 前後空白を除去
   const normalizedStr = !isNumeric && !isDate ? raw.trim() : raw;
-  // number フィールド: parseFloat して有限数でなければ null
-  const parsedNum = isNumeric && raw.trim() !== "" ? parseFloat(raw.trim()) : NaN;
-  const numValue = isNumeric ? (Number.isFinite(parsedNum) ? parsedNum : null) : null;
+  // number フィールド: strict parser で部分成功パースを排除。"12abc" 等は null になる
+  const numValue = isNumeric ? parseStrictNumber(raw) : null;
   // date フィールド: YYYY-MM-DD 形式のみ保存（それ以外は null）
   const dateValue =
     isDate && /^\d{4}-\d{2}-\d{2}$/.test(raw.trim()) ? raw.trim() : null;

--- a/src/lib/schemas/settingsSchema.test.ts
+++ b/src/lib/schemas/settingsSchema.test.ts
@@ -128,12 +128,13 @@ describe("parseSettings — 異常系", () => {
   });
 
   it("target_weight (goal_weight) が負数で失敗する", () => {
+    // strict parser は負数を「数値でない」として拒否する（範囲チェックより前）
     const result = parseSettings({ goal_weight: "-5" });
     expect(result.ok).toBe(false);
     if (result.ok) return;
     const err = result.errors.find((e) => e.field === "goal_weight");
     expect(err).toBeDefined();
-    expect(err!.message).toContain("20〜200");
+    expect(err!.message).toContain("数値");
   });
 
   it("文字列を数値フィールドに渡して失敗する", () => {

--- a/src/lib/schemas/settingsSchema.ts
+++ b/src/lib/schemas/settingsSchema.ts
@@ -6,6 +6,8 @@
  * 各設定キーが number か string かをここで明確に定義する。
  */
 
+import { parseStrictNumber } from "@/lib/utils/parseNumber";
+
 // ─── 設定キー一覧 ────────────────────────────────────────────────────────────
 
 /** value_num に保存する数値系キー */
@@ -160,8 +162,8 @@ export function parseSettings(input: SettingsInput): ParseSettingsResult {
       records.push({ key, value_num: null, value_str: null });
       continue;
     }
-    const parsed = parseFloat(raw);
-    if (!Number.isFinite(parsed)) {
+    const parsed = parseStrictNumber(raw);
+    if (parsed === null) {
       errors.push({ field: key, message: `${NUMERIC_RULES[key].label} は数値で入力してください` });
       continue;
     }

--- a/src/lib/utils/csvParser.ts
+++ b/src/lib/utils/csvParser.ts
@@ -1,5 +1,6 @@
 /**
  * csvParser.ts — CSV パース共通ユーティリティ
+ * parseNum は parseStrictNumber を使用して部分成功パースを排除している。
  *
  * - RFC 4180 準拠のクォート付きセル（"value with, comma"）に対応
  * - クォートフィールド内の改行（multiline フィールド）に対応
@@ -10,6 +11,8 @@
  * - 列数不足の行（実際のセル数 < ヘッダー数）はスキップし、errors に記録する。
  *   列数が多い場合（実際のセル数 > ヘッダー数）の余剰列は無視する。
  */
+
+import { parseStrictNumber } from "./parseNumber";
 
 export interface ParsedRow {
   log_date: string;
@@ -63,9 +66,7 @@ export function normalizeKey(raw: string): keyof ParsedRow | null {
 }
 
 export function parseNum(v: string): number | null {
-  if (v.trim() === "") return null;
-  const n = parseFloat(v.trim());
-  return isNaN(n) ? null : n;
+  return parseStrictNumber(v, { allowNegative: true });
 }
 
 /** "true" / "1" → true, それ以外（空文字含む）→ false */

--- a/src/lib/utils/parseNumber.test.ts
+++ b/src/lib/utils/parseNumber.test.ts
@@ -1,0 +1,152 @@
+import { parseStrictNumber } from "./parseNumber";
+
+// ─── 正常系 ──────────────────────────────────────────────────────────────────
+
+describe("parseStrictNumber — 正常系", () => {
+  it("整数を返す", () => {
+    expect(parseStrictNumber("72")).toBe(72);
+  });
+
+  it("小数を返す (allowDecimal デフォルト true)", () => {
+    expect(parseStrictNumber("72.5")).toBe(72.5);
+  });
+
+  it("0 を返す", () => {
+    expect(parseStrictNumber("0")).toBe(0);
+  });
+
+  it("0.0 を返す", () => {
+    expect(parseStrictNumber("0.0")).toBe(0);
+  });
+
+  it("前後の空白を trim して処理する", () => {
+    expect(parseStrictNumber("  72.5  ")).toBe(72.5);
+  });
+
+  it("allowNegative: true のとき負数を返す", () => {
+    expect(parseStrictNumber("-1", { allowNegative: true })).toBe(-1);
+  });
+
+  it("allowNegative: true のとき負の小数を返す", () => {
+    expect(parseStrictNumber("-0.5", { allowNegative: true })).toBe(-0.5);
+  });
+
+  it("allowDecimal: false のとき整数を返す", () => {
+    expect(parseStrictNumber("30", { allowDecimal: false })).toBe(30);
+  });
+
+  it("min/max 範囲内の値を返す", () => {
+    expect(parseStrictNumber("5", { min: 0, max: 10 })).toBe(5);
+    expect(parseStrictNumber("0", { min: 0, max: 10 })).toBe(0);
+    expect(parseStrictNumber("10", { min: 0, max: 10 })).toBe(10);
+  });
+
+  it("大きな整数を正しく処理する", () => {
+    expect(parseStrictNumber("6000")).toBe(6000);
+  });
+});
+
+// ─── 異常系: 空・null・undefined ─────────────────────────────────────────────
+
+describe("parseStrictNumber — 空・null・undefined", () => {
+  it("空文字は null を返す", () => {
+    expect(parseStrictNumber("")).toBeNull();
+  });
+
+  it("空白のみは null を返す", () => {
+    expect(parseStrictNumber("   ")).toBeNull();
+  });
+
+  it("null は null を返す", () => {
+    expect(parseStrictNumber(null)).toBeNull();
+  });
+
+  it("undefined は null を返す", () => {
+    expect(parseStrictNumber(undefined)).toBeNull();
+  });
+});
+
+// ─── 異常系: 部分成功パース ───────────────────────────────────────────────────
+
+describe("parseStrictNumber — 部分成功パースを拒否する", () => {
+  it("\"12abc\" は null を返す (parseFloat なら 12 になる)", () => {
+    expect(parseStrictNumber("12abc")).toBeNull();
+  });
+
+  it("\"1,234\" は null を返す (カンマ区切り)", () => {
+    expect(parseStrictNumber("1,234")).toBeNull();
+  });
+
+  it("\"08kg\" は null を返す (単位付き)", () => {
+    expect(parseStrictNumber("08kg")).toBeNull();
+  });
+
+  it("\"72.5abc\" は null を返す", () => {
+    expect(parseStrictNumber("72.5abc")).toBeNull();
+  });
+
+  it("\"abc\" は null を返す", () => {
+    expect(parseStrictNumber("abc")).toBeNull();
+  });
+});
+
+// ─── 異常系: 記号のみ ─────────────────────────────────────────────────────────
+
+describe("parseStrictNumber — 記号のみは拒否する", () => {
+  it("\".\" は null を返す", () => {
+    expect(parseStrictNumber(".")).toBeNull();
+  });
+
+  it("\"-\" は null を返す", () => {
+    expect(parseStrictNumber("-")).toBeNull();
+  });
+
+  it("\"+\" は null を返す", () => {
+    expect(parseStrictNumber("+")).toBeNull();
+  });
+
+  it("\".5\" は null を返す (小数点のみ先行)", () => {
+    // 整数部必須: `.5` は拒否する
+    expect(parseStrictNumber(".5")).toBeNull();
+  });
+});
+
+// ─── 異常系: 負数の制御 ───────────────────────────────────────────────────────
+
+describe("parseStrictNumber — allowNegative の制御", () => {
+  it("allowNegative デフォルト (false) のとき負数は null を返す", () => {
+    expect(parseStrictNumber("-1")).toBeNull();
+  });
+
+  it("allowNegative: false を明示したとき負数は null を返す", () => {
+    expect(parseStrictNumber("-1", { allowNegative: false })).toBeNull();
+  });
+});
+
+// ─── 異常系: 小数の制御 ───────────────────────────────────────────────────────
+
+describe("parseStrictNumber — allowDecimal の制御", () => {
+  it("allowDecimal: false のとき小数は null を返す", () => {
+    expect(parseStrictNumber("72.5", { allowDecimal: false })).toBeNull();
+  });
+});
+
+// ─── 異常系: 範囲外 ───────────────────────────────────────────────────────────
+
+describe("parseStrictNumber — 範囲外は null を返す", () => {
+  it("min 未満は null", () => {
+    expect(parseStrictNumber("5", { min: 10 })).toBeNull();
+  });
+
+  it("max 超過は null", () => {
+    expect(parseStrictNumber("100", { max: 50 })).toBeNull();
+  });
+
+  it("min と一致する値は通す", () => {
+    expect(parseStrictNumber("10", { min: 10 })).toBe(10);
+  });
+
+  it("max と一致する値は通す", () => {
+    expect(parseStrictNumber("50", { max: 50 })).toBe(50);
+  });
+});

--- a/src/lib/utils/parseNumber.ts
+++ b/src/lib/utils/parseNumber.ts
@@ -1,0 +1,60 @@
+/**
+ * parseNumber.ts — 数値入力の strict parser
+ *
+ * 入力系コードで `parseFloat()` を直接使うと `"12abc"` が `12` に部分成功する。
+ * この関数は完全一致のみを受け入れ、部分成功パースを排除する。
+ *
+ * 対象: UI 入力 / CSV 入力 / 設定保存など、ユーザー起点の文字列を数値に変換する箇所
+ * 非対象: analytics / 表示専用の数値変換（parseFloat を引き続き使用してよい）
+ */
+
+export interface ParseStrictNumberOptions {
+  /** 小数を許可するか (default: true) */
+  allowDecimal?: boolean;
+  /** 負数を許可するか (default: false) */
+  allowNegative?: boolean;
+  /** 最小値。範囲外は null を返す */
+  min?: number;
+  /** 最大値。範囲外は null を返す */
+  max?: number;
+}
+
+/**
+ * 厳格な数値パーサー。
+ *
+ * - 空文字 / null / undefined → null（「未入力」扱い）
+ * - 前後空白は trim して処理する
+ * - 数字列・符号・小数点のみからなる文字列のみ受け入れる
+ * - `"12abc"` `"1,234"` `"08kg"` `"."` `"-"` はすべて null
+ * - `"72"` `"72.5"` `"0"` は正常に数値を返す
+ * - `-1` は `allowNegative: true` のときのみ許可
+ * - 範囲外は null を返す（min / max を指定した場合）
+ */
+export function parseStrictNumber(
+  input: string | null | undefined,
+  options: ParseStrictNumberOptions = {}
+): number | null {
+  const { allowDecimal = true, allowNegative = false, min, max } = options;
+
+  if (input == null) return null;
+  const trimmed = input.trim();
+  if (trimmed === "") return null;
+
+  const pattern = allowDecimal
+    ? allowNegative
+      ? /^-?\d+(\.\d+)?$/
+      : /^\d+(\.\d+)?$/
+    : allowNegative
+      ? /^-?\d+$/
+      : /^\d+$/;
+
+  if (!pattern.test(trimmed)) return null;
+
+  const n = Number(trimmed);
+  if (!Number.isFinite(n)) return null;
+
+  if (min !== undefined && n < min) return null;
+  if (max !== undefined && n > max) return null;
+
+  return n;
+}


### PR DESCRIPTION
## 概要

数値入力の解釈を共通の strict parser に統一する。`parseFloat()` の直接使用を入力系コードから除去し、`"12abc"` `"1,234"` `"08kg"` などが静かに通らないようにする。

Closes #116

## 変更内容

### 追加: `src/lib/utils/parseNumber.ts`
- `parseStrictNumber(input, options?)` を定義
- 正規表現で完全一致のみ受け入れ（部分成功パースを排除）
- オプション: `allowDecimal` (default: true) / `allowNegative` (default: false) / `min` / `max`

### 追加: `src/lib/utils/parseNumber.test.ts`
- 30 件のユニットテスト（正常系・空・null・undefined・部分成功・記号のみ・範囲外）

### 置換した `parseFloat()` 利用箇所（入力系）
| ファイル | 概要 |
|---|---|
| `csvParser.ts` | `parseNum` 内の `parseFloat` を `parseStrictNumber` に置換 |
| `settingsSchema.ts` | 数値設定フィールドのバリデーション |
| `normalizeSettingField.ts` | 設定フィールドの正規化（現在未使用だが整合のため修正） |
| `MealLogger.tsx` | weight / sleep_hours の保存時変換 |
| `FoodTable.tsx` | 食品追加フォームの validation + payload 構築 |
| `MonthlyGoalPlanSection.tsx` | 月次目標体重 commit 時の変換 |

### 変更なし（表示専用ロジック）
- `SettingsForm.tsx` の `calcPfcDerivedKcal` / `pfcConsistencyWarning` / `goal_weight` 表示 — スコープ外

## strict parser 導入理由

`parseFloat("12abc")` は `12` を返す。入力系コードがこれを直接使うと、ユーザーの誤入力（単位付き・カンマ区切り・混在文字列）が静かに通って DB に保存される。共通 parser を定義し、完全一致判定のみに統一することで保存系の信頼性を上げる。

## 影響範囲

- **既存の正常入力は全て通る**: `"72"` `"72.5"` `"0"` `"7.5"` 等
- **新たに拒否される入力**: `"12abc"` `"1,234"` `"08kg"` `".5"` `"-5"`（設定値）など
- **挙動が変わる具体ケース**:
  - 設定画面で `-5` を goal_weight に入力 → 従来「範囲外」エラー → 新「数値でない」エラー（より適切）
  - CSV に `"65.0abc"` のような値 → 従来 `65.0` として取り込まれる → 新 `null`（スキップ）

## テスト

- 新規: `parseNumber.test.ts` 30 件
- 更新: `settingsSchema.test.ts` 1 件（負数のエラーメッセージを「数値でない」に変更。意図的な変更）
- 既存: 825 件すべて継続 pass（合計 856 件）

## 補足

- `normalizeSettingField.ts` は現在 `SettingsForm` から import されていない（dead code）が、ファイルとして残存しているため一貫性のために修正
- `SettingsForm.tsx` の表示計算用 `parseFloat`（PFC kcal 警告・goal_weight 表示）は今回スコープ外。別 issue が必要な場合は分離して対応すること