### PR TITLE
refactor: unify query layer error returns with QueryResult

### DIFF
--- a/src/app/foods/page.tsx
+++ b/src/app/foods/page.tsx
@@ -5,14 +5,25 @@ import { fetchFoods, fetchMenus } from "@/lib/queries/foods";
 export const revalidate = 0;
 
 export default async function FoodsPage() {
-  const [foods, menus] = await Promise.all([fetchFoods(), fetchMenus()]);
+  const [foodsResult, menusResult] = await Promise.all([fetchFoods(), fetchMenus()]);
+
+  if (foodsResult.kind === "error" || menusResult.kind === "error") {
+    return (
+      <main className="min-h-screen bg-gray-50 p-6">
+        <h1 className="mb-6 text-xl font-bold text-gray-800">食品データベース</h1>
+        <div className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+          食品データベースの取得に失敗しました。しばらく経ってから再度お試しください。
+        </div>
+      </main>
+    );
+  }
 
   return (
     <main className="min-h-screen bg-gray-50 p-6">
       <h1 className="mb-6 text-xl font-bold text-gray-800">食品データベース</h1>
       <div className="space-y-8">
-        <FoodTable initialFoods={foods} />
-        <MenuTable initialMenus={menus} foods={foods} />
+        <FoodTable initialFoods={foodsResult.data} />
+        <MenuTable initialMenus={menusResult.data} foods={foodsResult.data} />
       </div>
     </main>
   );

--- a/src/app/forecast-accuracy/page.tsx
+++ b/src/app/forecast-accuracy/page.tsx
@@ -9,7 +9,23 @@ export const revalidate = 3600; // 1時間キャッシュ (バッチは週1回)
 // ─── ページ ──────────────────────────────────────────────────────────────────
 
 export default async function ForecastAccuracyPage() {
-  const { dailyRun, sma7Run } = await fetchLatestRuns();
+  const runsResult = await fetchLatestRuns();
+
+  if (runsResult.kind === "error") {
+    return (
+      <main className="min-h-screen bg-gray-50 p-6">
+        <div className="flex items-center gap-2 mb-6">
+          <BarChart2 size={20} className="text-blue-600" />
+          <h1 className="text-xl font-bold text-gray-800">予測精度評価</h1>
+        </div>
+        <div className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+          バックテストデータの取得に失敗しました。しばらく経ってから再度お試しください。
+        </div>
+      </main>
+    );
+  }
+
+  const { dailyRun, sma7Run } = runsResult.data;
 
   // 両方ともデータなし
   if (!dailyRun && !sma7Run) {
@@ -44,10 +60,13 @@ export default async function ForecastAccuracyPage() {
   }
 
   // metrics を並列取得
-  const [dailyMetrics, sma7Metrics] = await Promise.all([
-    dailyRun ? fetchMetrics(dailyRun.id) : Promise.resolve([]),
-    sma7Run ? fetchMetrics(sma7Run.id) : Promise.resolve([]),
+  const [dailyMetricsResult, sma7MetricsResult] = await Promise.all([
+    dailyRun ? fetchMetrics(dailyRun.id) : Promise.resolve({ kind: "ok" as const, data: [] }),
+    sma7Run ? fetchMetrics(sma7Run.id) : Promise.resolve({ kind: "ok" as const, data: [] }),
   ]);
+
+  const dailyMetrics = dailyMetricsResult.kind === "ok" ? dailyMetricsResult.data : [];
+  const sma7Metrics = sma7MetricsResult.kind === "ok" ? sma7MetricsResult.data : [];
 
   return (
     <main className="min-h-screen bg-gray-50 p-6">
@@ -66,7 +85,7 @@ export default async function ForecastAccuracyPage() {
         />
 
         {/* ── 単日評価の詳細 (既存) ── */}
-        {dailyRun && dailyMetrics.length > 0 ? (
+        {dailyRun && dailyMetricsResult.kind === "ok" && dailyMetrics.length > 0 ? (
           <div>
             <h2 className="mb-3 text-sm font-bold text-slate-600">
               単日体重ベース評価
@@ -76,6 +95,10 @@ export default async function ForecastAccuracyPage() {
             </h2>
             <BacktestResults run={dailyRun} metrics={dailyMetrics} />
           </div>
+        ) : dailyRun && dailyMetricsResult.kind === "error" ? (
+          <div className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+            単日評価: 指標データの取得に失敗しました。
+          </div>
         ) : dailyRun ? (
           <div className="rounded-xl border border-dashed border-slate-300 bg-white p-6 text-center text-sm text-slate-500">
             単日評価: バックテスト実行は記録されていますが、指標データが見つかりませんでした。
@@ -83,7 +106,7 @@ export default async function ForecastAccuracyPage() {
         ) : null}
 
         {/* ── 7日平均評価の詳細 (新セクション) ── */}
-        {sma7Run && sma7Metrics.length > 0 ? (
+        {sma7Run && sma7MetricsResult.kind === "ok" && sma7Metrics.length > 0 ? (
           <div>
             <h2 className="mb-3 text-sm font-bold text-slate-600">
               7日平均体重ベース評価
@@ -95,6 +118,10 @@ export default async function ForecastAccuracyPage() {
               </span>
             </h2>
             <BacktestResults run={sma7Run} metrics={sma7Metrics} />
+          </div>
+        ) : sma7Run && sma7MetricsResult.kind === "error" ? (
+          <div className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+            7日平均評価: 指標データの取得に失敗しました。
           </div>
         ) : sma7Run ? (
           <div className="rounded-xl border border-dashed border-slate-300 bg-white p-6 text-center text-sm text-slate-500">

--- a/src/lib/queries/backtest.test.ts
+++ b/src/lib/queries/backtest.test.ts
@@ -1,0 +1,145 @@
+/**
+ * backtest query layer テスト
+ *
+ * Supabase client をモックして、fetchLatestRuns / fetchMetrics の
+ * 成功・空・エラーケースを検証する。
+ */
+
+import { fetchLatestRuns, fetchMetrics } from "./backtest";
+
+// ── Mock ──────────────────────────────────────────────────────────────────────
+
+const mockLimit = jest.fn();
+const mockOrder = jest.fn();
+const mockEq = jest.fn();
+const mockSelect = jest.fn();
+const mockFrom = jest.fn();
+
+jest.mock("@/lib/supabase/server", () => ({
+  createClient: () => ({ from: mockFrom }),
+}));
+
+type ChainResult = { data: unknown; error: unknown };
+
+// ── fetchLatestRuns ───────────────────────────────────────────────────────────
+
+describe("fetchLatestRuns", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  function setupRunsChain(result: ChainResult) {
+    mockLimit.mockReturnValue(Promise.resolve(result));
+    mockOrder.mockReturnValue({ limit: mockLimit });
+    mockSelect.mockReturnValue({ order: mockOrder });
+    mockFrom.mockReturnValue({ select: mockSelect });
+  }
+
+  it("正常系: kind=ok で dailyRun / sma7Run を返す", async () => {
+    const rows = [
+      { id: "run-1", config: { series_type: "daily" }, created_at: "2026-03-01T00:00:00Z" },
+      { id: "run-2", config: { series_type: "sma7" },  created_at: "2026-03-01T00:00:00Z" },
+    ];
+    setupRunsChain({ data: rows, error: null });
+    const result = await fetchLatestRuns();
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.data.dailyRun?.id).toBe("run-1");
+      expect(result.data.sma7Run?.id).toBe("run-2");
+    }
+  });
+
+  it("正常系: series_type なしの run は daily として扱う", async () => {
+    const rows = [
+      { id: "run-legacy", config: {}, created_at: "2026-03-01T00:00:00Z" },
+    ];
+    setupRunsChain({ data: rows, error: null });
+    const result = await fetchLatestRuns();
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.data.dailyRun?.id).toBe("run-legacy");
+      expect(result.data.sma7Run).toBeNull();
+    }
+  });
+
+  it("正常系: データが空のとき kind=ok で dailyRun / sma7Run が null", async () => {
+    setupRunsChain({ data: [], error: null });
+    const result = await fetchLatestRuns();
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.data.dailyRun).toBeNull();
+      expect(result.data.sma7Run).toBeNull();
+    }
+  });
+
+  it("正常系: データが null のとき kind=ok で dailyRun / sma7Run が null", async () => {
+    setupRunsChain({ data: null, error: null });
+    const result = await fetchLatestRuns();
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.data.dailyRun).toBeNull();
+      expect(result.data.sma7Run).toBeNull();
+    }
+  });
+
+  it("異常系: DB エラーのとき kind=error を返す（null フォールバックしない）", async () => {
+    setupRunsChain({ data: null, error: { message: "connection error" } });
+    const result = await fetchLatestRuns();
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.message).toBe("connection error");
+    }
+  });
+});
+
+// ── fetchMetrics ──────────────────────────────────────────────────────────────
+
+describe("fetchMetrics", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  function setupMetricsChain(result: ChainResult) {
+    mockOrder.mockReturnValue(Promise.resolve(result));
+    mockEq.mockReturnValue({ order: mockOrder });
+    mockSelect.mockReturnValue({ eq: mockEq });
+    mockFrom.mockReturnValue({ select: mockSelect });
+  }
+
+  it("正常系: kind=ok でメトリクス配列を返す", async () => {
+    const rows = [
+      { id: "m-1", run_id: "run-1", horizon_days: 7, mae: 0.42, rmse: 0.55 },
+      { id: "m-2", run_id: "run-1", horizon_days: 14, mae: 0.58, rmse: 0.71 },
+    ];
+    setupMetricsChain({ data: rows, error: null });
+    const result = await fetchMetrics("run-1");
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.data).toHaveLength(2);
+      expect(result.data[0].horizon_days).toBe(7);
+    }
+  });
+
+  it("正常系: データが null のとき kind=ok で空配列を返す", async () => {
+    setupMetricsChain({ data: null, error: null });
+    const result = await fetchMetrics("run-1");
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.data).toEqual([]);
+    }
+  });
+
+  it("正常系: 指標データ未生成のとき kind=ok で空配列（正常な空状態）", async () => {
+    setupMetricsChain({ data: [], error: null });
+    const result = await fetchMetrics("run-1");
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.data).toEqual([]);
+    }
+  });
+
+  it("異常系: DB エラーのとき kind=error を返す（空配列フォールバックしない）", async () => {
+    setupMetricsChain({ data: null, error: { message: "DB error" } });
+    const result = await fetchMetrics("run-1");
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.message).toBe("DB error");
+    }
+  });
+});

--- a/src/lib/queries/backtest.ts
+++ b/src/lib/queries/backtest.ts
@@ -9,6 +9,7 @@
  */
 import { createClient } from "@/lib/supabase/server";
 import type { ForecastBacktestRun, ForecastBacktestMetric, Json } from "@/lib/supabase/types";
+import type { QueryResult } from "./queryResult";
 
 /**
  * config.series_type を安全に読み出す。
@@ -27,12 +28,16 @@ function getSeriesType(run: ForecastBacktestRun): string {
  * 最新 20 件の run を取得し、daily / sma7 それぞれの最新 run を返す。
  * 旧来の run (config.series_type なし) は daily として扱う。
  *
- * フォールバック: エラー時は { dailyRun: null, sma7Run: null } を返す。
+ * 戻り値:
+ *   kind: "ok"    — 取得成功。dailyRun / sma7Run が null = バックテスト未実行（正常な空状態）。
+ *   kind: "error" — DB フェッチ失敗。呼び出し側で error banner を表示すること。
+ *
+ * エラー時に null を返すと「バックテスト未実行」と誤表示されるため QueryResult を使用する。
  */
-export async function fetchLatestRuns(): Promise<{
+export async function fetchLatestRuns(): Promise<QueryResult<{
   dailyRun: ForecastBacktestRun | null;
   sma7Run: ForecastBacktestRun | null;
-}> {
+}>> {
   const supabase = createClient();
   const { data, error } = await supabase
     .from("forecast_backtest_runs")
@@ -41,23 +46,28 @@ export async function fetchLatestRuns(): Promise<{
     .limit(20);
 
   if (error) {
-    console.error("forecast_backtest_runs fetch error:", error.message);
-    return { dailyRun: null, sma7Run: null };
+    console.error("[fetchLatestRuns] forecast_backtest_runs fetch error:", error.message);
+    return { kind: "error", message: error.message };
   }
 
   const runs = (data as ForecastBacktestRun[]) ?? [];
   const dailyRun = runs.find((r) => getSeriesType(r) === "daily") ?? null;
   const sma7Run = runs.find((r) => getSeriesType(r) === "sma7") ?? null;
 
-  return { dailyRun, sma7Run };
+  return { kind: "ok", data: { dailyRun, sma7Run } };
 }
 
 /**
  * 指定 run_id のメトリクスを horizon_days 昇順で取得する。
  *
- * フォールバック: エラー時は空配列を返す。
+ * 戻り値:
+ *   kind: "ok"    — 取得成功。data が空配列 = 指標データ未生成（正常な空状態）。
+ *   kind: "error" — DB フェッチ失敗。呼び出し側で error banner を表示すること。
+ *
+ * run の存在は fetchLatestRuns で確認済みのうえで呼ばれるため、
+ * エラー時に空配列を返すと「指標データが見つかりませんでした」と誤表示されるおそれがある。
  */
-export async function fetchMetrics(runId: string): Promise<ForecastBacktestMetric[]> {
+export async function fetchMetrics(runId: string): Promise<QueryResult<ForecastBacktestMetric[]>> {
   const supabase = createClient();
   const { data, error } = await supabase
     .from("forecast_backtest_metrics")
@@ -65,8 +75,8 @@ export async function fetchMetrics(runId: string): Promise<ForecastBacktestMetri
     .eq("run_id", runId)
     .order("horizon_days", { ascending: true });
   if (error) {
-    console.error("forecast_backtest_metrics fetch error:", error.message);
-    return [];
+    console.error("[fetchMetrics] forecast_backtest_metrics fetch error:", error.message);
+    return { kind: "error", message: error.message };
   }
-  return (data as ForecastBacktestMetric[]) ?? [];
+  return { kind: "ok", data: (data as ForecastBacktestMetric[]) ?? [] };
 }

--- a/src/lib/queries/foods.test.ts
+++ b/src/lib/queries/foods.test.ts
@@ -1,0 +1,122 @@
+/**
+ * foods query layer テスト
+ *
+ * Supabase client をモックして、fetchFoods / fetchMenus の
+ * 成功・空・エラーケースを検証する。
+ */
+
+import { fetchFoods, fetchMenus } from "./foods";
+
+// ── Mock ──────────────────────────────────────────────────────────────────────
+
+const mockOrder = jest.fn();
+const mockSelect = jest.fn();
+const mockFrom = jest.fn();
+
+jest.mock("@/lib/supabase/server", () => ({
+  createClient: () => ({ from: mockFrom }),
+}));
+
+type ChainResult = { data: unknown; error: unknown };
+
+function setupChain(result: ChainResult) {
+  const terminal = Promise.resolve(result);
+  mockOrder.mockReturnValue(terminal);
+  mockSelect.mockReturnValue({ order: mockOrder });
+  mockFrom.mockReturnValue({ select: mockSelect });
+}
+
+// ── fetchFoods ────────────────────────────────────────────────────────────────
+
+describe("fetchFoods", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("正常系: kind=ok で FoodMaster[] を返す", async () => {
+    const rows = [
+      { name: "鶏むね肉", calories: 108, protein: 22.3, fat: 1.5, carbs: 0, category: "肉類" },
+      { name: "卵", calories: 151, protein: 12.3, fat: 10.3, carbs: 0.3, category: "卵・乳製品" },
+    ];
+    setupChain({ data: rows, error: null });
+    const result = await fetchFoods();
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.data).toHaveLength(2);
+      expect(result.data[0].name).toBe("鶏むね肉");
+    }
+  });
+
+  it("正常系: データが null のとき kind=ok で空配列を返す", async () => {
+    setupChain({ data: null, error: null });
+    const result = await fetchFoods();
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.data).toEqual([]);
+    }
+  });
+
+  it("正常系: 空配列のとき kind=ok で空配列を返す（食品未登録 = 正常な空状態）", async () => {
+    setupChain({ data: [], error: null });
+    const result = await fetchFoods();
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.data).toEqual([]);
+    }
+  });
+
+  it("異常系: DB エラーのとき kind=error を返す（空配列フォールバックしない）", async () => {
+    setupChain({ data: null, error: { message: "connection error" } });
+    const result = await fetchFoods();
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.message).toBe("connection error");
+    }
+  });
+});
+
+// ── fetchMenus ────────────────────────────────────────────────────────────────
+
+describe("fetchMenus", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("正常系: kind=ok で MenuEntry[] を返す", async () => {
+    const rows = [
+      { name: "鶏むね肉定食", recipe: [{ food_name: "鶏むね肉", grams: 200 }] },
+    ];
+    setupChain({ data: rows, error: null });
+    const result = await fetchMenus();
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].name).toBe("鶏むね肉定食");
+      expect(result.data[0].recipe).toHaveLength(1);
+    }
+  });
+
+  it("正常系: recipe が非配列のとき空配列にフォールバックする", async () => {
+    const rows = [{ name: "不正メニュー", recipe: null }];
+    setupChain({ data: rows, error: null });
+    const result = await fetchMenus();
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.data[0].recipe).toEqual([]);
+    }
+  });
+
+  it("正常系: データが null のとき kind=ok で空配列を返す", async () => {
+    setupChain({ data: null, error: null });
+    const result = await fetchMenus();
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.data).toEqual([]);
+    }
+  });
+
+  it("異常系: DB エラーのとき kind=error を返す（空配列フォールバックしない）", async () => {
+    setupChain({ data: null, error: { message: "DB error" } });
+    const result = await fetchMenus();
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.message).toBe("DB error");
+    }
+  });
+});

--- a/src/lib/queries/foods.ts
+++ b/src/lib/queries/foods.ts
@@ -10,42 +10,55 @@
 import { createClient } from "@/lib/supabase/server";
 import type { FoodMaster, RecipeItem } from "@/lib/supabase/types";
 import type { MenuEntry } from "@/lib/hooks/useMenuList";
+import type { QueryResult } from "./queryResult";
 
 /**
  * food_master を全件・名前昇順で取得する。
  *
- * フォールバック: エラー時は空配列を返す。
+ * 戻り値:
+ *   kind: "ok"    — 取得成功。data が空配列 = 食品未登録（正常な空状態）。
+ *   kind: "error" — DB フェッチ失敗。呼び出し側で error banner を表示すること。
+ *
+ * foods/page.tsx の主データ。エラー時に空配列を返すと
+ * 「食品が登録されていません」と誤表示されるため QueryResult を使用する。
  */
-export async function fetchFoods(): Promise<FoodMaster[]> {
+export async function fetchFoods(): Promise<QueryResult<FoodMaster[]>> {
   const supabase = createClient();
   const { data, error } = await supabase
     .from("food_master")
     .select("*")
     .order("name", { ascending: true });
   if (error) {
-    console.error("food_master fetch error:", error.message);
-    return [];
+    console.error("[fetchFoods] food_master fetch error:", error.message);
+    return { kind: "error", message: error.message };
   }
-  return (data as FoodMaster[]) ?? [];
+  return { kind: "ok", data: (data as FoodMaster[]) ?? [] };
 }
 
 /**
  * menu_master を全件・名前昇順で取得し、MenuEntry 形式に変換する。
  *
- * フォールバック: エラー時は空配列を返す。
+ * 戻り値:
+ *   kind: "ok"    — 取得成功。data が空配列 = メニュー未登録（正常な空状態）。
+ *   kind: "error" — DB フェッチ失敗。呼び出し側で error banner を表示すること。
+ *
+ * foods/page.tsx の主データ。fetchFoods と同一ページで使うため同水準のエラー処理を持つ。
  */
-export async function fetchMenus(): Promise<MenuEntry[]> {
+export async function fetchMenus(): Promise<QueryResult<MenuEntry[]>> {
   const supabase = createClient();
   const { data, error } = await supabase
     .from("menu_master")
     .select("name, recipe")
     .order("name", { ascending: true });
   if (error) {
-    console.error("menu_master fetch error:", error.message);
-    return [];
+    console.error("[fetchMenus] menu_master fetch error:", error.message);
+    return { kind: "error", message: error.message };
   }
-  return ((data as Array<{ name: string; recipe: unknown }>) ?? []).map((row) => ({
-    name: row.name,
-    recipe: Array.isArray(row.recipe) ? (row.recipe as RecipeItem[]) : [],
-  }));
+  return {
+    kind: "ok",
+    data: ((data as Array<{ name: string; recipe: unknown }>) ?? []).map((row) => ({
+      name: row.name,
+      recipe: Array.isArray(row.recipe) ? (row.recipe as RecipeItem[]) : [],
+    })),
+  };
 }

--- a/src/lib/queries/queryResult.ts
+++ b/src/lib/queries/queryResult.ts
@@ -14,6 +14,10 @@
  *   - fetchCareerLogs           (career_logs — history ページ主データ)
  *   - fetchSettings             (settings → AppSettings 変換)
  *   - fetchSettingsRows         (settings 行配列 — SettingsForm 用)
+ *   - fetchFoods                (food_master — foods ページ主データ)
+ *   - fetchMenus                (menu_master — foods ページ主データ)
+ *   - fetchLatestRuns           (forecast_backtest_runs — 予測精度ページ主データ)
+ *   - fetchMetrics              (forecast_backtest_metrics — 予測精度ページ主データ)
  *
  * ベストエフォート (空配列フォールバックで graceful degradation が成立する補助クエリ):
  *   - fetchWeightLogs / fetchCareerLogsForDashboard / fetchPredictions


### PR DESCRIPTION
## 概要

query layer の戻り値契約を統一し、DB エラーと正常な空状態（データ未登録）を区別できるようにする。

Closes #117

## 変更内容

### `src/lib/queries/foods.ts`
- `fetchFoods()` / `fetchMenus()` の戻り値を空配列フォールバックから `QueryResult<T>` に変更
- 食品ページは主データ管理画面であり、DB エラーを「食品未登録」と誤表示しないようにする

### `src/lib/queries/backtest.ts`
- `fetchLatestRuns()` / `fetchMetrics()` の戻り値を同様に `QueryResult<T>` に変更
- DB エラーを「バックテスト未実行」や「指標データが見つかりません」と誤表示しないようにする

### `src/lib/queries/queryResult.ts`
- JSDoc の使用関数一覧に今回追加した 4 関数を追記

### `src/app/foods/page.tsx`
- `QueryResult` の `kind` で分岐し、`error` 時にエラーバナーを表示
- `ok` 時は従来通り `FoodTable` / `MenuTable` に data を渡す

### `src/app/forecast-accuracy/page.tsx`
- `fetchLatestRuns()` の `error` 時にエラーページを表示
- `fetchMetrics()` の `error` 時にセクション単位でエラーバナーを表示（他セクションはブロックしない）

### テスト追加
- `src/lib/queries/foods.test.ts` — 8 件（正常系・空状態・エラー系）
- `src/lib/queries/backtest.test.ts` — 9 件（同上 + series_type なし run の扱い）

## QueryResult 統一方針

| 関数 | 変更前 | 変更後 | 理由 |
|---|---|---|---|
| `fetchFoods` | `FoodMaster[]`（エラー→`[]`） | `QueryResult<FoodMaster[]>` | 食品ページ主データ |
| `fetchMenus` | `MenuEntry[]`（エラー→`[]`） | `QueryResult<MenuEntry[]>` | 同上 |
| `fetchLatestRuns` | `{dailyRun,sma7Run}`（エラー→null） | `QueryResult<{...}>` | backtest ページ主データ |
| `fetchMetrics` | `ForecastBacktestMetric[]`（エラー→`[]`） | `QueryResult<T>` | 同上 |

## empty / error 分岐の整理

- **empty state**（`kind: "ok"` + data 空）: 正常な「未登録」「未実行」として扱う
- **error state**（`kind: "error"`）: DB 接続失敗などの異常として rose 系バナーを表示

## 例外を残した箇所と理由

以下は今回も空配列フォールバックを維持する。既存 JSDoc に理由を明記済み。
- `fetchWeightLogs` — history ページ補助データ。空でも主要機能は維持される
- `fetchCareerLogsForDashboard` — シーズンバッジ補助表示
- `fetchPredictions` — ForecastChart 補助。ML バッチ未実行の空状態と区別不要
- `fetchMacroTargets` — 目標未設定として扱えば十分

## テスト

全 873 件 pass（新規 17 件追加）

## 補足

- `fetchMetrics` は `fetchLatestRuns` で run の存在を確認してから呼ばれるため、エラーと空は意味が異なる
- `forecast-accuracy/page.tsx` では metrics エラーはセクション単位で表示し、他のセクションをブロックしない設計