### PR TITLE
ci: add code scanning with CodeQL for js/ts and python (#120)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,53 @@
+name: CodeQL
+
+# PR および main への push で JavaScript/TypeScript と Python を静的解析する。
+# 結果は GitHub の Security → Code scanning alerts に表示され、PR 上でも確認できる。
+#
+# required check 化は GitHub Settings → Branches → Branch protection rules で
+# "CodeQL" または "Analyze (javascript-typescript)" / "Analyze (python)" を
+# Required status checks に追加することで実現できる（コード変更不要）。
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # 毎週月曜 AM 9:00 JST (= UTC 00:00) に定期スキャン
+    - cron: "0 0 * * 1"
+
+permissions:
+  contents: read
+  security-events: write  # SARIF 結果を Code Scanning に送信するために必要
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - javascript-typescript  # Next.js / TypeScript ソース全体
+          - python                 # ml-pipeline/ 配下の ML バッチスクリプト
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # デフォルトの query suite ("security-extended") を使用する。
+          # 将来 query-suite: security-and-quality に変更することで対象を広げられる。
+          query-suite: security-extended
+
+      # JavaScript/TypeScript と Python はインタープリタ言語のため autobuild は実質不要。
+      # ただし将来 compiled 言語を追加する場合や build エラーを明示したい場合は
+      # autobuild ステップを追加すること。
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,6 +127,24 @@ permissions:
 
 ### Code Scanning
 
+CodeQL による静的解析を `.github/workflows/codeql.yml` で設定している。
+
+**対象言語:** `javascript-typescript` (Next.js / TypeScript) と `python` (ml-pipeline/)
+
+**実行タイミング:**
+- main への push
+- main への pull request
+- 毎週月曜定期スキャン
+
+**結果の確認方法:**
+- PR チェック: "Analyze (javascript-typescript)" / "Analyze (python)" として表示される
+- リポジトリの Security → Code scanning alerts でアラート一覧を確認できる
+
+**required check 化:**
+PR マージブロックにしたい場合は GitHub Settings → Branches → Branch protection rules の Required status checks に "Analyze (javascript-typescript)" / "Analyze (python)" を追加すること（コード変更不要のリポジトリ設定）。
+
+**アラート対応基準:**
+
 | Severity | Expected action |
 |---|---|
 | **Critical / High** | Address as a rule. If a fix is not immediately possible, leave a comment explaining the blocker. |


### PR DESCRIPTION
## 概要

CodeQL による静的解析を `.github/workflows/codeql.yml` として明示化する。JS/TypeScript と Python の 2 言語を対象に、PR 時点でセキュリティリスクを検知できる構成にした。

## 変更内容

| ファイル | 内容 |
|---|---|
| `.github/workflows/codeql.yml` | 新規作成。matrix で `javascript-typescript` / `python` を解析 |
| `CONTRIBUTING.md` | Code Scanning セクションを補強 — 設定・結果確認方法・required check 化の手順を追記 |

## CodeQL を導入する理由

Jest / lint / build では拾えない以下のリスクを静的解析で検知する:
- XSS / injection 系の危険なコードパターン（Next.js / TypeScript）
- ML pipeline (Python) 内の安全でない eval・パス操作・外部入力処理

## 対象言語

| 言語 | 対象ディレクトリ | 理由 |
|---|---|---|
| `javascript-typescript` | `src/` 全体 | Next.js App Router / Server Actions / Client Components |
| `python` | `ml-pipeline/` | NeuralProphet / XGBoost / Supabase write バッチ |

## PR / code scanning UI での見え方

- PR チェック: **"Analyze (javascript-typescript)"** / **"Analyze (python)"** として表示される
- アラート一覧: GitHub Security → Code scanning alerts で確認できる

## required check 化は GitHub 設定

PR マージブロックにしたい場合は **GitHub Settings → Branches → Branch protection rules** の Required status checks に上記の check 名を追加すること。コード変更不要。

## 補足

GitHub の **default setup** (2026-03-14 設定済み) が同じ言語で既に動いていた。本 PR の workflow ファイルが同名言語の解析を引き継ぎ、設定を version-controlled にする。default setup は `actions` 言語分のみ残るが実害はない。

`query-suite: security-extended` を採用。`security-and-quality` より軽量で導入初期に適している。将来必要なら変更可能。

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)