### PR TITLE
Improve clarity of clear/delete-pending UX in edit mode

### DIFF
--- a/src/components/meal/MealLogger.tsx
+++ b/src/components/meal/MealLogger.tsx
@@ -287,7 +287,7 @@ export function MealLogger({ sidebar = false }: MealLoggerProps) {
 
   const inputCls =
     "w-full rounded-xl border border-slate-200 bg-slate-50 px-3 py-2.5 text-sm text-slate-800 outline-none transition-colors focus:border-blue-400 focus:bg-white focus:ring-2 focus:ring-blue-100 placeholder:text-slate-400";
-  // 明示的クリア状態（null）のときの入力欄スタイル
+  // 明示的クリア状態（null）のときの入力欄スタイル（pr-8 不要 — オーバーレイボタンは外に出す）
   const inputClearedCls =
     "w-full rounded-xl border border-rose-200 bg-rose-50 px-3 py-2.5 text-sm text-rose-400 placeholder:text-rose-300 outline-none opacity-75 cursor-default";
 
@@ -316,62 +316,85 @@ export function MealLogger({ sidebar = false }: MealLoggerProps) {
           <label className="mb-1.5 block text-xs font-semibold uppercase tracking-wide text-slate-400">体重 (kg)</label>
           <div className="relative">
             {weight === null ? (
-              <input type="number" disabled placeholder="削除予定" className={`${inputClearedCls} pr-8`} />
+              <input type="number" disabled placeholder="削除予定" className={inputClearedCls} />
             ) : (
               <input type="number" step="0.1" min="0" placeholder="70.5" value={weight}
                 onChange={(e) => { setWeight(e.target.value); setWeightTouched(true); }}
                 className={`${inputCls} ${weight !== "" ? "pr-8" : ""}`} />
             )}
             {weight !== "" && weight !== null && (
-              <button type="button" onClick={() => { setWeight(null); setWeightTouched(true); }} title="null 保存（クリア）"
+              <button type="button"
+                onClick={() => { setWeight(null); setWeightTouched(true); }}
+                aria-label="体重を削除予定にする"
+                title="保存時にこの値を削除する"
                 className="absolute right-2.5 top-1/2 -translate-y-1/2 text-slate-300 hover:text-rose-400 transition-colors">
                 <X size={13} />
               </button>
             )}
-            {weight === null && (
-              <button type="button"
+          </div>
+          {weight === null && (
+            <p className="mt-1 flex items-center gap-1 text-xs text-rose-500">
+              <Undo2 size={11} className="shrink-0" />
+              <span>
+                {hydratedLog?.weight !== null && hydratedLog?.weight !== undefined
+                  ? `保存すると体重 (${hydratedLog.weight} kg) を削除します。`
+                  : "保存時に体重を空欄で送信します。"}
+              </span>
+              <button
+                type="button"
                 onClick={() => {
-                  // 既存ログがある場合は hydrated 値に戻す。なければ空フォームに戻す。
                   setWeight(hydratedLog?.weight !== null && hydratedLog?.weight !== undefined
                     ? String(hydratedLog.weight)
                     : "");
                   setWeightTouched(false);
                 }}
-                title="クリアを取り消す"
-                className="absolute right-2.5 top-1/2 -translate-y-1/2 text-rose-400 hover:text-slate-500 transition-colors">
-                <Undo2 size={13} />
+                className="underline font-medium"
+              >
+                元に戻す
               </button>
-            )}
-          </div>
+            </p>
+          )}
         </div>
         <div>
           <label className="mb-1.5 block text-xs font-semibold uppercase tracking-wide text-slate-400">メモ</label>
           <div className="relative">
             {note === null ? (
-              <input type="text" disabled placeholder="削除予定" className={`${inputClearedCls} pr-8`} />
+              <input type="text" disabled placeholder="削除予定" className={inputClearedCls} />
             ) : (
               <input type="text" placeholder="任意" value={note}
                 onChange={(e) => { setNote(e.target.value); setNoteTouched(true); }}
                 className={`${inputCls} ${note !== "" ? "pr-8" : ""}`} />
             )}
             {note !== "" && note !== null && (
-              <button type="button" onClick={() => { setNote(null); setNoteTouched(true); }} title="null 保存（クリア）"
+              <button type="button"
+                onClick={() => { setNote(null); setNoteTouched(true); }}
+                aria-label="メモを削除予定にする"
+                title="保存時にこの値を削除する"
                 className="absolute right-2.5 top-1/2 -translate-y-1/2 text-slate-300 hover:text-rose-400 transition-colors">
                 <X size={13} />
               </button>
             )}
-            {note === null && (
-              <button type="button"
+          </div>
+          {note === null && (
+            <p className="mt-1 flex items-center gap-1 text-xs text-rose-500">
+              <Undo2 size={11} className="shrink-0" />
+              <span>
+                {hydratedLog?.note
+                  ? "保存するとメモを削除します。"
+                  : "保存時にメモを空欄で送信します。"}
+              </span>
+              <button
+                type="button"
                 onClick={() => {
                   setNote(hydratedLog?.note ?? "");
                   setNoteTouched(false);
                 }}
-                title="クリアを取り消す"
-                className="absolute right-2.5 top-1/2 -translate-y-1/2 text-rose-400 hover:text-slate-500 transition-colors">
-                <Undo2 size={13} />
+                className="underline font-medium"
+              >
+                元に戻す
               </button>
-            )}
-          </div>
+            </p>
+          )}
         </div>
       </div>
 
@@ -418,7 +441,7 @@ export function MealLogger({ sidebar = false }: MealLoggerProps) {
             <label className="mb-1.5 block text-xs font-medium text-slate-500">睡眠時間 (h)</label>
             <div className="relative">
               {sleepHours === null ? (
-                <input type="number" disabled placeholder="削除予定" className={`${inputClearedCls} pr-8`} />
+                <input type="number" disabled placeholder="削除予定" className={inputClearedCls} />
               ) : (
                 <input type="number" step="0.5" min="0" max="24" placeholder="7.5"
                   value={sleepHours}
@@ -426,25 +449,37 @@ export function MealLogger({ sidebar = false }: MealLoggerProps) {
                   className={`${inputCls} ${sleepHours !== "" ? "pr-8" : ""}`} />
               )}
               {sleepHours !== "" && sleepHours !== null && (
-                <button type="button" onClick={() => { setSleepHours(null); setSleepHoursTouched(true); }} title="null 保存（クリア）"
+                <button type="button"
+                  onClick={() => { setSleepHours(null); setSleepHoursTouched(true); }}
+                  aria-label="睡眠時間を削除予定にする"
+                  title="保存時にこの値を削除する"
                   className="absolute right-2.5 top-1/2 -translate-y-1/2 text-slate-300 hover:text-rose-400 transition-colors">
                   <X size={13} />
                 </button>
               )}
-              {sleepHours === null && (
-                <button type="button"
+            </div>
+            {sleepHours === null && (
+              <p className="mt-1 flex items-center gap-1 text-xs text-rose-500">
+                <Undo2 size={11} className="shrink-0" />
+                <span>
+                  {hydratedLog?.sleep_hours !== null && hydratedLog?.sleep_hours !== undefined
+                    ? `保存すると睡眠時間 (${hydratedLog.sleep_hours} h) を削除します。`
+                    : "保存時に睡眠時間を空欄で送信します。"}
+                </span>
+                <button
+                  type="button"
                   onClick={() => {
                     setSleepHours(hydratedLog?.sleep_hours !== null && hydratedLog?.sleep_hours !== undefined
                       ? String(hydratedLog.sleep_hours)
                       : "");
                     setSleepHoursTouched(false);
                   }}
-                  title="クリアを取り消す"
-                  className="absolute right-2.5 top-1/2 -translate-y-1/2 text-rose-400 hover:text-slate-500 transition-colors">
-                  <Undo2 size={13} />
+                  className="underline font-medium"
+                >
+                  元に戻す
                 </button>
-              )}
-            </div>
+              </p>
+            )}
           </div>
           {/* 便通 */}
           <div>


### PR DESCRIPTION
## 概要

既存ログ編集時の「削除予定」状態（`value === null`）を、ユーザーが意図を正しく理解できる UI に改善します。

Closes #114

## 現状の問題

`weight` / `note` / `sleepHours` の各フィールドでXボタンを押すと `null`（削除予定）状態になりますが、現状は以下の問題がありました：

- `disabled` input の `placeholder="削除予定"` のみが視覚的手がかり
- Undo 操作が、`disabled` input 上に絶対配置された小さな Undo2 アイコンだけで表現されていた
  - ホバーしないとツールチップが見えない
  - アイコンの意味が直感的でない
- 「保存すると何が起きるか」（DB の値が削除される / 空欄で送信される）が伝わらない
- 「元の値が何か」が分からず、Undo の効果を事前に判断できない

## 変更内容

`MealLogger.tsx` のみ変更。ロジックは一切変えず、表示 UI のみ改善。

**削除予定状態（`value === null`）で、`disabled` input の下に補助行を追加：**

```
[Undo2 icon] 保存すると体重 (70.5 kg) を削除します。 [元に戻す]
```

- 既存ログに値があった場合: `"保存すると体重 (70.5 kg) を削除します。"`
- 既存ログに値がない（新規ログでのクリア）: `"保存時に体重を空欄で送信します。"`
- 「元に戻す」はテキストリンク形式で、絶対配置アイコンより発見しやすい

**合わせて改善：**
- `disabled` input から `pr-8` を除去（オーバーレイボタンが不要になったため）
- 絶対配置の Undo2 アイコンボタンを除去（補助行に統合）
- X ボタンの `title` を `"null 保存（クリア）"` → `"保存時にこの値を削除する"` に変更

## 採用した UX 方針

第一候補（削除予定バッジ・補助文・Undo 導線の強化）を採用。

`disabled` input は維持しつつ、その下に意味のある補助テキストを表示する構成。`disabled` は「この状態は直接編集できないが、取り消せる特殊状態」を示す点で適切であるため維持。

## 判断理由

- 保存ロジック（null 送信の意味論・touched フラグ・payload 生成）には一切触れないことで影響範囲を最小化
- アイコンのみ → テキスト+アイコンの補助行にすることで「何が起きるか」を明文化
- 元の値（DB の現在値）を表示することで、Undo した場合の結果が事前に分かる

## テスト内容

- `npx tsc --noEmit` — 型エラーなし
- `npx jest --no-coverage` — 885 テスト全パス（既存の `computeHasContent` テスト含む）

保存ロジックとステート管理は変更していないため、既存の保存導線テストがそのまま有効。

## 影響範囲

- `src/components/meal/MealLogger.tsx` のみ
- 変更対象: weight / note / sleepHours の null 状態 UI
- 保存ロジック・ステート管理・payload 生成: 変更なし

## スコープ外にした事項

- `disabled` を取り外す案（第二候補）: 今回は最小差分優先で第一候補を採用
- 差分表示（保存前の変更サマリー）: 実装コストが高いため今回は見送り

## 残課題・別 Issue 候補

- `had_bowel_movement` の三状態化（DB が `BOOLEAN DEFAULT NULL` になったため、false と null の区別が可能になった部分）は別 Issue で対応済み（memory 記録あり）