### PR TITLE
docs: front SSR / full-read 経路境界を明文化する (#167)

### DIFF
--- a/docs/daily-logs-read-inventory.md
+++ b/docs/daily-logs-read-inventory.md
@@ -1,7 +1,7 @@
 # daily_logs read API 利用箇所棚卸し
 
-> Issue: #164（設計整理）、#165（Dashboard read 実装）、#166（Macro / TDEE read 整理）
-> 作成日: 2026-03-21 / #165 追記: 2026-03-21 / #166 追記: 2026-03-21
+> Issue: #164（設計整理）、#165（Dashboard read 実装）、#166（Macro / TDEE read 整理）、#167（front / full read 経路分離）
+> 作成日: 2026-03-21 / #165 追記: 2026-03-21 / #166 追記: 2026-03-21 / #167 追記: 2026-03-21
 > 目的: 後続 Issue (#165 #166 #167) が迷わず着手できる粒度での設計整理
 
 ---
@@ -82,6 +82,65 @@ Dashboard は 18列中 16列を使用しており全列に近い。ただし:
 | `fetchCareerLogs()` | `career_logs` | `*` (全列) | なし | log_date ASC | `QueryResult<CareerLog[]>` | error banner 表示、空配列フォールバック |
 | `fetchCareerLogsForDashboard()` | `career_logs` | log_date, season, target_date | なし | log_date ASC | `Pick<CareerLog, ...>[]` | 空配列（ベストエフォート） |
 | `fetchPredictions()` | `predictions` | `*` (全列) | なし | ds ASC | `Prediction[]` | 空配列（ベストエフォート） |
+
+---
+
+## 0c. #167 実装サマリー（front / full read 経路分離）
+
+#167 で以下を実施した:
+
+- `src/lib/queries/dailyLogs.ts` のファイルヘッダーを刷新
+  - 「front SSR 専用 projection query モジュール」であることを明記
+  - full read の所在（useDailyLogs hook / export route / ML batch）を一覧化
+  - 新画面追加時の指針（専用 query をここに追加すること）を明記
+- `src/lib/hooks/useDailyLogs.ts` に docstring を追加
+  - client-side full read であること・MealLogger 専用であることを明記
+  - Server Component は `src/lib/queries/dailyLogs.ts` を使うことを注記
+- `src/app/api/export/route.ts` の full read 箇所にコメントを追加
+  - CSV export のため全列必要であること・projection query 経路と別物であることを明記
+- `src/lib/queries/queryResult.ts` の `fetchTdeeDailyLogs` コメントを修正（LIMIT 30 → 180）
+
+**新設関数なし**: front SSR 側はすでに projection query 完全分離済みであり、
+全読み取り用関数を追加しても呼び出し元がない。責務境界はコメント・docstring・docs で明文化した。
+
+---
+
+## 1a. front / full read 経路境界
+
+### front SSR projection query（`src/lib/queries/dailyLogs.ts`）
+
+- Server Components が Next.js SSR 時に呼ぶ read query のみを提供
+- すべての関数が「画面必要列のみ」の projection query
+- full read（`select("*")`）は含まない
+- **ここを起点に新画面の query を追加すること**
+
+### full read が必要な経路（front SSR query 外）
+
+| 経路 | ファイル | 用途 | クライアント種別 |
+|---|---|---|---|
+| Client SWR hook | `src/lib/hooks/useDailyLogs.ts` | MealLogger フォーム hydration | Browser (anon key) |
+| CSV export route | `src/app/api/export/route.ts` | CSV ダウンロード（全列必要） | Server Route Handler (anon key) |
+| ML batch enrich | `ml-pipeline/enrich.py` | TDEE 推定バッチ（全列必要） | Python supabase-py (service_role key) |
+| ML batch analyze | `ml-pipeline/analyze.py` | XGBoost 因子分析バッチ（全列必要） | Python supabase-py (service_role key) |
+| ML batch predict | `ml-pipeline/predict.py` | 体重予測バッチ（log_date, weight のみ） | Python supabase-py (service_role key) |
+
+### 各 full read が許容される理由
+
+**`useDailyLogs.ts`**: MealLogger は編集フォームのため、どの列が操作されるか事前に絞れない。
+Browser から直接取得する client-side SWR であり、Server Component SSR の projection 最適化とは別レイヤー。
+
+**`api/export/route.ts`**: CSV エクスポートはユーザーがバックアップ目的で全データを取得するもの。
+表示最適化の対象外であり、全列取得が機能要件。
+
+**`ml-pipeline/*.py`**: GitHub Actions cron で実行される Python バッチ。
+anon key ではなく service_role key を使用し、JS の query layer と完全に独立した経路。
+アルゴリズム計算に全列・全件が必要なため projection 最適化の対象外。
+
+### 将来の拡張指針
+
+- **新しい画面（Server Component ページ）を追加する場合**: 必要列を絞った専用 query を `dailyLogs.ts` に追加する
+- **`useDailyLogs.ts` の全列取得を変更する場合**: MealLogger の全フィールド参照を確認してから projection を検討する
+- **full read を Server Component から呼ぶことは避ける**: `dailyLogs.ts` に `fetchDailyLogsFull()` 相当の関数を追加したくなった場合、その画面が本当に全列必要か再検討すること
 
 ---
 

--- a/src/app/api/export/route.ts
+++ b/src/app/api/export/route.ts
@@ -27,6 +27,8 @@ export async function GET(req: NextRequest) {
   const supabase = createClient();
 
   if (table === "daily_logs") {
+    // CSV エクスポートのため全列 select("*") が必要。
+    // front SSR 用 projection query (src/lib/queries/dailyLogs.ts) とは異なる経路。
     let query = supabase.from("daily_logs").select("*").order("log_date", { ascending: true });
     if (start) query = query.gte("log_date", start);
     if (end) query = query.lte("log_date", end);

--- a/src/lib/hooks/useDailyLogs.ts
+++ b/src/lib/hooks/useDailyLogs.ts
@@ -1,3 +1,18 @@
+/**
+ * useDailyLogs — MealLogger 専用クライアントサイド SWR フック
+ *
+ * ## スコープと制約
+ *
+ * - このフックは **client component (MealLogger) 専用** であり、Server Components からは使わないこと
+ * - `daily_logs` の **全列 full read** を行う（`select("*")`）
+ *   - 理由: MealLogger はフォーム hydration に既存ログの全フィールドが必要
+ *   - front 側の Server Component ページは `src/lib/queries/dailyLogs.ts` の projection query を使うこと
+ * - 保存後は `mutate()` でキャッシュを更新する（revalidatePath ではなく SWR 側で即時反映）
+ *
+ * ## full read が許容される理由
+ * Client Component がブラウザから直接フォームを操作するため、
+ * どの列が編集されるか事前に絞れない。Server Component SSR 側の read 最適化とは別物として扱う。
+ */
 "use client";
 
 import useSWR from "swr";

--- a/src/lib/queries/dailyLogs.ts
+++ b/src/lib/queries/dailyLogs.ts
@@ -1,20 +1,35 @@
 /**
- * daily_logs テーブルの read 責務を集約する。
+ * daily_logs テーブルの **front SSR 専用 projection query** を集約する。
+ *
+ * ## このモジュールのスコープ
+ *
+ * - Server Components / Server Actions / Route Handlers が Next.js SSR 時に呼ぶ read query
+ * - すべての関数は「画面が必要とする列のみ」の projection query であり、全列 full read は含まない
+ * - write 系・UI 固有文言はここに含めない
+ *
+ * ## full read が必要な箇所（このモジュール外で管理）
+ *
+ * | 経路 | 場所 | 用途 |
+ * |---|---|---|
+ * | Client SWR hook    | `src/lib/hooks/useDailyLogs.ts`    | MealLogger フォーム hydration 用クライアント全列取得 |
+ * | CSV export route   | `src/app/api/export/route.ts`      | CSV ダウンロード用全列取得（全列が必要）              |
+ * | ML/batch (Python)  | `ml-pipeline/enrich.py`, `analyze.py` | TDEE・因子分析バッチ。supabase-py 経由で直接読む    |
+ *
+ * front 側の Server Component ページがこれらの経路を使わないようにすること。
+ * 新しい画面を追加する場合は、必要な列を絞った専用 query をここに追加すること。
  *
  * ## 現行クエリ一覧
  *
  * | 関数 | 取得列 | 用途 | 戻り値型 |
  * |---|---|---|---|
- * | fetchDashboardDailyLogs()   | 16列（note・leg_flag 除く） | Dashboard 専用 (#165)          | QueryResult |
- * | fetchMacroDailyLogs(days)   | 6列・DESC LIMIT days        | Macro 専用 (#166)              | QueryResult |
- * | fetchTdeeDailyLogs(limit)   | 3列・DESC LIMIT limit       | TDEE raw fallback 専用 (#166)  | QueryResult |
- * | fetchLatestUpdatedAt()      | updated_at 1行              | stale 判定用（Macro/TDEE共用） | ベストエフォート |
- * | fetchWeightLogs()           | log_date, weight            | History ページ補助             | ベストエフォート |
- * | fetchDailyLogsForSettings() | log_date, weight, calories  | Settings DataQuality 計算      | QueryResult |
+ * | fetchDashboardDailyLogs()   | 16列（note・leg_flag 除く）  | Dashboard 専用 (#165)                | QueryResult |
+ * | fetchMacroDailyLogs(days)   | 6列・DESC LIMIT days         | Macro 専用 (#166)                    | QueryResult |
+ * | fetchTdeeDailyLogs(limit)   | 3列・DESC LIMIT limit        | TDEE raw fallback 専用 (#166)        | QueryResult |
+ * | fetchLatestUpdatedAt()      | updated_at 1行               | stale 判定用（Macro/TDEE共用）       | ベストエフォート |
+ * | fetchWeightLogs()           | log_date, weight             | History ページ補助                   | ベストエフォート |
+ * | fetchDailyLogsForSettings() | log_date, weight, calories   | Settings DataQuality 計算            | QueryResult |
  *
  * 詳細: docs/daily-logs-read-inventory.md
- *
- * ## write 系・UI 固有文言はここに含めない
  */
 import { createClient } from "@/lib/supabase/server";
 import type { DailyLog, DashboardDailyLog, MacroDailyLog, TdeeDailyLog, CareerLog, Prediction } from "@/lib/supabase/types";

--- a/src/lib/queries/queryResult.ts
+++ b/src/lib/queries/queryResult.ts
@@ -11,7 +11,7 @@
  * この型を使用する関数 (空状態と取得エラーを区別すべき主要クエリ):
  *   - fetchDashboardDailyLogs   (daily_logs 16列 — Dashboard 専用)
  *   - fetchMacroDailyLogs       (daily_logs 6列 LIMIT 60 — Macro 専用)
- *   - fetchTdeeDailyLogs        (daily_logs 3列 LIMIT 30 — TDEE 専用)
+ *   - fetchTdeeDailyLogs        (daily_logs 3列 LIMIT 180 — TDEE 専用)
  *   - fetchDailyLogsForSettings (daily_logs — settings ページ用)
  *   - fetchCareerLogs           (career_logs — history ページ主データ)
  *   - fetchSettings             (settings → AppSettings 変換)


### PR DESCRIPTION
## Summary

- `src/lib/queries/dailyLogs.ts` のヘッダーを刷新し「front SSR 専用 projection query モジュール」と明示
  - full read の所在（useDailyLogs hook / export route / ML batch）を一覧化
  - 新画面追加時の指針を追記
- `src/lib/hooks/useDailyLogs.ts` に docstring 追加（client-side full read・MealLogger 専用・SSR query 層とは別レイヤーと明記）
- `src/app/api/export/route.ts` の full read にコメント追加（CSV export のため全列必要、projection query 経路と別物）
- `src/lib/queries/queryResult.ts`: `fetchTdeeDailyLogs` コメントの LIMIT 30 → 180 修正
- `docs/daily-logs-read-inventory.md`: #167 サマリー・front/full-read 境界テーブル・拡張指針を追加

## 設計判断: `fetchDailyLogsFull()` を新設しない理由

- front SSR 側は #165/#166 で projection query 完全分離済み
- 残る full read はすべて別レイヤー（client hook / export Route Handler / Python batch）
- 呼び出し元のない関数を追加しても責務が混乱するだけ
- 責務境界はコメント・docstring・docs で明文化することで十分

## full read 経路の整理結果

| 経路 | ファイル | クライアント |
|---|---|---|
| Client SWR hook | `src/lib/hooks/useDailyLogs.ts` | Browser (anon key) |
| CSV export route | `src/app/api/export/route.ts` | Server Route Handler (anon key) |
| ML batch enrich/analyze | `ml-pipeline/enrich.py`, `analyze.py` | Python supabase-py (service_role key) |

## Test plan

- [x] `npx tsc --noEmit` — 型エラーなし
- [x] `npx jest --no-coverage` — 914 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)