### PR TITLE
test: add minimal e2e coverage for core user flows (#122)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,48 @@
+name: E2E Smoke Tests
+
+# 手動トリガーのみ。PR ゲートには含めない（ブラウザ起動コストのため）。
+# 主要ページ表示の smoke tests を chromium で実行する。
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  e2e-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium --with-deps
+
+      - name: Build
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+        run: npm run build
+
+      - name: Run smoke tests
+        env:
+          CI: true
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+        run: npm run e2e:smoke
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,7 @@ supabase/.temp/
 
 # Vercel
 .vercel
+
+# Playwright
+/playwright-report/
+/test-results/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,61 @@ CI uses **Node 20 LTS** (`node-version: "20"` in `.github/workflows/ci.yml`).
 A `.nvmrc` is provided — run `nvm use` to switch automatically if you use nvm.
 `package.json` declares `engines: { "node": ">=20" }` as the minimum.
 
+## E2E Tests (Playwright)
+
+E2E テストは Playwright (Chromium) で実装している。
+
+### テスト種別
+
+| ファイル | 内容 | CI |
+|---|---|---|
+| `e2e/smoke.spec.ts` | 主要ページ表示確認 (読み取り専用) | 手動トリガー (`e2e.yml`) |
+| `e2e/write-flows.spec.ts` | 保存系フロー (日次ログ / 設定) | スキップ (要テスト環境) |
+
+### ローカル実行手順
+
+1. 初回のみ: Playwright ブラウザをインストール
+
+   ```bash
+   npx playwright install chromium
+   ```
+
+2. 開発サーバーが起動していることを確認 (未起動ならコマンドが自動起動する)
+
+3. Smoke tests を実行
+
+   ```bash
+   npm run e2e:smoke
+   # または全テスト
+   npm run e2e
+   ```
+
+4. UI モードで実行 (デバッグ向け)
+
+   ```bash
+   npm run e2e:ui
+   ```
+
+### Write tests の実行
+
+Write tests は本番 DB への書き込みを防ぐため**デフォルトでスキップ**する。
+
+実行するには、**テスト専用の Supabase プロジェクト**を用意し、そこを指す環境変数をセットした上で実行すること:
+
+```bash
+NEXT_PUBLIC_SUPABASE_URL=<test-project-url> \
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<test-project-anon-key> \
+npm run e2e:write
+```
+
+テスト用の日付 (`2099-12-31`) を使ってレコードを作成し、テスト後に自動削除する。
+
+### CI での実行
+
+Smoke tests は `.github/workflows/e2e.yml` (`workflow_dispatch`) で手動実行できる。PR ゲートには含めない (ブラウザ起動コストのため)。
+
+---
+
 In addition, `ml-pipeline/test_analyze.py` runs as a separate `python-test` job on the same triggers.
 To run Python tests locally: `cd ml-pipeline && pytest test_analyze.py -v`
 Dependencies: `pip install -r ml-pipeline/requirements-ci.txt` (pandas / xgboost / scikit-learn / supabase / pytest — no torch required).

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,0 +1,58 @@
+/**
+ * smoke.spec.ts — 主要ページ表示確認 (smoke tests)
+ *
+ * 読み取り専用。Supabase への書き込みは行わない。
+ * CI でも安全に実行可能。
+ *
+ * ## 確認内容
+ * - 主要ページが HTTP 500 / "Application error" なしにロードできる
+ * - NavBar (ナビゲーション) が表示される
+ * - ページ固有の見出しが表示される
+ * - NavBar リンクから設定ページへの遷移が動作する
+ *
+ * ## データ依存
+ * DB が空でもテストは通る（graceful degradation を前提とした設計のため）。
+ */
+
+import { test, expect } from "@playwright/test";
+
+// ナビゲーションリンク名と URL の対応 (NavBar.tsx の NAV_ITEMS に準拠)
+const MAIN_PAGES = [
+  { path: "/",        navLabel: "ダッシュボード" },
+  { path: "/history", navLabel: "履歴" },
+  { path: "/settings",navLabel: "設定" },
+  { path: "/tdee",    navLabel: "TDEE" },
+  { path: "/macro",   navLabel: "栄養" },
+] as const;
+
+for (const { path, navLabel } of MAIN_PAGES) {
+  test(`${navLabel} ページが表示できる (${path})`, async ({ page }) => {
+    await page.goto(path);
+
+    // NavBar が常に表示されること (layout.tsx で全ページ共通)
+    await expect(page.locator("nav")).toBeVisible();
+
+    // Next.js の Application error ページが出ていないこと
+    await expect(page.getByText("Application error")).not.toBeVisible();
+  });
+}
+
+test("設定ページ: 「基本設定」セクションが表示できる", async ({ page }) => {
+  await page.goto("/settings");
+
+  // h1 "設定" が表示される
+  await expect(page.getByRole("heading", { name: "設定", exact: true })).toBeVisible();
+
+  // 「基本設定」セクション見出しが表示される
+  await expect(page.getByText("基本設定")).toBeVisible();
+});
+
+test("NavBar リンクからダッシュボード → 設定ページへ遷移できる", async ({ page }) => {
+  await page.goto("/");
+
+  // NavBar の「設定」リンクをクリック
+  await page.getByRole("link", { name: "設定" }).click();
+  await page.waitForURL("/settings");
+
+  await expect(page.getByRole("heading", { name: "設定", exact: true })).toBeVisible();
+});

--- a/e2e/write-flows.spec.ts
+++ b/e2e/write-flows.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * write-flows.spec.ts — 保存系フロー E2E テスト
+ *
+ * ⚠️  デフォルトではスキップ。本番データへの書き込みを防ぐため。
+ *
+ * ## 実行方法
+ * ```
+ * E2E_WRITE_TESTS=true npx playwright test e2e/write-flows.spec.ts
+ * ```
+ *
+ * ## 前提条件
+ * - NEXT_PUBLIC_SUPABASE_URL / NEXT_PUBLIC_SUPABASE_ANON_KEY を
+ *   **テスト専用 Supabase プロジェクト** に向けること。
+ *   本番 DB を指定すると TEST_LOG_DATE のレコードが書き込まれ、テスト後に削除される。
+ *
+ * ## 対象シナリオ
+ * 1. 日次ログを 1 件保存できる (MealLogger — 体重のみ)
+ * 2. 設定を保存できる (SettingsForm — current_season を更新)
+ */
+
+import { test, expect, request as playwrightRequest } from "@playwright/test";
+
+/** テスト専用の日付。実データと衝突しにくい遠未来日を使用する。 */
+const TEST_LOG_DATE = "2099-12-31";
+
+/** テスト実行後に Supabase REST API で test レコードを削除する */
+async function cleanupTestLog() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!url || !key) return;
+
+  const ctx = await playwrightRequest.newContext();
+  await ctx.delete(`${url}/rest/v1/daily_logs?log_date=eq.${TEST_LOG_DATE}`, {
+    headers: {
+      apikey: key,
+      Authorization: `Bearer ${key}`,
+      Prefer: "return=minimal",
+    },
+  });
+  await ctx.dispose();
+}
+
+// E2E_WRITE_TESTS=true でない限りこのファイルの全テストをスキップする
+test.beforeEach(() => {
+  if (!process.env.E2E_WRITE_TESTS) {
+    test.skip(true, "Skipped by default. Set E2E_WRITE_TESTS=true with a test Supabase instance to run.");
+  }
+});
+
+test.describe("日次ログ保存", () => {
+  test.afterEach(async () => {
+    await cleanupTestLog();
+  });
+
+  test("体重を入力して保存すると「保存しました」が表示される", async ({ page }) => {
+    await page.goto("/");
+
+    // ダッシュボードは DashboardLayout で MealLogger をサイドバー (lg:block) に表示する。
+    // Desktop Chrome (1280px) では sidebar が表示される。
+    // 体重入力欄は placeholder="70.5" で識別する。
+    const weightInput = page.getByPlaceholder("70.5").first();
+    await expect(weightInput).toBeVisible();
+
+    // テスト専用の日付に変更して既存データと衝突しないようにする
+    const dateInput = page.getByLabel("日付").first();
+    await dateInput.fill(TEST_LOG_DATE);
+
+    // 体重を入力（touched フラグが立ち、保存ボタンが有効になる）
+    await weightInput.fill("65.0");
+
+    // 保存ボタンをクリック
+    const saveBtn = page.getByRole("button", { name: "保存" }).first();
+    await saveBtn.click();
+
+    // 成功メッセージが表示されること
+    await expect(page.getByText("保存しました")).toBeVisible({ timeout: 10_000 });
+  });
+});
+
+test.describe("設定保存", () => {
+  test("current_season を更新して保存すると「保存しました」が表示される", async ({ page }) => {
+    await page.goto("/settings");
+
+    // 「現在のシーズン」は text input (placeholder: "2026_TokyoNovice")
+    const seasonInput = page.getByPlaceholder("2026_TokyoNovice");
+    await expect(seasonInput).toBeVisible();
+
+    // テスト用の値に書き換える
+    await seasonInput.fill("E2E_Test_Season");
+
+    // 保存ボタンをクリック
+    const saveBtn = page.getByRole("button", { name: "保存" });
+    await saveBtn.click();
+
+    // 成功メッセージが表示されること
+    await expect(page.getByText("保存しました")).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "swr": "^2.4.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.2",
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -37,6 +38,9 @@
         "tailwindcss": "^4",
         "ts-jest": "^29.4.6",
         "typescript": "^5"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2461,6 +2465,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@reduxjs/toolkit": {
@@ -9538,6 +9558,52 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,11 @@
     "start": "next start",
     "lint": "eslint",
     "test": "jest --config jest.config.cjs",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "e2e": "playwright test",
+    "e2e:smoke": "playwright test e2e/smoke.spec.ts",
+    "e2e:write": "E2E_WRITE_TESTS=true playwright test e2e/write-flows.spec.ts",
+    "e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.98.0",
@@ -30,6 +34,7 @@
     "flatted": "3.4.2"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * E2E テスト設定。
+ *
+ * ## webServer の使い分け
+ * - ローカル: `next dev` を自動起動。既存サーバーを再利用可能。
+ * - CI: `next start` を使用。ビルド済み `.next` が必要なため CI ワークフローで先に build を実行すること。
+ *
+ * ## テスト種別
+ * - smoke tests (e2e/smoke.spec.ts): 主要ページの表示確認。読み取り専用で CI でも安全に実行可能。
+ * - write-flows (e2e/write-flows.spec.ts): 保存系フロー。E2E_WRITE_TESTS=true かつテスト用 Supabase 環境が必要。
+ *   デフォルトではスキップ（本番データへの書き込みを避けるため）。
+ */
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI ? "github" : "list",
+  use: {
+    baseURL: "http://localhost:3000",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    // CI では next start (ビルド済み前提)、ローカルでは next dev
+    command: process.env.CI ? "npm run start" : "npm run dev",
+    url: "http://localhost:3000",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    stdout: "ignore",
+    stderr: "pipe",
+  },
+});


### PR DESCRIPTION
## 概要

Playwright による最小 E2E テスト基盤を追加。主要ページ表示（smoke tests）と保存系フロー（write-flows）をカバーする。

## 変更内容

| ファイル | 内容 |
|---|---|
| `playwright.config.ts` | Playwright 設定。Chromium 1 ブラウザ、webServer 自動起動 |
| `e2e/smoke.spec.ts` | 主要ページ表示 smoke tests (7件) |
| `e2e/write-flows.spec.ts` | 保存系フロー (日次ログ / 設定) — デフォルトスキップ |
| `.github/workflows/e2e.yml` | CI 手動トリガー smoke test ワークフロー |
| `package.json` | `e2e` / `e2e:smoke` / `e2e:write` / `e2e:ui` スクリプト追加 |
| `CONTRIBUTING.md` | E2E 実行手順・テスト種別・write tests 前提条件を追記 |
| `.gitignore` | `playwright-report/` / `test-results/` 追加 |

## 導入した E2E 基盤

- **Playwright** + Chromium (1 ブラウザ、1 worker)
- `webServer`: ローカルは `next dev` 自動起動 / CI は `next start` (ビルド済み前提)
- テストディレクトリ: `e2e/`

## 自動化した主要フロー

### smoke tests (`e2e/smoke.spec.ts`) — 7件全パス ✅

- `/`, `/history`, `/settings`, `/tdee`, `/macro` が Application error なしに表示できる
- 設定ページに h1「設定」と「基本設定」セクションが表示できる
- NavBar の「設定」リンクからダッシュボード → 設定ページへ遷移できる

### write-flows (`e2e/write-flows.spec.ts`) — デフォルトスキップ

- 体重を入力して保存すると「保存しました」が表示される
- current_season を更新して保存すると「保存しました」が表示される

## 実行手順

```bash
# 初回: ブラウザインストール
npx playwright install chromium

# Smoke tests (読み取り専用・安全)
npm run e2e:smoke

# Write tests (テスト用 Supabase 環境が必要)
NEXT_PUBLIC_SUPABASE_URL=<test-url> NEXT_PUBLIC_SUPABASE_ANON_KEY=<test-key> npm run e2e:write

# UI モード (デバッグ向け)
npm run e2e:ui
```

## CI 対応状況

Smoke tests は `.github/workflows/e2e.yml` の `workflow_dispatch` で手動実行可能。

**PR ゲートには含めない** — Playwright ブラウザインストール（~90MB）とサーバー起動コストが PR ごとに発生するため。重大な回帰確認が必要なリリース前やリリース後に手動トリガーで実行する想定。

## 補足

Write tests のデフォルトスキップ理由: 本番 Supabase DB への書き込みを防ぐため。日付 `2099-12-31` をテスト専用レコードとして使い、テスト後に Supabase REST API で自動削除する設計。テスト専用 Supabase プロジェクトを使う場合は `E2E_WRITE_TESTS=true` で有効化できる。

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)