### PR TITLE
feat: improve dashboard mobile reading flow (#174)

### DIFF
--- a/src/components/dashboard/DashboardLayout.tsx
+++ b/src/components/dashboard/DashboardLayout.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { PanelLeftClose, PanelLeftOpen, PenLine } from "lucide-react";
 import { MealLogger } from "@/components/meal/MealLogger";
+import { MobileMealLoggerSheet } from "./MobileMealLoggerSheet";
 
 interface DashboardLayoutProps {
   children: React.ReactNode;
@@ -74,12 +75,12 @@ export function DashboardLayout({ children, header }: DashboardLayoutProps) {
 
       {/* メインコンテンツ */}
       <main className="min-w-0 flex-1 flex flex-col gap-6">
-        {/* モバイル用 MealLogger（lg 以上では非表示） */}
-        <div className="lg:hidden rounded-2xl border border-slate-100 bg-white p-5 shadow-sm">
-          <MealLogger sidebar />
-        </div>
-
         {children}
+
+        {/* モバイル用 MealLogger: 閲覧コンテンツの後に trigger を配置し、
+            bottom sheet で入力フォームを開く（lg+ では描画なし）。
+            閲覧導線（KPI → GoalNavigator → WeeklyReview → Tabs）を先に確保する。 */}
+        <MobileMealLoggerSheet />
       </main>
       </div>
     </div>

--- a/src/components/dashboard/KpiCards.tsx
+++ b/src/components/dashboard/KpiCards.tsx
@@ -117,7 +117,7 @@ export function KpiCards({ logs, settings }: KpiCardsProps) {
   const goalReachLabel = goalReachResult.label;
 
   return (
-    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
       {/* 現在体重 */}
       <KpiCard
         label="現在体重"

--- a/src/components/dashboard/LogsAndSummaryTabs.tsx
+++ b/src/components/dashboard/LogsAndSummaryTabs.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { RecentLogsTable } from "./RecentLogsTable";
+import { RecentLogsCards } from "./RecentLogsCards";
 import { MonthlyCalendar } from "./MonthlyCalendar";
 import { MonthlyGoalTable } from "./MonthlyGoalTable";
 import { SeasonSummary } from "@/components/history/SeasonSummary";
@@ -25,7 +26,7 @@ type Tab = "logs" | "calendar" | "monthly";
 const TAB_LABELS: Record<Tab, string> = {
   logs:     "直近ログ",
   calendar: "カレンダー",
-  monthly:  "月別サマリー",
+  monthly:  "月別",
 };
 
 export function LogsAndSummaryTabs({ logs, monthStats, seasonMap, currentSeason, monthlyGoalSummaryRows, phase }: LogsAndSummaryTabsProps) {
@@ -56,7 +57,13 @@ export function LogsAndSummaryTabs({ logs, monthStats, seasonMap, currentSeason,
       <div className="p-4 sm:p-5">
         {tab === "logs" && (
           <div role="tabpanel" id="panel-logs" aria-labelledby="tab-logs">
-            <RecentLogsTable logs={logs} embedded seasonMap={seasonMap} currentSeason={currentSeason} />
+            {/* モバイル: カードリスト。sm+ ではテーブル表示に切り替え */}
+            <div className="sm:hidden">
+              <RecentLogsCards logs={logs} seasonMap={seasonMap} currentSeason={currentSeason} />
+            </div>
+            <div className="hidden sm:block">
+              <RecentLogsTable logs={logs} embedded seasonMap={seasonMap} currentSeason={currentSeason} />
+            </div>
           </div>
         )}
         {tab === "calendar" && (

--- a/src/components/dashboard/MobileMealLoggerSheet.tsx
+++ b/src/components/dashboard/MobileMealLoggerSheet.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+/**
+ * MobileMealLoggerSheet — モバイル専用の食事ログ入力 bottom sheet
+ *
+ * デスクトップ (lg+) では何も描画しない（aside の MealLogger を使う）。
+ * モバイルでは trigger ボタンを表示し、タップで bottom sheet を開く。
+ *
+ * - backdrop クリック / Esc / × ボタン で閉じる
+ * - sheet open 中は body スクロールを抑制する
+ * - z-50 で MobileBottomNav (z-30) より上に重なる
+ */
+
+import { useState, useEffect } from "react";
+import { PenLine, X } from "lucide-react";
+import { MealLogger } from "@/components/meal/MealLogger";
+
+export function MobileMealLoggerSheet() {
+  const [open, setOpen] = useState(false);
+
+  // Escape キーで閉じる
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  // sheet 開閉中は body スクロールを抑制
+  useEffect(() => {
+    document.body.style.overflow = open ? "hidden" : "";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [open]);
+
+  return (
+    <div className="lg:hidden">
+      {/* ── Trigger ── */}
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="flex w-full items-center justify-center gap-2 rounded-2xl border border-blue-100 bg-blue-50 py-3.5 text-sm font-semibold text-blue-700 transition-colors hover:bg-blue-100 active:bg-blue-200"
+      >
+        <PenLine size={16} />
+        食事・体重を記録する
+      </button>
+
+      {/* ── Backdrop ── */}
+      {open && (
+        <div
+          className="fixed inset-0 z-50 bg-black/40"
+          aria-hidden="true"
+          onClick={() => setOpen(false)}
+        />
+      )}
+
+      {/* ── Bottom Sheet ── */}
+      {open && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="食事・体重ログ入力"
+          className="fixed bottom-0 left-0 right-0 z-50 max-h-[88svh] rounded-t-2xl bg-white shadow-2xl"
+          style={{ paddingBottom: "env(safe-area-inset-bottom, 0px)" }}
+        >
+          {/* Sheet ヘッダー */}
+          <div className="flex items-center justify-between border-b border-slate-100 px-5 py-3">
+            <div className="flex items-center gap-2">
+              <div className="flex h-7 w-7 items-center justify-center rounded-xl bg-blue-50">
+                <PenLine size={14} className="text-blue-600" />
+              </div>
+              <span className="text-sm font-semibold text-slate-700">食事ログ</span>
+            </div>
+            <button
+              type="button"
+              onClick={() => setOpen(false)}
+              aria-label="食事ログを閉じる"
+              className="flex h-8 w-8 items-center justify-center rounded-lg text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600"
+            >
+              <X size={18} />
+            </button>
+          </div>
+
+          {/* Sheet コンテンツ（スクロール可能） */}
+          <div
+            className="overflow-y-auto px-5 py-4"
+            style={{ maxHeight: "calc(88svh - 56px)" }}
+          >
+            <MealLogger sidebar showHeader={false} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/dashboard/RecentLogsCards.tsx
+++ b/src/components/dashboard/RecentLogsCards.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+/**
+ * RecentLogsCards — 直近ログのモバイル向けカードリスト表示
+ *
+ * RecentLogsTable はデスクトップ用の横スクロール table。
+ * このコンポーネントはモバイルで各行を縦積みカードとして表示し、
+ * 日付・体重・カロリーの要点を視認しやすくする。
+ *
+ * 表示情報を意図的に絞る:
+ *   - 日付（font-mono）+ シーズン・タグバッジ
+ *   - 体重 + 前日比
+ *   - カロリー
+ * 詳細（条件メモ・sleep_hours など）は secondary として小さく添える。
+ */
+
+import { ArrowDown, ArrowUp, Minus } from "lucide-react";
+import type { DashboardDailyLog } from "@/lib/supabase/types";
+import { DAY_TAGS, DAY_TAG_LABELS, DAY_TAG_BADGE_COLORS } from "@/lib/utils/dayTags";
+import { formatConditionSummary } from "@/lib/utils/trainingType";
+
+interface RecentLogsCardsProps {
+  logs: DashboardDailyLog[];
+  seasonMap?: Map<string, string>;
+  currentSeason?: string | null;
+}
+
+export function RecentLogsCards({ logs, seasonMap, currentSeason }: RecentLogsCardsProps) {
+  const sorted = [...logs]
+    .filter((d) => d.weight !== null)
+    .sort((a, b) => b.log_date.localeCompare(a.log_date))
+    .slice(0, 14);
+
+  const ascending = [...logs]
+    .filter((d) => d.weight !== null)
+    .sort((a, b) => a.log_date.localeCompare(b.log_date));
+
+  function getDelta(log: DashboardDailyLog): number | null {
+    const idx = ascending.findIndex((d) => d.log_date === log.log_date);
+    if (idx <= 0) return null;
+    const prev = ascending[idx - 1];
+    if (prev.weight === null || log.weight === null) return null;
+    return log.weight - prev.weight;
+  }
+
+  if (sorted.length === 0) {
+    return (
+      <p className="py-6 text-center text-sm text-slate-400">ログがありません</p>
+    );
+  }
+
+  return (
+    <div className="divide-y divide-slate-50">
+      {sorted.map((log) => {
+        const delta = getDelta(log);
+        const DeltaIcon =
+          delta === null ? null : delta > 0 ? ArrowUp : delta < 0 ? ArrowDown : Minus;
+        const season = seasonMap?.get(log.log_date) ?? currentSeason;
+        const conditionSummary = formatConditionSummary({
+          had_bowel_movement: log.had_bowel_movement as boolean | null,
+          training_type: log.training_type,
+          work_mode: log.work_mode,
+        });
+
+        return (
+          <div
+            key={log.log_date}
+            className="flex items-start justify-between gap-3 py-3"
+          >
+            {/* 左: 日付 + バッジ */}
+            <div className="min-w-0 flex-1">
+              <div className="font-mono text-xs font-medium text-slate-600">
+                {log.log_date}
+              </div>
+              <div className="mt-0.5 flex flex-wrap gap-1">
+                {season && (
+                  <span className="rounded-full bg-blue-50 px-1.5 py-0.5 text-[9px] font-semibold leading-none text-blue-500">
+                    {season}
+                  </span>
+                )}
+                {DAY_TAGS.filter((tag) => log[tag]).map((tag) => (
+                  <span
+                    key={tag}
+                    className={`rounded-full px-1.5 py-0.5 text-[9px] font-semibold leading-none ${DAY_TAG_BADGE_COLORS[tag]}`}
+                  >
+                    {DAY_TAG_LABELS[tag]}
+                  </span>
+                ))}
+              </div>
+              {(conditionSummary || log.sleep_hours !== null) && (
+                <div className="mt-0.5 text-[10px] leading-snug text-slate-400">
+                  {[
+                    conditionSummary,
+                    log.sleep_hours !== null ? `${log.sleep_hours}h` : null,
+                  ]
+                    .filter(Boolean)
+                    .join(" / ")}
+                </div>
+              )}
+            </div>
+
+            {/* 右: 体重 + カロリー */}
+            <div className="flex-shrink-0 text-right">
+              <div className="flex items-baseline justify-end gap-1">
+                <span className="font-semibold text-slate-800">
+                  {log.weight?.toFixed(1)}
+                </span>
+                <span className="text-xs text-slate-400">kg</span>
+                {delta !== null && DeltaIcon && (
+                  <span
+                    className={`inline-flex items-center gap-0.5 text-xs font-semibold ${
+                      delta > 0
+                        ? "text-rose-500"
+                        : delta < 0
+                        ? "text-blue-500"
+                        : "text-slate-300"
+                    }`}
+                  >
+                    <DeltaIcon size={11} />
+                    {Math.abs(delta).toFixed(1)}
+                  </span>
+                )}
+              </div>
+              <div className="mt-0.5 text-xs text-slate-500">
+                {log.calories !== null ? (
+                  <>
+                    {log.calories.toLocaleString()}
+                    <span className="ml-0.5 text-[10px] text-slate-400">kcal</span>
+                  </>
+                ) : (
+                  <span className="text-slate-300">—</span>
+                )}
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #174

## 変更概要

1. **MobileMealLoggerSheet** (新規) — モバイル専用 bottom sheet 入力 UI
2. **DashboardLayout** — 閲覧導線を先に、入力 trigger を後に配置
3. **KpiCards** — モバイル 1 列表示（2+1 崩れ解消）
4. **RecentLogsCards** (新規) — 直近ログのモバイル向けカードリスト
5. **LogsAndSummaryTabs** — タブラベル短縮 + ログタブにカードビュー追加

## モバイル導線の変更内容

### 表示順（変更前 → 変更後）
| 変更前 | 変更後 |
|---|---|
| 1. MealLogger（常時展開） | 1. KpiCards |
| 2. KpiCards | 2. GoalNavigator |
| 3. GoalNavigator | 3. WeeklyReview |
| 4. WeeklyReview | 4. ForecastChart |
| 5. ForecastChart | 5. LogsAndSummaryTabs |
| 6. LogsAndSummaryTabs | 6. 「食事・体重を記録する」trigger |

### MealLogger
- 常時展開 → trigger ボタン（`食事・体重を記録する`）からのみ開く
- タップで bottom sheet が開き、Esc / backdrop / × で閉じる
- デスクトップ aside の常時表示構成は維持

### KpiCards
- `grid-cols-2`（2+1 崩れ）→ `grid-cols-1 sm:grid-cols-3`（縦積み 1 列 → sm+ 3 列）

### LogsAndSummaryTabs / RecentLogs
- タブラベル「月別サマリー」→「月別」
- ログタブ: sm 未満で `RecentLogsCards`（カードリスト）、sm+ で `RecentLogsTable`（テーブル）
- カードは日付・タグ・体重+前日比・カロリーを縦積みで表示（横スクロール不要）

## desktop への影響

- デスクトップ: `DashboardLayout` の aside + MealLogger 構成を維持
- `MobileMealLoggerSheet` は `lg:hidden` のため desktop に影響なし
- `KpiCards` の `sm:grid-cols-3` で sm+ は 3 列を維持
- `RecentLogsCards` は `sm:hidden` のため sm+ には非表示

## テスト結果

- `tsc --noEmit`: エラーなし
- `jest --no-coverage`: 935 passed / 38 suites（既存テスト全件パス）
- `eslint`: 変更ファイル全件クリーン

## 残課題

- GoalNavigator のモバイル結論サマリー優先化（分析ロジック変更を伴わない UI 調整で可能だが今回スコープ外）
- Monthly Summary のモバイル要点カード（TableScroll で横スクロールは対応済み、カード化は次 Issue）
- MobileMealLoggerSheet のフォーカストラップ（基本操作は揃えたが、A11y 強化は将来課題）

🤖 Generated with [Claude Code](https://claude.com/claude-code)