### PR TITLE
feat: reorganize settings page for mobile sections (#178)

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -41,9 +41,22 @@ export default async function SettingsPage() {
       <div className="space-y-6">
         <SettingsForm initialSettings={settingsRows} currentWeight={currentWeight} />
         <DataQualityPanel report={qualityReport} />
-        <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-          <ExportSection />
-          <ImportSection />
+
+        {/* データ操作セクション: エクスポート / インポート */}
+        <div>
+          <div className="mb-3 flex items-center gap-3">
+            <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+              データ操作
+            </span>
+            <div className="flex-1 border-t border-slate-100" />
+            <span className="rounded-full bg-amber-50 px-2.5 py-1 text-xs font-medium text-amber-600">
+              既存データに影響します
+            </span>
+          </div>
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+            <ExportSection />
+            <ImportSection />
+          </div>
         </div>
       </div>
     </PageShell>

--- a/src/components/settings/DataQualityPanel.tsx
+++ b/src/components/settings/DataQualityPanel.tsx
@@ -2,6 +2,10 @@
  * DataQualityPanel — 設定ページ向け詳細品質パネル
  *
  * Server Component。props は settings/page.tsx で計算済みの report を受け取る。
+ *
+ * 表示構造:
+ *   - 常時表示: 総合スコアバッジ（7日 / 14日）
+ *   - <details>: 詳細ウィンドウ・異常値リスト（折りたたみ可能、JS 不要）
  */
 
 import type { DataQualityReport, QualityWindow } from "@/lib/utils/calcDataQuality";
@@ -26,6 +30,12 @@ function scoreBorder(score: number): string {
   if (score >= 90) return "border-emerald-200";
   if (score >= 70) return "border-amber-200";
   return "border-rose-200";
+}
+
+function scoreLabel(score: number): string {
+  if (score >= 90) return "良好";
+  if (score >= 70) return "注意";
+  return "要確認";
 }
 
 function WindowSection({ title, w }: { title: string; w: QualityWindow }) {
@@ -93,50 +103,89 @@ function WindowSection({ title, w }: { title: string; w: QualityWindow }) {
 }
 
 export function DataQualityPanel({ report }: Props) {
+  const minScore = Math.min(report.period7.score, report.period14.score);
+
   return (
     <div className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
-      <h2 className="mb-1 text-base font-bold text-gray-800">データ品質レポート</h2>
-      <p className="mb-4 text-xs text-gray-500">
-        直近 7日 / 14日 ウィンドウの欠損・異常値を自動検出します。
-        閾値: 体重 ±{3.0} kg 超、カロリー {500}〜{8000} kcal 範囲外。
-      </p>
-
-      <div className="space-y-4">
-        <WindowSection title="直近 7 日" w={report.period7} />
-        <WindowSection title="直近 14 日" w={report.period14} />
-
-        {/* 重複日付 */}
-        <div className="rounded-xl border border-gray-200 bg-gray-50 p-4">
-          <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-gray-500">
-            重複日付
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-bold text-gray-800">データ品質レポート</h2>
+          <p className="mt-0.5 text-xs text-gray-500">
+            直近 7日 / 14日 ウィンドウの欠損・異常値を自動検出
           </p>
-          {report.duplicateDates.length === 0 ? (
-            <p className="text-sm text-emerald-600">なし</p>
-          ) : (
-            <ul className="flex flex-wrap gap-2">
-              {report.duplicateDates.map((d) => (
-                <li key={d} className="rounded bg-rose-100 px-2 py-0.5 text-xs font-mono text-rose-700">
-                  {d}
-                </li>
-              ))}
-            </ul>
-          )}
         </div>
+        {/* 総合ステータスバッジ */}
+        <span className={`rounded-full px-3 py-1 text-xs font-bold ${scoreColor(minScore)} ${scoreBg(minScore)} border ${scoreBorder(minScore)}`}>
+          {scoreLabel(minScore)}
+        </span>
       </div>
 
-      {/* スコア凡例 */}
-      <div className="mt-4 flex flex-wrap gap-4 text-xs text-gray-400">
-        <span>
-          <span className="font-semibold text-emerald-600">90〜100</span>: 良好
-        </span>
-        <span>
-          <span className="font-semibold text-amber-600">70〜89</span>: 注意
-        </span>
-        <span>
-          <span className="font-semibold text-rose-600">0〜69</span>: 要確認
-        </span>
-        <span className="ml-auto">体重欠損 −10 / カロリー欠損 −5 / 異常値 −15</span>
+      {/* スコアサマリー行 — 常時表示 */}
+      <div className="mt-4 flex flex-wrap gap-3">
+        {([
+          { label: "直近 7 日", w: report.period7 },
+          { label: "直近 14 日", w: report.period14 },
+        ] as const).map(({ label, w }) => (
+          <div
+            key={label}
+            className={`flex items-center gap-2 rounded-xl border px-3 py-2 text-sm ${scoreBg(w.score)} ${scoreBorder(w.score)}`}
+          >
+            <span className="text-xs text-gray-500">{label}</span>
+            <span className={`font-bold tabular-nums ${scoreColor(w.score)}`}>{w.score}<span className="text-xs font-normal">/100</span></span>
+            {w.weightMissingDays > 0 && (
+              <span className="text-xs text-amber-600">体重欠損 {w.weightMissingDays}日</span>
+            )}
+            {w.anomalies.length > 0 && (
+              <span className="text-xs text-rose-600">異常値 {w.anomalies.length}件</span>
+            )}
+          </div>
+        ))}
       </div>
+
+      {/* 詳細は <details> で折りたたみ（JS 不要） */}
+      <details className="mt-4 group">
+        <summary className="cursor-pointer select-none list-none text-xs font-medium text-slate-500 hover:text-slate-700">
+          <span className="group-open:hidden">詳細を見る ▸</span>
+          <span className="hidden group-open:inline">詳細を閉じる ▾</span>
+        </summary>
+
+        <div className="mt-4 space-y-4">
+          <WindowSection title="直近 7 日" w={report.period7} />
+          <WindowSection title="直近 14 日" w={report.period14} />
+
+          {/* 重複日付 */}
+          <div className="rounded-xl border border-gray-200 bg-gray-50 p-4">
+            <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-gray-500">
+              重複日付
+            </p>
+            {report.duplicateDates.length === 0 ? (
+              <p className="text-sm text-emerald-600">なし</p>
+            ) : (
+              <ul className="flex flex-wrap gap-2">
+                {report.duplicateDates.map((d) => (
+                  <li key={d} className="rounded bg-rose-100 px-2 py-0.5 text-xs font-mono text-rose-700">
+                    {d}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          {/* スコア凡例 */}
+          <div className="flex flex-wrap gap-4 text-xs text-gray-400">
+            <span>
+              <span className="font-semibold text-emerald-600">90〜100</span>: 良好
+            </span>
+            <span>
+              <span className="font-semibold text-amber-600">70〜89</span>: 注意
+            </span>
+            <span>
+              <span className="font-semibold text-rose-600">0〜69</span>: 要確認
+            </span>
+            <span className="ml-auto">体重欠損 −10 / カロリー欠損 −5 / 異常値 −15</span>
+          </div>
+        </div>
+      </details>
     </div>
   );
 }

--- a/src/components/settings/SettingsForm.integration.test.tsx
+++ b/src/components/settings/SettingsForm.integration.test.tsx
@@ -28,6 +28,7 @@ jest.mock("lucide-react", () => ({
   CheckCircle2: () => <span data-testid="icon-check" />,
   AlertCircle: () => <span data-testid="icon-alert" />,
   Loader2: () => <span data-testid="icon-loader" />,
+  ChevronDown: () => <span data-testid="icon-chevron-down" />,
 }));
 
 // MonthlyGoalPlanSection はこのテストのスコープ外なのでモックする

--- a/src/components/settings/SettingsForm.tsx
+++ b/src/components/settings/SettingsForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useMemo } from "react";
-import { Save, CheckCircle2, AlertCircle, Loader2 } from "lucide-react";
+import { Save, CheckCircle2, AlertCircle, Loader2, ChevronDown } from "lucide-react";
 import { saveSettings } from "@/app/settings/actions";
 import type { Setting } from "@/lib/supabase/types";
 import { toJstDateStr } from "@/lib/utils/date";
@@ -27,12 +27,12 @@ interface FieldMeta {
 const FIELDS: Record<string, FieldMeta> = {
   current_season:    { label: "現在のシーズン", type: "text", placeholder: "2026_TokyoNovice" },
   current_phase:     { label: "現在のフェーズ", type: "select", options: ["Cut", "Bulk"] },
-  sex:               { label: "性別", type: "select", options: ["male", "female"], optionLabels: ["男性", "女性"] },
-  goal_weight:       { label: "目標体重", unit: "kg", type: "number", placeholder: "58.5" },
   contest_date:      { label: "コンテスト日", type: "date" },
-  activity_factor:   { label: "活動係数", unit: "1.2〜1.9", type: "number", placeholder: "1.55" },
+  goal_weight:       { label: "目標体重", unit: "kg", type: "number", placeholder: "58.5" },
+  sex:               { label: "性別", type: "select", options: ["male", "female"], optionLabels: ["男性", "女性"] },
   height_cm:         { label: "身長", unit: "cm", type: "number", placeholder: "170" },
   age:               { label: "年齢", unit: "歳", type: "number", placeholder: "30" },
+  activity_factor:   { label: "活動係数", unit: "1.2〜1.9", type: "number", placeholder: "1.55" },
 };
 
 const MACRO_TARGET_FIELDS: Record<string, FieldMeta> = {
@@ -42,7 +42,9 @@ const MACRO_TARGET_FIELDS: Record<string, FieldMeta> = {
   target_carbs_g:       { label: "目標炭水化物", unit: "g", type: "number", placeholder: "200" },
 };
 
-const FIELD_KEYS = Object.keys(FIELDS);
+// セクション別フィールドキー
+const SEASON_FIELD_KEYS = ["current_season", "current_phase", "contest_date"];
+const BODY_FIELD_KEYS = ["goal_weight", "sex", "height_cm", "age", "activity_factor"];
 const MACRO_TARGET_KEYS = Object.keys(MACRO_TARGET_FIELDS);
 
 /** PFC由来kcal = P×4 + F×9 + C×4 。いずれか未入力なら null */
@@ -57,6 +59,115 @@ function calcPfcDerivedKcal(values: Record<string, string>): number | null {
 const inputCls =
   "w-full rounded-xl border border-slate-200 bg-slate-50 px-3 py-2.5 text-sm text-slate-800 outline-none transition-colors focus:border-blue-400 focus:bg-white focus:ring-2 focus:ring-blue-100 placeholder:text-slate-400";
 
+// ─── アコーディオン セクション ────────────────────────────────────────────────
+
+interface FormSectionProps {
+  id: string;
+  title: string;
+  subtitle?: string;
+  isOpen: boolean;
+  onToggle: () => void;
+  children: React.ReactNode;
+  border?: boolean;
+}
+
+function FormSection({ id, title, subtitle, isOpen, onToggle, children, border = true }: FormSectionProps) {
+  const panelId = `settings-panel-${id}`;
+  return (
+    <div className={border ? "mt-5 border-t border-slate-100 pt-5" : ""}>
+      <div className="flex items-start justify-between">
+        <div>
+          <h2 className="text-sm font-semibold text-slate-700">{title}</h2>
+          {subtitle && <p className="mt-0.5 text-xs text-slate-400">{subtitle}</p>}
+        </div>
+        {/* アコーディオントグル: モバイルのみ表示。sm+ は常に展開 */}
+        <button
+          type="button"
+          onClick={onToggle}
+          aria-expanded={isOpen}
+          aria-controls={panelId}
+          className="sm:hidden ml-3 flex-shrink-0 rounded-lg p-1 text-slate-400 hover:bg-slate-50 hover:text-slate-600"
+        >
+          <ChevronDown
+            size={16}
+            className={`transition-transform duration-200 ${isOpen ? "rotate-180" : ""}`}
+          />
+        </button>
+      </div>
+      {/* sm+ では常に表示。モバイルでは isOpen でトグル */}
+      <div
+        id={panelId}
+        role="region"
+        className={`mt-4 ${!isOpen ? "hidden sm:block" : ""}`}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ─── フィールド描画ヘルパー ────────────────────────────────────────────────────
+
+function FieldItem({
+  fieldKey,
+  meta,
+  value,
+  error,
+  onChange,
+}: {
+  fieldKey: string;
+  meta: FieldMeta;
+  value: string;
+  error?: string;
+  onChange: (val: string) => void;
+}) {
+  return (
+    <div>
+      <label className="mb-1.5 block text-xs font-semibold uppercase tracking-wide text-slate-400">
+        {meta.label}
+        {meta.unit && <span className="ml-1 normal-case font-normal text-slate-300">({meta.unit})</span>}
+      </label>
+
+      {meta.type === "select" ? (
+        <div role="radiogroup" aria-label={meta.label} className="flex gap-2">
+          {meta.options!.map((opt, i) => (
+            <button
+              key={opt}
+              type="button"
+              role="radio"
+              aria-checked={value === opt}
+              onClick={() => onChange(opt)}
+              className={`flex-1 rounded-xl border py-2.5 text-sm font-semibold transition-all ${
+                value === opt
+                  ? opt === "Cut"
+                    ? "border-blue-400 bg-blue-600 text-white shadow-sm"
+                    : "border-emerald-400 bg-emerald-600 text-white shadow-sm"
+                  : "border-slate-200 bg-slate-50 text-slate-500 hover:border-slate-300 hover:bg-slate-100"
+              }`}
+            >
+              {meta.optionLabels?.[i] ?? opt}
+            </button>
+          ))}
+        </div>
+      ) : (
+        <input
+          type={meta.type}
+          step={meta.type === "number" ? "any" : undefined}
+          placeholder={meta.placeholder}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className={`${inputCls} ${error ? "border-rose-400 focus:border-rose-400 focus:ring-rose-100" : ""}`}
+        />
+      )}
+      {error && (
+        <p className="mt-1 text-xs text-rose-500">{error}</p>
+      )}
+    </div>
+  );
+}
+
+// ─── メインコンポーネント ────────────────────────────────────────────────────
+
 export function SettingsForm({ initialSettings, currentWeight = null }: SettingsFormProps) {
   const initMap = Object.fromEntries(
     initialSettings.map((s) => [
@@ -68,6 +179,18 @@ export function SettingsForm({ initialSettings, currentWeight = null }: Settings
   const [values, setValues] = useState<Record<string, string>>(initMap);
   const [status, setStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+
+  // アコーディオン開閉状態: デフォルトは "season" セクションのみ開く
+  const [openSections, setOpenSections] = useState(() => new Set(["season"]));
+
+  function toggleSection(id: string) {
+    setOpenSections((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
 
   // 月次目標計画の手動 override リスト。JSON 文字列で DB に保存される。
   const [monthlyPlanOverrides, setMonthlyPlanOverrides] = useState<MonthlyGoalOverride[]>(() => {
@@ -159,85 +282,88 @@ export function SettingsForm({ initialSettings, currentWeight = null }: Settings
 
   return (
     <div className="rounded-2xl border border-slate-100 bg-white p-6 shadow-sm">
-      <h2 className="mb-5 text-sm font-semibold text-slate-700">基本設定</h2>
 
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        {FIELD_KEYS.map((key) => {
-          const meta = FIELDS[key];
-          return (
-            <div key={key}>
-              <label className="mb-1.5 block text-xs font-semibold uppercase tracking-wide text-slate-400">
-                {meta.label}
-                {meta.unit && <span className="ml-1 normal-case font-normal text-slate-300">({meta.unit})</span>}
-              </label>
-
-              {meta.type === "select" ? (
-                <div role="radiogroup" aria-label={meta.label} className="flex gap-2">
-                  {meta.options!.map((opt, i) => (
-                    <button
-                      key={opt}
-                      type="button"
-                      role="radio"
-                      aria-checked={values[key] === opt}
-                      onClick={() => set(key, opt)}
-                      className={`flex-1 rounded-xl border py-2.5 text-sm font-semibold transition-all ${
-                        values[key] === opt
-                          ? opt === "Cut"
-                            ? "border-blue-400 bg-blue-600 text-white shadow-sm"
-                            : "border-emerald-400 bg-emerald-600 text-white shadow-sm"
-                          : "border-slate-200 bg-slate-50 text-slate-500 hover:border-slate-300 hover:bg-slate-100"
-                      }`}
-                    >
-                      {meta.optionLabels?.[i] ?? opt}
-                    </button>
-                  ))}
-                </div>
-              ) : (
-                <input
-                  type={meta.type}
-                  step={meta.type === "number" ? "any" : undefined}
-                  placeholder={meta.placeholder}
-                  value={values[key] ?? ""}
-                  onChange={(e) => set(key, e.target.value)}
-                  className={`${inputCls} ${fieldErrors[key] ? "border-rose-400 focus:border-rose-400 focus:ring-rose-100" : ""}`}
-                />
-              )}
-              {fieldErrors[key] && (
-                <p className="mt-1 text-xs text-rose-500">{fieldErrors[key]}</p>
-              )}
-            </div>
-          );
-        })}
+      {/* ── セクション 1: シーズン・コンテスト (デフォルト展開) ── */}
+      <div>
+        <div className="flex items-start justify-between">
+          <div>
+            <h2 className="text-sm font-semibold text-slate-700">シーズン・コンテスト</h2>
+            <p className="mt-0.5 text-xs text-slate-400">大会日・シーズン名・フェーズを設定します</p>
+          </div>
+          <button
+            type="button"
+            onClick={() => toggleSection("season")}
+            aria-expanded={openSections.has("season")}
+            aria-controls="settings-panel-season"
+            className="sm:hidden ml-3 flex-shrink-0 rounded-lg p-1 text-slate-400 hover:bg-slate-50 hover:text-slate-600"
+          >
+            <ChevronDown
+              size={16}
+              className={`transition-transform duration-200 ${openSections.has("season") ? "rotate-180" : ""}`}
+            />
+          </button>
+        </div>
+        <div
+          id="settings-panel-season"
+          role="region"
+          className={`mt-4 ${!openSections.has("season") ? "hidden sm:block" : ""}`}
+        >
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            {SEASON_FIELD_KEYS.map((key) => (
+              <FieldItem
+                key={key}
+                fieldKey={key}
+                meta={FIELDS[key]}
+                value={values[key] ?? ""}
+                error={fieldErrors[key]}
+                onChange={(val) => set(key, val)}
+              />
+            ))}
+          </div>
+        </div>
       </div>
 
-      {/* 目標マクロ設定 */}
-      <div className="mt-6 border-t border-slate-100 pt-6">
-        <h2 className="mb-1.5 text-sm font-semibold text-slate-700">目標マクロ</h2>
-        <p className="mb-4 text-xs text-slate-400">Macro 画面の差分表示に使用します。</p>
+      {/* ── セクション 2: 目標・身体情報 ── */}
+      <FormSection
+        id="body"
+        title="目標・身体情報"
+        subtitle="目標体重・性別・身長・年齢・活動係数"
+        isOpen={openSections.has("body")}
+        onToggle={() => toggleSection("body")}
+      >
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {BODY_FIELD_KEYS.map((key) => (
+            <FieldItem
+              key={key}
+              fieldKey={key}
+              meta={FIELDS[key]}
+              value={values[key] ?? ""}
+              error={fieldErrors[key]}
+              onChange={(val) => set(key, val)}
+            />
+          ))}
+        </div>
+      </FormSection>
 
+      {/* ── セクション 3: 目標マクロ ── */}
+      <FormSection
+        id="macro"
+        title="目標マクロ"
+        subtitle="Macro 画面の差分表示に使用します"
+        isOpen={openSections.has("macro")}
+        onToggle={() => toggleSection("macro")}
+      >
         <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-          {MACRO_TARGET_KEYS.map((key) => {
-            const meta = MACRO_TARGET_FIELDS[key];
-            return (
-              <div key={key}>
-                <label className="mb-1.5 block text-xs font-semibold uppercase tracking-wide text-slate-400">
-                  {meta.label}
-                  {meta.unit && <span className="ml-1 normal-case font-normal text-slate-300">({meta.unit})</span>}
-                </label>
-                <input
-                  type="number"
-                  step="any"
-                  placeholder={meta.placeholder}
-                  value={values[key] ?? ""}
-                  onChange={(e) => set(key, e.target.value)}
-                  className={`${inputCls} ${fieldErrors[key] ? "border-rose-400 focus:border-rose-400 focus:ring-rose-100" : ""}`}
-                />
-                {fieldErrors[key] && (
-                  <p className="mt-1 text-xs text-rose-500">{fieldErrors[key]}</p>
-                )}
-              </div>
-            );
-          })}
+          {MACRO_TARGET_KEYS.map((key) => (
+            <FieldItem
+              key={key}
+              fieldKey={key}
+              meta={MACRO_TARGET_FIELDS[key]}
+              value={values[key] ?? ""}
+              error={fieldErrors[key]}
+              onChange={(val) => set(key, val)}
+            />
+          ))}
         </div>
 
         {/* PFC由来kcal 参考表示 + 整合性警告 */}
@@ -252,14 +378,16 @@ export function SettingsForm({ initialSettings, currentWeight = null }: Settings
             {pfcConsistencyWarning}
           </p>
         )}
-      </div>
+      </FormSection>
 
-      {/* 月次目標計画 */}
-      <div className="mt-6 border-t border-slate-100 pt-6">
-        <h2 className="mb-1.5 text-sm font-semibold text-slate-700">月次目標計画</h2>
-        <p className="mb-4 text-xs text-slate-400">
-          コンテスト日・目標体重をもとに月末の目標体重を自動配分します。各月を手動で上書きすると翌月以降が再配分されます。
-        </p>
+      {/* ── セクション 4: 月次目標計画 ── */}
+      <FormSection
+        id="plan"
+        title="月次目標計画"
+        subtitle="コンテスト日・目標体重をもとに月末目標体重を自動配分します"
+        isOpen={openSections.has("plan")}
+        onToggle={() => toggleSection("plan")}
+      >
         <MonthlyGoalPlanSection
           goalWeight={(() => { const v = parseFloat(values["goal_weight"] ?? ""); return isFinite(v) ? v : null; })()}
           contestDate={values["contest_date"] || null}
@@ -268,19 +396,29 @@ export function SettingsForm({ initialSettings, currentWeight = null }: Settings
           overrides={monthlyPlanOverrides}
           onOverridesChange={setMonthlyPlanOverrides}
         />
-      </div>
+      </FormSection>
 
-      <div className="mt-6 flex items-center justify-end gap-3">
-        {status === "error" && (
-          <span className="flex items-center gap-1.5 text-xs font-medium text-rose-500">
-            <AlertCircle size={14} /> 保存に失敗しました
-          </span>
-        )}
-        {status === "saved" && (
-          <span className="flex items-center gap-1.5 text-xs font-medium text-emerald-600">
-            <CheckCircle2 size={14} /> 保存しました
-          </span>
-        )}
+      {/* ── 保存エリア ──
+          モバイル: fixed で bottom nav の上に浮かせる
+          sm+    : static でフォーム末尾にインライン表示
+      */}
+      <div
+        className="fixed left-0 right-0 z-40 flex items-center justify-between gap-3 border-t border-slate-100 bg-white/95 px-4 py-3 shadow-lg backdrop-blur-sm sm:static sm:mt-6 sm:justify-end sm:border-0 sm:bg-transparent sm:p-0 sm:shadow-none sm:backdrop-blur-none"
+        style={{ bottom: "calc(var(--bottom-nav-height, 56px) + env(safe-area-inset-bottom, 0px))" }}
+      >
+        {/* ステータス表示 */}
+        <div className="flex items-center gap-1.5 text-xs font-medium sm:mr-3">
+          {status === "error" && (
+            <span className="flex items-center gap-1.5 text-rose-500">
+              <AlertCircle size={13} /> 保存に失敗しました
+            </span>
+          )}
+          {status === "saved" && (
+            <span className="flex items-center gap-1.5 text-emerald-600">
+              <CheckCircle2 size={13} /> 保存しました
+            </span>
+          )}
+        </div>
         <button
           onClick={handleSave}
           disabled={status === "saving"}


### PR DESCRIPTION
## Summary

- **SettingsForm — 4セクション分割 + モバイルアコーディオン**: シーズン・コンテスト / 目標・身体情報 / 目標マクロ / 月次目標計画 の4セクションに分割。モバイルでは「シーズン・コンテスト」のみデフォルト展開、他は折りたたみ。sm+ では全セクション常時表示（ChevronDown ボタンは `sm:hidden`）
- **SettingsForm — 保存導線改善**: 保存バーをモバイルで `fixed`（bottom nav 上）、sm+ では `sm:static` インラインに変更。DOM上はボタン1つのため既存テスト互換性を維持
- **DataQualityPanel — 要約化**: 7日/14日スコアバッジを常時表示。詳細ウィンドウは `<details>/<summary>` で折りたたみ（JS 不要、Server Component のまま）
- **settings/page.tsx — データ操作セクション分離**: Export / Import グリッドの前に「データ操作」ヘッダー + 「既存データに影響します」アンバーバッジを追加

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `src/components/settings/SettingsForm.tsx` | セクション分割・アコーディオン・保存バー改善 |
| `src/components/settings/DataQualityPanel.tsx` | スコアサマリー追加・詳細 details 化 |
| `src/app/settings/page.tsx` | データ操作セクションヘッダー追加 |
| `src/components/settings/SettingsForm.integration.test.tsx` | ChevronDown をモックに追加 |

## Test plan

- [ ] `npx tsc --noEmit` — clean (verified)
- [ ] `npx jest --no-coverage` — 935/935 pass (verified)
- [ ] モバイル幅: シーズン・コンテストセクションのみ展開、他は折りたたみ表示
- [ ] 保存バーがスクロール中も bottom nav の上に固定表示される
- [ ] 各アコーディオントグルで開閉、入力中の値が失われない
- [ ] DataQualityPanel のスコアバッジが常時表示、「詳細を見る」で展開可能
- [ ] Export / Import が「データ操作」ヘッダー + アンバーバッジで通常設定と視覚分離
- [ ] sm+ (desktop): 全セクション常時表示、ChevronDown ボタン非表示、インライン保存ボタン表示

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)