### PR TITLE
Remove any from chart tooltip formatters and improve type safety

### DIFF
--- a/src/components/charts/MacroChart.tsx
+++ b/src/components/charts/MacroChart.tsx
@@ -10,6 +10,7 @@ import {
   Legend,
   ResponsiveContainer,
 } from "recharts";
+import type { TooltipValueType } from "recharts";
 import type { DailyLog } from "@/lib/supabase/types";
 import { lastNEntries } from "@/lib/utils/timeWindow";
 
@@ -43,8 +44,7 @@ export function MacroChart({ logs, days = 30 }: MacroChartProps) {
           <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
           <XAxis dataKey="date" tick={{ fontSize: 11 }} minTickGap={20} />
           <YAxis tick={{ fontSize: 11 }} width={36} unit="g" />
-          {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-          <Tooltip formatter={(v: any, name: any) => [`${v} g`, name]} />
+          <Tooltip formatter={(v: TooltipValueType | undefined, name: number | string | undefined) => [`${v} g`, name ?? ""]} />
           <Legend />
           <Bar dataKey="タンパク質" stackId="macro" fill="#3b82f6" />
           <Bar dataKey="脂質" stackId="macro" fill="#f59e0b" />

--- a/src/components/charts/TdeeChart.tsx
+++ b/src/components/charts/TdeeChart.tsx
@@ -18,6 +18,7 @@ import {
   ResponsiveContainer,
   Legend,
 } from "recharts";
+import type { TooltipValueType } from "recharts";
 import type { EnrichedLogPayloadRow } from "@/lib/supabase/types";
 
 // Re-export for convenience so other modules can import from here
@@ -77,8 +78,7 @@ export function TdeeChart({ enrichedRows, days = 60 }: TdeeChartProps) {
           <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
           <XAxis dataKey="date" tick={{ fontSize: 11 }} minTickGap={20} />
           <YAxis tick={{ fontSize: 11 }} width={52} unit="kcal" />
-          {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-          <Tooltip formatter={(v: any, name: any) => [typeof v === "number" ? `${v.toLocaleString()} kcal` : String(v), name]} />
+          <Tooltip formatter={(v: TooltipValueType | undefined, name: number | string | undefined) => [typeof v === "number" ? `${v.toLocaleString()} kcal` : String(v), name ?? ""]} />
           <Legend />
           {avgTdeeDisplay !== null && (
             <ReferenceLine y={avgTdeeDisplay} stroke="#94a3b8" strokeDasharray="4 4" />


### PR DESCRIPTION
## 概要

`TdeeChart.tsx` と `MacroChart.tsx` の Tooltip formatter に残っていた `any` を除去し、recharts の型定義に沿った明示的な型へ置き換えます。

Closes #121

## 現状の問題

```tsx
// Before (両ファイル共通)
{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
<Tooltip formatter={(v: any, name: any) => [...]} />
```

- formatter 引数が `any` のため、recharts の値型変更が型チェックで検知されない
- `eslint-disable` が必要な状態になっていた

## 変更内容

```tsx
// After
import type { TooltipValueType } from "recharts";

<Tooltip formatter={(v: TooltipValueType | undefined, name: number | string | undefined) => [..., name ?? ""]} />
```

2 ファイルとも同じパターンで統一。`ForecastChart.tsx` がすでに採用していた方法に揃えました。

## 採用した型方針

**recharts 既存型をそのまま利用（第一候補）**

| 引数 | Before | After |
|---|---|---|
| `v` (value) | `any` | `TooltipValueType \| undefined` = `number \| string \| ReadonlyArray<number \| string> \| undefined` |
| `name` | `any` | `number \| string \| undefined` |

`TooltipValueType` は recharts の `index.d.ts` から re-export されている公開型であり、`DefaultTooltipContent` の `ValueType` と同一です。

## 判断理由

- `ForecastChart.tsx` でまったく同じパターンが使われており、プロジェクト内での一貫性がある
- `TooltipValueType` は recharts の公開型なので安定している
- `name ?? ""` で `undefined` を除外し、戻り値型 `[React.ReactNode, NameType]` を満たす
- 差分は import 1 行 + formatter の型注釈のみ。表示ロジックは一切変わらない

## 表示互換性の確認

- TdeeChart: `typeof v === "number"` による分岐は引き続き正しく型を絞り込める（number → `v.toLocaleString()` は型安全）
- MacroChart: `` `${v} g` `` はテンプレートリテラルなので `ValueType | undefined` すべてに有効
- どちらも `name ?? ""` のフォールバックが加わるだけで表示文字列は変わらない

## テスト内容

- `npx tsc --noEmit` — 型エラーなし
- `npm run lint` — `no-explicit-any` エラーなし（既存 warning 2 件は今回と無関係の pre-existing）
- `npx jest --no-coverage` — 899 テスト全パス

## 補足

- 今回の変更は `TdeeChart.tsx` / `MacroChart.tsx` の2ファイルのみ
- `ForecastChart.tsx` はすでに対応済みのため変更不要
- lint warning 2 件（`MonthlyGoalWarningCode` / `MonthlyGoalSummaryRow` の unused vars）は既存問題であり今回スコープ外