### PR TITLE
refactor: clarify settings save model and prevent accidental null overwrite (#120)

### DIFF
--- a/src/lib/schemas/settingsSchema.test.ts
+++ b/src/lib/schemas/settingsSchema.test.ts
@@ -1,11 +1,11 @@
-import { parseSettings } from "./settingsSchema";
+import { parseSettings, EMPTY_SETTINGS_INPUT } from "./settingsSchema";
 import type { SettingsInput } from "./settingsSchema";
 
 // ─── 正常系 ─────────────────────────────────────────────────────────────────
 
 describe("parseSettings — 正常系", () => {
   it("有効な contest_date (YYYY-MM-DD) が通る", () => {
-    const result = parseSettings({ contest_date: "2026-11-01" });
+    const result = parseSettings({ ...EMPTY_SETTINGS_INPUT, contest_date: "2026-11-01" });
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     const rec = result.records.find((r) => r.key === "contest_date");
@@ -15,7 +15,7 @@ describe("parseSettings — 正常系", () => {
   });
 
   it("有効な target_weight (数値) が通る", () => {
-    const result = parseSettings({ goal_weight: "62.5" });
+    const result = parseSettings({ ...EMPTY_SETTINGS_INPUT, goal_weight: "62.5" });
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     const rec = result.records.find((r) => r.key === "goal_weight");
@@ -24,10 +24,10 @@ describe("parseSettings — 正常系", () => {
     expect(rec!.value_str).toBeNull();
   });
 
-  it("全フィールド省略でも通る（全キーが null レコードとして生成される）", () => {
-    // parseSettings は部分更新関数ではなく全項目保存関数。
-    // 省略フィールドは null として records に積まれ DB で上書きされる。
-    const result = parseSettings({});
+  it("全フィールドが空文字で通る（全キーが null レコードとして生成される）", () => {
+    // parseSettings は full-replace 関数。EMPTY_SETTINGS_INPUT (全フィールド "") を渡すと
+    // 全キーが null として records に積まれ DB で上書きされる。
+    const result = parseSettings(EMPTY_SETTINGS_INPUT);
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     // 全キー分のレコードが生成される
@@ -39,26 +39,26 @@ describe("parseSettings — 正常系", () => {
     }
   });
 
-  it("一部キーだけ渡しても残りのキーは null レコードとして生成される（全キー上書き）", () => {
-    // 「goal_weight だけ更新したい」と思って一部キーだけ渡しても、
-    // 他の全キーが null で upsert され既存値が消えることを明示するテスト。
-    // parseSettings は partial update ではなく full-save 関数である。
-    const result = parseSettings({ goal_weight: "65.0" });
+  it("1 フィールドだけ有効値を入れると、他の全フィールドは null レコードになる（full-replace の意味論）", () => {
+    // goal_weight だけ有効値。他フィールドはすべて "" (→ null) を渡している。
+    // これは「goal_weight だけ更新する」partial update ではなく、
+    // 「goal_weight = 65.0、他フィールド = null」として全件 upsert する。
+    const result = parseSettings({ ...EMPTY_SETTINGS_INPUT, goal_weight: "65.0" });
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     // goal_weight は正しく設定される
     const gw = result.records.find((r) => r.key === "goal_weight");
     expect(gw!.value_num).toBe(65.0);
-    // 渡していない contest_date は null レコードとして生成されている（上書き対象になる）
+    // "" で渡した contest_date は null レコードとして生成されている（上書き対象）
     const cd = result.records.find((r) => r.key === "contest_date");
     expect(cd!.value_str).toBeNull();
-    // 渡していない height_cm も null レコードとして生成されている
+    // "" で渡した height_cm も null レコードとして生成されている
     const hc = result.records.find((r) => r.key === "height_cm");
     expect(hc!.value_num).toBeNull();
   });
 
   it("空文字列フィールドは null として保存される", () => {
-    const result = parseSettings({ goal_weight: "", contest_date: "" });
+    const result = parseSettings({ ...EMPTY_SETTINGS_INPUT, goal_weight: "", contest_date: "" });
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     const gw = result.records.find((r) => r.key === "goal_weight");
@@ -68,7 +68,7 @@ describe("parseSettings — 正常系", () => {
   });
 
   it("有効な current_phase (Cut) が通る", () => {
-    const result = parseSettings({ current_phase: "Cut" });
+    const result = parseSettings({ ...EMPTY_SETTINGS_INPUT, current_phase: "Cut" });
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     const rec = result.records.find((r) => r.key === "current_phase");
@@ -76,7 +76,7 @@ describe("parseSettings — 正常系", () => {
   });
 
   it("有効な current_phase (Bulk) が通る", () => {
-    const result = parseSettings({ current_phase: "Bulk" });
+    const result = parseSettings({ ...EMPTY_SETTINGS_INPUT, current_phase: "Bulk" });
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     const rec = result.records.find((r) => r.key === "current_phase");
@@ -84,7 +84,7 @@ describe("parseSettings — 正常系", () => {
   });
 
   it("activity_factor の境界値 (1.2) が通る", () => {
-    const result = parseSettings({ activity_factor: "1.2" });
+    const result = parseSettings({ ...EMPTY_SETTINGS_INPUT, activity_factor: "1.2" });
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     const rec = result.records.find((r) => r.key === "activity_factor");
@@ -92,7 +92,7 @@ describe("parseSettings — 正常系", () => {
   });
 
   it("数値フィールドの前後空白が除去されて通る", () => {
-    const result = parseSettings({ height_cm: "  170  " });
+    const result = parseSettings({ ...EMPTY_SETTINGS_INPUT, height_cm: "  170  " });
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     const rec = result.records.find((r) => r.key === "height_cm");
@@ -100,7 +100,7 @@ describe("parseSettings — 正常系", () => {
   });
 
   it("current_season は任意の文字列が通る", () => {
-    const result = parseSettings({ current_season: "2026_TokyoNovice" });
+    const result = parseSettings({ ...EMPTY_SETTINGS_INPUT, current_season: "2026_TokyoNovice" });
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     const rec = result.records.find((r) => r.key === "current_season");
@@ -112,7 +112,7 @@ describe("parseSettings — 正常系", () => {
 
 describe("parseSettings — 異常系", () => {
   it("contest_date が不正な日付形式で失敗する", () => {
-    const result = parseSettings({ contest_date: "2026/11/01" });
+    const result = parseSettings({ ...EMPTY_SETTINGS_INPUT, contest_date: "2026/11/01" });
     expect(result.ok).toBe(false);
     if (result.ok) return;
     const err = result.errors.find((e) => e.field === "contest_date");
@@ -120,7 +120,7 @@ describe("parseSettings — 異常系", () => {
   });
 
   it("contest_date が存在しない日付で失敗する", () => {
-    const result = parseSettings({ contest_date: "2026-02-30" });
+    const result = parseSettings({ ...EMPTY_SETTINGS_INPUT, contest_date: "2026-02-30" });
     expect(result.ok).toBe(false);
     if (result.ok) return;
     const err = result.errors.find((e) => e.field === "contest_date");
@@ -129,7 +129,7 @@ describe("parseSettings — 異常系", () => {
 
   it("target_weight (goal_weight) が負数で失敗する", () => {
     // strict parser は負数を「数値でない」として拒否する（範囲チェックより前）
-    const result = parseSettings({ goal_weight: "-5" });
+    const result = parseSettings({ ...EMPTY_SETTINGS_INPUT, goal_weight: "-5" });
     expect(result.ok).toBe(false);
     if (result.ok) return;
     const err = result.errors.find((e) => e.field === "goal_weight");
@@ -138,7 +138,7 @@ describe("parseSettings — 異常系", () => {
   });
 
   it("文字列を数値フィールドに渡して失敗する", () => {
-    const result = parseSettings({ height_cm: "not_a_number" });
+    const result = parseSettings({ ...EMPTY_SETTINGS_INPUT, height_cm: "not_a_number" });
     expect(result.ok).toBe(false);
     if (result.ok) return;
     const err = result.errors.find((e) => e.field === "height_cm");
@@ -147,7 +147,7 @@ describe("parseSettings — 異常系", () => {
   });
 
   it("activity_factor が範囲外 (1.1) で失敗する", () => {
-    const result = parseSettings({ activity_factor: "1.1" });
+    const result = parseSettings({ ...EMPTY_SETTINGS_INPUT, activity_factor: "1.1" });
     expect(result.ok).toBe(false);
     if (result.ok) return;
     const err = result.errors.find((e) => e.field === "activity_factor");
@@ -156,7 +156,7 @@ describe("parseSettings — 異常系", () => {
   });
 
   it("target_calories_kcal が範囲外 (100) で失敗する", () => {
-    const result = parseSettings({ target_calories_kcal: "100" });
+    const result = parseSettings({ ...EMPTY_SETTINGS_INPUT, target_calories_kcal: "100" });
     expect(result.ok).toBe(false);
     if (result.ok) return;
     const err = result.errors.find((e) => e.field === "target_calories_kcal");
@@ -164,7 +164,7 @@ describe("parseSettings — 異常系", () => {
   });
 
   it("current_phase が不正な値で失敗する", () => {
-    const result = parseSettings({ current_phase: "Maintain" });
+    const result = parseSettings({ ...EMPTY_SETTINGS_INPUT, current_phase: "Maintain" });
     expect(result.ok).toBe(false);
     if (result.ok) return;
     const err = result.errors.find((e) => e.field === "current_phase");
@@ -172,7 +172,7 @@ describe("parseSettings — 異常系", () => {
   });
 
   it("sex が不正な値で失敗する", () => {
-    const result = parseSettings({ sex: "unknown" });
+    const result = parseSettings({ ...EMPTY_SETTINGS_INPUT, sex: "unknown" });
     expect(result.ok).toBe(false);
     if (result.ok) return;
     const err = result.errors.find((e) => e.field === "sex");
@@ -181,6 +181,7 @@ describe("parseSettings — 異常系", () => {
 
   it("複数フィールドが不正な場合、全エラーが返される", () => {
     const input: SettingsInput = {
+      ...EMPTY_SETTINGS_INPUT,
       goal_weight: "-100",
       contest_date: "not-a-date",
       current_phase: "Invalid",
@@ -200,7 +201,7 @@ describe("parseSettings — 異常系", () => {
 
 describe("parseSettings — DB レコード構造", () => {
   it("数値フィールドは value_num に保存され value_str は null になる", () => {
-    const result = parseSettings({ age: "30" });
+    const result = parseSettings({ ...EMPTY_SETTINGS_INPUT, age: "30" });
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     const rec = result.records.find((r) => r.key === "age");
@@ -209,7 +210,7 @@ describe("parseSettings — DB レコード構造", () => {
   });
 
   it("文字列フィールドは value_str に保存され value_num は null になる", () => {
-    const result = parseSettings({ contest_date: "2026-11-01" });
+    const result = parseSettings({ ...EMPTY_SETTINGS_INPUT, contest_date: "2026-11-01" });
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     const rec = result.records.find((r) => r.key === "contest_date");
@@ -218,7 +219,7 @@ describe("parseSettings — DB レコード構造", () => {
   });
 
   it("全キーのレコードが生成される", () => {
-    const result = parseSettings({});
+    const result = parseSettings(EMPTY_SETTINGS_INPUT);
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     const keys = result.records.map((r) => r.key);
@@ -230,5 +231,70 @@ describe("parseSettings — DB レコード構造", () => {
     expect(keys).toContain("sex");
     expect(keys).toContain("current_season");
     expect(keys).toContain("monthly_plan_overrides");
+  });
+});
+
+// ─── SettingsInput 型契約の検証 ───────────────────────────────────────────
+
+describe("SettingsInput — 全フィールド必須の契約", () => {
+  it("EMPTY_SETTINGS_INPUT は全 13 フィールドを持つ", () => {
+    // SettingsInput が全フィールド必須であることを、
+    // EMPTY_SETTINGS_INPUT の実際のキー数で確認する。
+    // フィールドを追加/削除した場合はここも追従する。
+    const keys = Object.keys(EMPTY_SETTINGS_INPUT);
+    expect(keys).toHaveLength(13);
+  });
+
+  it("EMPTY_SETTINGS_INPUT の全フィールドが空文字", () => {
+    for (const [, value] of Object.entries(EMPTY_SETTINGS_INPUT)) {
+      expect(value).toBe("");
+    }
+  });
+
+  it("SettingsForm パターン (全フィールドを ?? '' で渡す) で問題なく動作する", () => {
+    // SettingsForm.tsx の handleSave が生成するパターン:
+    // values[key] が undefined/null のとき ?? "" でフォールバックする。
+    // この呼び出しパターンが SettingsInput 型を満たすことを確認する。
+    const mockValues: Record<string, string> = {
+      goal_weight: "65.0",
+      activity_factor: "1.55",
+      height_cm: "170",
+      age: "30",
+      target_calories_kcal: "2000",
+      target_protein_g: "150",
+      target_fat_g: "60",
+      target_carbs_g: "200",
+      current_season: "2026_TokyoNovice",
+      current_phase: "Cut",
+      sex: "male",
+      contest_date: "2026-11-01",
+      // monthly_plan_overrides: 未設定のケース
+    };
+
+    const input: SettingsInput = {
+      goal_weight:             mockValues["goal_weight"] ?? "",
+      activity_factor:         mockValues["activity_factor"] ?? "",
+      height_cm:               mockValues["height_cm"] ?? "",
+      age:                     mockValues["age"] ?? "",
+      target_calories_kcal:    mockValues["target_calories_kcal"] ?? "",
+      target_protein_g:        mockValues["target_protein_g"] ?? "",
+      target_fat_g:            mockValues["target_fat_g"] ?? "",
+      target_carbs_g:          mockValues["target_carbs_g"] ?? "",
+      current_season:          mockValues["current_season"] ?? "",
+      current_phase:           mockValues["current_phase"] ?? "",
+      sex:                     mockValues["sex"] ?? "",
+      contest_date:            mockValues["contest_date"] ?? "",
+      monthly_plan_overrides:  mockValues["monthly_plan_overrides"] ?? "",
+    };
+
+    const result = parseSettings(input);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    // 有効値フィールドが正しく変換されている
+    expect(result.records.find((r) => r.key === "goal_weight")?.value_num).toBe(65.0);
+    expect(result.records.find((r) => r.key === "current_phase")?.value_str).toBe("Cut");
+    // monthly_plan_overrides は "" → null
+    expect(result.records.find((r) => r.key === "monthly_plan_overrides")?.value_str).toBeNull();
   });
 });

--- a/src/lib/schemas/settingsSchema.ts
+++ b/src/lib/schemas/settingsSchema.ts
@@ -40,29 +40,70 @@ export type SettingKey = NumericSettingKey | StringSettingKey;
 /**
  * 保存対象の設定値 (入力値は文字列で渡ってくることを前提)。
  *
- * 全フィールドが省略可能だが、省略したフィールドは parseSettings() 内で
- * null として扱われ DB に上書きされる。
- * これは部分更新インターフェースではなく、全項目一括保存を前提とした入力型である。
- * 一部キーだけを渡すと、残りのキーが null で消えるため注意すること。
+ * 【全フィールド必須】
+ * この型はすべてのフィールドが必須の string である。
+ * 空欄フィールドには "" (空文字) を渡すこと。
+ * "" は parseSettings() 内で null として DB に保存される。
+ *
+ * なぜ全フィールド必須か:
+ * parseSettings() は partial update ではなく full-replace 関数であり、
+ * 渡されたすべてのフィールドを DB に upsert する。
+ * フィールドを省略できる型（optional）にすると、省略フィールドが
+ * null で上書きされることに気づかずに partial save を呼び出す
+ * accidental null overwrite を引き起こしやすい。
+ * 全フィールド必須にすることで、コンパイル時にこのミスを検知できる。
+ *
+ * 利用時のパターン:
+ * saveSettings({
+ *   goal_weight: values["goal_weight"] ?? "",
+ *   activity_factor: values["activity_factor"] ?? "",
+ *   // ... 全フィールドを渡す
+ * });
+ *
+ * テストで一部フィールドだけ変えたい場合は EMPTY_SETTINGS_INPUT をスプレッドする:
+ * parseSettings({ ...EMPTY_SETTINGS_INPUT, goal_weight: "65.0" })
  */
 export interface SettingsInput {
   // 数値系 (文字列として渡し、schema 側で number に変換する)
-  goal_weight?: string | null;
-  activity_factor?: string | null;
-  height_cm?: string | null;
-  age?: string | null;
-  target_calories_kcal?: string | null;
-  target_protein_g?: string | null;
-  target_fat_g?: string | null;
-  target_carbs_g?: string | null;
+  goal_weight: string;
+  activity_factor: string;
+  height_cm: string;
+  age: string;
+  target_calories_kcal: string;
+  target_protein_g: string;
+  target_fat_g: string;
+  target_carbs_g: string;
   // 文字列系
-  current_season?: string | null;
-  current_phase?: string | null;
-  sex?: string | null;
-  contest_date?: string | null;
-  /** JSON 文字列化した MonthlyGoalOverride[] */
-  monthly_plan_overrides?: string | null;
+  current_season: string;
+  current_phase: string;
+  sex: string;
+  contest_date: string;
+  /** JSON 文字列化した MonthlyGoalOverride[]。空のときは "" を渡す。 */
+  monthly_plan_overrides: string;
 }
+
+/**
+ * 全フィールドが空文字 ("") の SettingsInput。
+ * テストで一部フィールドだけ変えたい場合のベースとして使う。
+ *
+ * @example
+ * parseSettings({ ...EMPTY_SETTINGS_INPUT, goal_weight: "65.0" })
+ */
+export const EMPTY_SETTINGS_INPUT: SettingsInput = {
+  goal_weight: "",
+  activity_factor: "",
+  height_cm: "",
+  age: "",
+  target_calories_kcal: "",
+  target_protein_g: "",
+  target_fat_g: "",
+  target_carbs_g: "",
+  current_season: "",
+  current_phase: "",
+  sex: "",
+  contest_date: "",
+  monthly_plan_overrides: "",
+};
 
 /**
  * バリデーション・変換済みの DB upsert 用レコード型。
@@ -139,14 +180,13 @@ function isValidDate(s: string): boolean {
 /**
  * SettingsInput を検証・変換して DB upsert 用の SettingRecord[] を返す。
  *
- * 【全項目保存関数】
- * この関数は常に全設定キー (NUMERIC_SETTING_KEYS + STRING_SETTING_KEYS) の
- * レコードを生成する。省略・null・空文字のフィールドは value_num/value_str = null
- * として records に積まれ、DB で上書きされる。
+ * 【全項目保存関数 (full-replace)】
+ * SettingsInput は全フィールド必須。この関数は全設定キー
+ * (NUMERIC_SETTING_KEYS + STRING_SETTING_KEYS) のレコードを常に生成する。
+ * 空文字 ("") のフィールドは value_num/value_str = null として records に積まれ DB で上書きされる。
  *
  * partial update（一部キーのみ更新）には対応していない。
- * 一部キーだけ渡すと、残りキーが null で消えるため、必ず全フィールドを渡すこと。
- * 現状の唯一の caller (saveSettings) は SettingsForm から全フィールドを受け取って渡す。
+ * SettingsInput 型が全フィールド必須のため、コンパイル時に partial 呼び出しは検知できる。
  *
  * - バリデーションエラーがひとつでもあれば ok: false を返す（保存は行わない）。
  */


### PR DESCRIPTION
## 概要

`SettingsInput` の全フィールドを optional (`?: string | null`) から **必須 (`string`)** に変更し、settings 保存の full-replace 契約をコンパイル時に強制するようにした。

## 現状の問題

`parseSettings()` は partial update ではなく **full-replace 関数**（全13キーを必ず upsert する）。しかし従来の `SettingsInput` は全フィールドが optional だったため、以下のような呼び出しを TypeScript が通してしまっていた:

```ts
saveSettings({ goal_weight: "65.0" })
// → goal_weight 以外の 12 キーが null で上書きされる
// → TypeScript は何もエラーを出さない ← 問題
```

## 変更内容

| ファイル | 変更内容 |
|---|---|
| `settingsSchema.ts` | `SettingsInput` の全フィールドを `string` (required) に変更。`EMPTY_SETTINGS_INPUT` 定数を追加 |
| `settingsSchema.test.ts` | 全テストを `{ ...EMPTY_SETTINGS_INPUT, field: "value" }` パターンに更新。「全フィールド必須の契約」テストを追加 (3件) |

## 採用した保存モデル

**full-replace（全フィールド必須）** を型レベルで強制する方針:

- `SettingsInput` の全フィールドを `: string` (required) に変更
- 空欄フィールドには `""` (空文字) を渡す → `parseSettings()` が `null` に変換してDBに保存
- `EMPTY_SETTINGS_INPUT` (全フィールド `""`) を export してテストや将来の呼び出しで使えるように

## 判断理由

- `SettingsForm.tsx` はすでに全フィールドを `values[key] ?? ""` パターンで渡している → 変更なしで互換
- 現時点で partial update を必要とする caller は存在しない → 型を厳格化しても既存機能に影響なし
- full-replace と partial update は意味論が根本的に異なるため、現時点では型レベルで境界を引くのが最善

## テストで担保した内容 (885件全パス)

- 既存テスト全件: `{ ...EMPTY_SETTINGS_INPUT, ... }` パターンで動作継続
- 「EMPTY_SETTINGS_INPUT は全 13 フィールドを持つ」: フィールド数の変更をテストで検知できる
- 「EMPTY_SETTINGS_INPUT の全フィールドが空文字」: 定数内容の正確性
- 「SettingsForm パターン (全フィールドを ?? '' で渡す) で問題なく動作する」: 実際の caller との互換性

## 影響範囲

- `actions.ts` (saveSettings): 変更なし — すでに全フィールドを受け取っている
- `SettingsForm.tsx`: 変更なし — すでに全フィールドを `string` で渡している
- 型チェックが通る caller: 変更なし — 全フィールドを渡していれば互換

## スコープ外にした事項

- settings UI の分割・再設計
- partial update 専用 API の導入（現時点で必要な caller がないため）
- 他フォームへの横展開（daily_logs の partial update は別設計）

## 残課題 (別 Issue 候補)

- 将来 SettingsForm を複数のサブフォームに分割するときは partial update API の分離が必要になる
  その際は `SettingsInput` を分割するか、partial-safe な `patchSettings()` を新設すること

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)