### PR TITLE
refactor: centralize revalidatePath invalidation by mutation responsibility

### DIFF
--- a/src/app/actions/saveDailyLog.ts
+++ b/src/app/actions/saveDailyLog.ts
@@ -1,7 +1,7 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
+import { revalidateAfterDailyLogMutation } from "@/lib/cache/revalidate";
 import { isValidTrainingType, isValidWorkMode } from "@/lib/utils/trainingType";
 import { buildUpdatePayload } from "./buildUpdatePayload";
 import { parseLocalDateStr } from "@/lib/utils/date";
@@ -130,10 +130,7 @@ export async function saveDailyLog(
   }
 
   // --- On-demand revalidation ---
-  revalidatePath("/");
-  revalidatePath("/history");
-  revalidatePath("/macro");
-  revalidatePath("/tdee");
+  revalidateAfterDailyLogMutation();
 
   return { ok: true };
 }

--- a/src/app/forecast-accuracy/actions.ts
+++ b/src/app/forecast-accuracy/actions.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
+import { revalidateAfterForecastMutation } from "@/lib/cache/revalidate";
 
 /**
  * 保存済みバックテスト結果を即時反映するための再検証アクション。
@@ -9,5 +9,5 @@ import { revalidatePath } from "next/cache";
  * 通常運用は revalidate = 3600 で十分だが、バッチ実行直後の確認時に利用する。
  */
 export async function revalidateForecastAccuracy(): Promise<void> {
-  revalidatePath("/forecast-accuracy");
+  revalidateAfterForecastMutation();
 }

--- a/src/app/settings/actions.ts
+++ b/src/app/settings/actions.ts
@@ -7,8 +7,8 @@
  * バリデーションは src/lib/schemas/settingsSchema.ts の parseSettings に委譲する。
  */
 
-import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
+import { revalidateAfterSettingsMutation } from "@/lib/cache/revalidate";
 import { parseSettings } from "@/lib/schemas/settingsSchema";
 import type { SettingsInput } from "@/lib/schemas/settingsSchema";
 
@@ -45,11 +45,7 @@ export async function saveSettings(
   }
 
   // 3. On-demand revalidation（設定依存ページのキャッシュを破棄）
-  revalidatePath("/");
-  revalidatePath("/history");
-  revalidatePath("/macro");
-  revalidatePath("/tdee");
-  revalidatePath("/settings");
+  revalidateAfterSettingsMutation();
 
   return { ok: true };
 }

--- a/src/lib/cache/revalidate.ts
+++ b/src/lib/cache/revalidate.ts
@@ -1,0 +1,67 @@
+/**
+ * revalidate.ts — キャッシュ再検証の集約モジュール
+ *
+ * Next.js の revalidatePath() 呼び出しをここに集約し、
+ * 各 Server Action がバラバラに path 列挙するのを防ぐ。
+ *
+ * ## 使い方
+ * Server Action の保存処理が成功した直後に、対応する関数を呼ぶ。
+ *
+ * ## 将来の revalidateTag() 移行に向けた設計
+ * 現在は revalidatePath() ベースだが、fetch 側にキャッシュタグを付与したときは
+ * 各関数内の実装を revalidateTag() に差し替えるだけで移行できる。
+ * 呼び出し側 (Server Action) は変更不要。
+ *
+ * ## ページ依存マップ (更新種別 → 影響ページ)
+ *
+ * daily_logs 更新:
+ *   /             fetchDailyLogs / fetchEnrichedLogs
+ *   /history      fetchWeightLogs
+ *   /macro        fetchDailyLogs / fetchFactorAnalysis
+ *   /tdee         fetchDailyLogs / fetchEnrichedLogs
+ *   /settings     fetchDailyLogsForSettings (データ品質セクション)
+ *
+ * settings 更新:
+ *   /             fetchSettings
+ *   /history      fetchSettings
+ *   /macro        fetchSettings / fetchMacroTargets
+ *   /tdee         fetchSettings
+ *   /settings     fetchSettingsRows
+ *
+ * forecast backtest 更新:
+ *   /forecast-accuracy  fetchLatestRuns / fetchMetrics
+ */
+
+import { revalidatePath } from "next/cache";
+
+/**
+ * daily_logs への書き込み後に呼ぶ。
+ * daily_logs データを参照するすべてのページを再検証する。
+ */
+export function revalidateAfterDailyLogMutation(): void {
+  revalidatePath("/");
+  revalidatePath("/history");
+  revalidatePath("/macro");
+  revalidatePath("/tdee");
+  revalidatePath("/settings"); // fetchDailyLogsForSettings (データ品質セクション)
+}
+
+/**
+ * settings への書き込み後に呼ぶ。
+ * settings データを参照するすべてのページを再検証する。
+ */
+export function revalidateAfterSettingsMutation(): void {
+  revalidatePath("/");
+  revalidatePath("/history");
+  revalidatePath("/macro");
+  revalidatePath("/tdee");
+  revalidatePath("/settings");
+}
+
+/**
+ * forecast backtest データの更新後に呼ぶ。
+ * バックテスト結果を表示するページを再検証する。
+ */
+export function revalidateAfterForecastMutation(): void {
+  revalidatePath("/forecast-accuracy");
+}


### PR DESCRIPTION
## 概要

`revalidatePath()` の呼び出しを各 Server Action から切り離し、`src/lib/cache/revalidate.ts` に更新種別ごとの名前付き関数として集約する。あわせて `saveDailyLog` で `/settings` への再検証が漏れていたバグを修正する。

Closes #118

## 変更内容

### 追加: `src/lib/cache/revalidate.ts`
- `revalidateAfterDailyLogMutation()` — daily_logs 更新後に呼ぶ（5 ページ）
- `revalidateAfterSettingsMutation()` — settings 更新後に呼ぶ（5 ページ）
- `revalidateAfterForecastMutation()` — backtest 更新後に呼ぶ（1 ページ）
- ファイル冒頭にページ依存マップ（更新種別 → 影響ページ → 参照 fetch 関数）を記述

### 修正: `src/app/actions/saveDailyLog.ts`
- `revalidatePath()` 4 行を `revalidateAfterDailyLogMutation()` 1 行に置換

### 修正: `src/app/settings/actions.ts`
- `revalidatePath()` 5 行を `revalidateAfterSettingsMutation()` 1 行に置換

### 修正: `src/app/forecast-accuracy/actions.ts`
- `revalidatePath()` 1 行を `revalidateAfterForecastMutation()` 1 行に置換

## invalidate 責務の整理方針

| 更新種別 | 対象ページ | 理由 |
|---|---|---|
| daily_logs | `/` `/history` `/macro` `/tdee` `/settings` | 各ページが fetchDailyLogs / fetchWeightLogs / fetchDailyLogsForSettings を呼ぶ |
| settings | `/` `/history` `/macro` `/tdee` `/settings` | 各ページが fetchSettings / fetchSettingsRows / fetchMacroTargets を呼ぶ |
| forecast | `/forecast-accuracy` | fetchLatestRuns / fetchMetrics を呼ぶ |

## バグ修正: `/settings` の反映漏れ

`saveDailyLog` は従来 `/settings` を invalidate していなかった。settings ページは `fetchDailyLogsForSettings` でデータ品質セクションを描画するため、daily log 更新後に設定ページを開いても古いデータが表示されていた。今回の集約で修正済み。

## 将来の revalidateTag() 移行に向けた設計

- 呼び出し側 (Server Action) は責務関数名だけを知っていればよく、内部が path か tag かを意識しない
- `revalidate.ts` の各関数内の `revalidatePath()` を `revalidateTag()` に差し替えるだけで移行可能
- fetch 側へのタグ付与は今回のスコープ外だが、移行時の変更範囲を最小化できる構造になっている

## テスト

873 件全 pass（既存テストに変化なし）

## 補足

- `ForecastAccuracyRefreshButton.tsx` のコメントに `revalidatePath` という文字列があるが JSDoc コメントのため変更対象外