### PR TITLE
feat: add mobile card views for tdee and macro daily tables (#176)

### DIFF
--- a/src/components/macro/MacroDailyTable.tsx
+++ b/src/components/macro/MacroDailyTable.tsx
@@ -32,10 +32,93 @@ export function MacroDailyTable({ data, calTarget = null }: MacroDailyTableProps
     return absDiffs.length > 0 ? Math.max(...absDiffs) : 0;
   })();
 
+  if (recent.length === 0) {
+    return (
+      <div className="rounded-2xl border border-gray-100 bg-white p-5 shadow-sm">
+        <h2 className="mb-2 text-sm font-semibold text-gray-700">日次栄養内訳（直近 14 日）</h2>
+        <p className="text-sm text-gray-400">データがありません。</p>
+      </div>
+    );
+  }
+
   return (
-    <div className="rounded-2xl border border-gray-100 bg-white p-5 shadow-sm">
-      <h2 className="mb-4 text-base font-semibold text-gray-700">日次栄養内訳（直近 14 日）</h2>
-      <div className="overflow-x-auto">
+    <div className="rounded-2xl border border-gray-100 bg-white shadow-sm">
+      <div className="px-5 pt-5 pb-1">
+        <h2 className="text-sm font-semibold text-gray-700">日次栄養内訳（直近 14 日）</h2>
+      </div>
+
+      {/* ── モバイル: カードリスト (md 未満) ── */}
+      <div className="md:hidden divide-y divide-slate-50 px-4 pb-4">
+        {recent.map((row) => {
+          const calDiff = calTarget != null ? row.calories - calTarget : null;
+          const calRatio = calDiff !== null ? getNormalizedDiffWidth(calDiff, maxAbs) : 0;
+
+          return (
+            <div key={row.fullDate} className="py-3">
+              {/* 行 1: 日付 + カロリー + 差分 */}
+              <div className="flex items-baseline justify-between">
+                <span className="font-mono text-xs font-medium text-slate-600">{row.fullDate}</span>
+                <div className="flex items-baseline gap-1">
+                  <span className="tabular-nums text-sm font-semibold text-slate-700">
+                    {row.calories.toLocaleString()}
+                  </span>
+                  <span className="text-xs text-slate-400">kcal</span>
+                  {calDiff !== null && (
+                    <span
+                      className={`tabular-nums text-xs font-medium ${
+                        calDiff > 0
+                          ? "text-blue-500"
+                          : calDiff < 0
+                          ? "text-rose-500"
+                          : "text-slate-400"
+                      }`}
+                    >
+                      ({calDiff > 0 ? "+" : ""}{Math.round(calDiff)})
+                    </span>
+                  )}
+                </div>
+              </div>
+
+              {/* 行 2: P / F / C グリッド */}
+              <div className="mt-2 grid grid-cols-3 gap-1.5 text-xs">
+                {[
+                  { label: "P", value: row.protein, mult: 4 },
+                  { label: "F", value: row.fat,     mult: 9 },
+                  { label: "C", value: row.carbs,   mult: 4 },
+                ].map(({ label, value, mult }) => (
+                  <div
+                    key={label}
+                    className="rounded-lg bg-slate-50 px-2 py-1.5 text-center"
+                  >
+                    <div className="text-[10px] font-semibold uppercase tracking-wide text-slate-400">
+                      {label}
+                    </div>
+                    <div className="font-medium text-slate-700 tabular-nums">{value}g</div>
+                    <div className="text-[10px] text-slate-400">
+                      {pct(value, row.calories, mult)}
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              {/* 行 3: Diverging bar（目標設定時のみ） */}
+              {calDiff !== null && (
+                <div className="mt-2">
+                  <DivergingBar
+                    diff={calDiff}
+                    ratio={calRatio}
+                    leftColor="bg-rose-400"
+                    rightColor="bg-blue-400"
+                  />
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* ── デスクトップ: テーブル (md+) ── */}
+      <div className="hidden md:block overflow-x-auto px-5 pb-5 pt-4">
         <table className="w-full text-sm">
           <thead>
             <tr className="border-b border-gray-100 text-left text-xs text-gray-500">
@@ -54,7 +137,6 @@ export function MacroDailyTable({ data, calTarget = null }: MacroDailyTableProps
                 <tr key={row.fullDate} className="border-b border-gray-50 hover:bg-gray-50">
                   <td className="py-2 pr-4 font-medium text-gray-700">{row.fullDate}</td>
                   <td className="py-2 pr-4">
-                    {/* テキスト: 実績値 + 差分 */}
                     <div className="flex items-baseline gap-1">
                       <span className="text-xs text-gray-600">{row.calories.toLocaleString()}</span>
                       <span className="text-[10px] text-gray-400">kcal</span>
@@ -72,7 +154,6 @@ export function MacroDailyTable({ data, calTarget = null }: MacroDailyTableProps
                         </span>
                       )}
                     </div>
-                    {/* diverging bar（目標設定時のみ） */}
                     {calDiff !== null && (
                       <div className="mt-1">
                         <DivergingBar

--- a/src/components/tdee/TdeeDailyTable.tsx
+++ b/src/components/tdee/TdeeDailyTable.tsx
@@ -35,10 +35,79 @@ export function TdeeDailyTable({ data, phase = null }: TdeeDailyTableProps) {
 
   const { leftColor, rightColor } = getBalanceBarColors(phase);
 
+  if (recent.length === 0) {
+    return (
+      <div className="rounded-2xl border border-gray-100 bg-white p-5 shadow-sm">
+        <h2 className="mb-2 text-sm font-semibold text-gray-700">日次 TDEE ログ（直近 14 日）</h2>
+        <p className="text-sm text-gray-400">データがありません。</p>
+      </div>
+    );
+  }
+
   return (
-    <div className="rounded-2xl border border-gray-100 bg-white p-5 shadow-sm">
-      <h2 className="mb-4 text-base font-semibold text-gray-700">日次 TDEE ログ（直近 14 日）</h2>
-      <div className="overflow-x-auto">
+    <div className="rounded-2xl border border-gray-100 bg-white shadow-sm">
+      <div className="px-5 pt-5 pb-1">
+        <h2 className="text-sm font-semibold text-gray-700">日次 TDEE ログ（直近 14 日）</h2>
+      </div>
+
+      {/* ── モバイル: カードリスト (md 未満) ── */}
+      <div className="md:hidden divide-y divide-slate-50 px-4 pb-4">
+        {recent.map((row) => {
+          const balance =
+            row.calories !== null && row.tdee !== null
+              ? Math.round(row.calories - row.tdee)
+              : null;
+          const ratio =
+            balance !== null ? getNormalizedDiffWidth(balance, maxAbs) : 0;
+          const textColor =
+            balance !== null
+              ? getBalanceTextColor(balance, phase)
+              : "text-gray-300";
+
+          return (
+            <div key={row.date} className="py-3">
+              {/* 行 1: 日付 + 収支 */}
+              <div className="flex items-baseline justify-between">
+                <span className="font-mono text-xs font-medium text-slate-600">{row.date}</span>
+                <span className={`tabular-nums text-sm font-semibold ${textColor}`}>
+                  {balance !== null
+                    ? `${balance > 0 ? "+" : ""}${balance.toLocaleString()} kcal`
+                    : "—"}
+                </span>
+              </div>
+              {/* 行 2: TDEE + 摂取 */}
+              <div className="mt-1 flex items-center gap-5 text-xs">
+                <div>
+                  <span className="text-slate-400">TDEE </span>
+                  <span className="font-medium text-slate-700 tabular-nums">
+                    {row.tdee !== null ? Math.round(row.tdee).toLocaleString() : "—"}
+                  </span>
+                </div>
+                <div>
+                  <span className="text-slate-400">摂取 </span>
+                  <span className="font-medium text-slate-700 tabular-nums">
+                    {row.calories !== null ? row.calories.toLocaleString() : "—"}
+                  </span>
+                </div>
+              </div>
+              {/* 行 3: Diverging bar */}
+              {balance !== null && (
+                <div className="mt-2">
+                  <DivergingBar
+                    diff={balance}
+                    ratio={ratio}
+                    leftColor={leftColor}
+                    rightColor={rightColor}
+                  />
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* ── デスクトップ: テーブル (md+) ── */}
+      <div className="hidden md:block overflow-x-auto px-5 pb-5 pt-4">
         <table className="w-full text-sm">
           <thead>
             <tr className="border-b border-gray-100 text-left text-xs text-gray-500">
@@ -72,13 +141,11 @@ export function TdeeDailyTable({ data, phase = null }: TdeeDailyTableProps) {
                   </td>
                   <td className="py-2">
                     <div className="flex flex-col gap-1">
-                      {/* 数値テキスト */}
                       <span className={`text-xs font-medium ${textColor}`}>
                         {balance !== null
                           ? `${balance > 0 ? "+" : ""}${balance.toLocaleString()}`
                           : "—"}
                       </span>
-                      {/* diverging bar（balance がある行のみ） */}
                       {balance !== null && (
                         <DivergingBar
                           diff={balance}


### PR DESCRIPTION
## Summary

- **TdeeDailyTable**: `md:hidden` カードリスト追加 — 各行を「日付 + 収支 / TDEE + 摂取 / DivergingBar」の3行カードで表示。デスクトップ表は `hidden md:block`。空データ時のメッセージも追加
- **MacroDailyTable**: `md:hidden` カードリスト追加 — 各行を「日付 + kcal+差分 / P·F·C グリッド(g/%) / DivergingBar」の3行カードで表示。デスクトップ表は `hidden md:block`。空データ時のメッセージも追加
- 主要指標（TDEE/摂取/収支、kcal/P/F/C）をカード先頭に集約。横スクロールなしで全情報が読める
- 集計ロジック・指標定義・デスクトップ体験は変更なし

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `src/components/tdee/TdeeDailyTable.tsx` | モバイルカードビュー追加・デスクトップテーブル分岐・空状態ハンドリング |
| `src/components/macro/MacroDailyTable.tsx` | モバイルカードビュー追加・デスクトップテーブル分岐・空状態ハンドリング |

## mobile 日次表示の変更内容

### TDEE カード（1行あたり）
```
[2026-01-15]                  [+234 kcal]  ← 収支（色分け）
TDEE 2,100   摂取 2,334
[===DivergingBar===]
```

### Macro カード（1行あたり）
```
[2026-01-15]           [2,200 kcal (+150)]
┌──────┐ ┌──────┐ ┌──────┐
│  P   │ │  F   │ │  C   │
│ 150g │ │  60g │ │ 220g │
│  27% │ │  24% │ │  40% │
└──────┘ └──────┘ └──────┘
[===DivergingBar===]
```

- 空状態: データなしメッセージをカード内に表示（mobile/desktop 共通）
- デスクトップ: 既存テーブルをそのまま `hidden md:block` で維持

## Test plan

- [ ] `npx tsc --noEmit` — clean (verified)
- [ ] `npx jest --no-coverage` — 935/935 pass (verified)
- [ ] モバイル幅 (< 768px): `/tdee` でカードリスト表示、横スクロールなし
- [ ] モバイル幅 (< 768px): `/macro` でカードリスト表示、P/F/C グリッド確認
- [ ] desktop (≥ 768px): 既存テーブル表示、カードは非表示
- [ ] 収支・差分の色分けが正しい（Cut: 赤方向=摂取過多、緑=摂取不足）
- [ ] DivergingBar がカード内でも正しく描画される

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)