### PR TITLE
feat: foods page mobile search-first UI

### DIFF
--- a/src/components/foods/FoodTable.tsx
+++ b/src/components/foods/FoodTable.tsx
@@ -164,9 +164,21 @@ export function FoodTable({ initialFoods }: FoodTableProps) {
   const visibleFoods = filtered.slice(0, visibleCount);
 
   return (
-    <div className="space-y-4">
-      {/* ── セクションヘッダー ── */}
-      <div className="flex items-center justify-between">
+    <div className="flex flex-col gap-4">
+      {/* ── 検索（mobile: 最上位 / desktop: 2番目）── */}
+      <div className="relative order-1 md:order-2">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400" size={15} />
+        <input
+          type="text"
+          placeholder="食品名で検索..."
+          value={query}
+          onChange={(e) => { setQuery(e.target.value); setVisibleCount(15); }}
+          className="w-full rounded-xl border border-slate-200 bg-white py-2.5 pl-9 pr-3 text-sm outline-none focus:border-blue-400 focus:ring-2 focus:ring-blue-100"
+        />
+      </div>
+
+      {/* ── セクションヘッダー（mobile: 2番目 / desktop: 最上位）── */}
+      <div className="flex items-center justify-between order-2 md:order-1">
         <div>
           <h2 className="text-sm font-semibold text-slate-700">食品マスタ</h2>
           <p className="text-xs text-slate-400">100g あたりの栄養値</p>
@@ -182,21 +194,9 @@ export function FoodTable({ initialFoods }: FoodTableProps) {
         </button>
       </div>
 
-      {/* ── 検索 ── */}
-      <div className="relative">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400" size={15} />
-        <input
-          type="text"
-          placeholder="食品名で検索..."
-          value={query}
-          onChange={(e) => { setQuery(e.target.value); setVisibleCount(15); }}
-          className="w-full rounded-xl border border-slate-200 bg-white py-2 pl-9 pr-3 text-sm outline-none focus:border-blue-400 focus:ring-2 focus:ring-blue-100"
-        />
-      </div>
-
       {/* ── カテゴリフィルター ── */}
       {categories.length > 1 && (
-        <div className="flex gap-1.5 overflow-x-auto pb-1">
+        <div className="flex gap-1.5 overflow-x-auto pb-1 order-3">
           {categories.map((cat) => (
             <button
               key={cat}
@@ -215,7 +215,7 @@ export function FoodTable({ initialFoods }: FoodTableProps) {
 
       {/* ── 追加フォーム ── */}
       {showForm && (
-        <div className="rounded-2xl border border-blue-100 bg-blue-50 p-4">
+        <div className="rounded-2xl border border-blue-100 bg-blue-50 p-4 order-4">
           <p className="mb-3 text-sm font-semibold text-slate-700">新規食品を追加 (100g あたり)</p>
           <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
             {(["name", "calories", "protein", "fat", "carbs"] as const).map((field) => (
@@ -301,7 +301,7 @@ export function FoodTable({ initialFoods }: FoodTableProps) {
       )}
 
       {/* ── 食品リスト ── */}
-      <div className="rounded-2xl border border-slate-100 bg-white shadow-sm overflow-hidden">
+      <div className="rounded-2xl border border-slate-100 bg-white shadow-sm overflow-hidden order-5">
 
         {/* モバイル: カードリスト (md 未満) */}
         <div className="md:hidden divide-y divide-slate-50">

--- a/src/components/foods/MenuTable.tsx
+++ b/src/components/foods/MenuTable.tsx
@@ -268,61 +268,125 @@ export function MenuTable({ initialMenus, foods }: MenuTableProps) {
         </div>
       )}
 
-      {/* メニュー一覧 */}
+      {/* ── メニュー一覧 ── */}
       {menus.length === 0 ? (
         <p className="rounded-2xl border border-gray-100 bg-white p-8 text-center text-sm text-gray-400">
           セットメニューが登録されていません
         </p>
       ) : (
-        <ul className="rounded-2xl border border-gray-100 bg-white shadow-sm divide-y divide-gray-50">
-          {menus.map((menu) => {
-            const kcal = calcRecipeKcal(menu.recipe, foodMap);
-            const isOpen = expandedMenu === menu.name;
-            return (
-              <li key={menu.name}>
-                <div className="flex items-center justify-between px-4 py-3">
-                  <button
-                    onClick={() => setExpandedMenu(isOpen ? null : menu.name)}
-                    className="flex flex-1 items-center gap-2 text-left"
-                  >
-                    {isOpen ? <ChevronUp size={15} className="text-gray-400" /> : <ChevronDown size={15} className="text-gray-400" />}
-                    <span className="text-sm font-medium text-gray-800">{menu.name}</span>
-                    <span className="text-xs text-gray-400">{menu.recipe.length} 品 / {kcal} kcal</span>
-                  </button>
-                  <div className="flex items-center gap-2">
+        <>
+          {/* モバイル: カードリスト (md 未満) */}
+          <div className="md:hidden space-y-2">
+            {menus.map((menu) => {
+              const kcal = calcRecipeKcal(menu.recipe, foodMap);
+              const isOpen = expandedMenu === menu.name;
+              return (
+                <div key={menu.name} className="rounded-2xl border border-slate-100 bg-white shadow-sm overflow-hidden">
+                  {/* カードヘッダー */}
+                  <div className="flex items-start gap-2 px-4 py-3">
                     <button
-                      onClick={() => startEdit(menu)}
-                      className="rounded px-2 py-1 text-xs text-blue-500 hover:bg-blue-50"
+                      onClick={() => setExpandedMenu(isOpen ? null : menu.name)}
+                      className="min-w-0 flex-1 text-left"
                     >
-                      編集
+                      <div className="text-sm font-semibold text-slate-800">{menu.name}</div>
+                      <div className="mt-0.5 flex items-baseline gap-1.5 text-xs text-slate-400">
+                        <span>{menu.recipe.length} 品</span>
+                        <span className="text-slate-300">·</span>
+                        <span className="tabular-nums text-base font-bold text-slate-700">{kcal}</span>
+                        <span>kcal</span>
+                        {isOpen
+                          ? <ChevronUp size={13} className="ml-1 text-slate-400" />
+                          : <ChevronDown size={13} className="ml-1 text-slate-400" />}
+                      </div>
                     </button>
-                    <button
-                      onClick={() => handleDelete(menu.name)}
-                      disabled={isPending}
-                      className="text-gray-300 hover:text-rose-500 disabled:opacity-40"
-                    >
-                      <Trash2 size={15} />
-                    </button>
+                    <div className="flex flex-shrink-0 items-center gap-1">
+                      <button
+                        onClick={() => startEdit(menu)}
+                        className="rounded-lg px-2.5 py-1.5 text-xs font-medium text-blue-500 hover:bg-blue-50"
+                      >
+                        編集
+                      </button>
+                      <button
+                        onClick={() => handleDelete(menu.name)}
+                        disabled={isPending}
+                        className="p-2 -mr-1 text-slate-300 hover:text-rose-500 disabled:opacity-40"
+                        aria-label={`${menu.name}を削除`}
+                      >
+                        <Trash2 size={16} />
+                      </button>
+                    </div>
                   </div>
+                  {/* 展開: 食材リスト */}
+                  {isOpen && (
+                    <div className="border-t border-slate-50 bg-slate-50 px-4 py-3 space-y-1.5">
+                      {menu.recipe.map((ri, i) => {
+                        const food = foodMap.get(ri.name);
+                        const itemKcal = food ? Math.round((food.calories * ri.amount) / 100) : 0;
+                        return (
+                          <div key={i} className="flex justify-between text-xs text-slate-600">
+                            <span>{ri.name}</span>
+                            <span className="tabular-nums text-slate-400">{ri.amount}g · {itemKcal} kcal</span>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  )}
                 </div>
-                {isOpen && (
-                  <ul className="border-t border-gray-50 bg-gray-50 px-6 py-2 space-y-1">
-                    {menu.recipe.map((ri, i) => {
-                      const food = foodMap.get(ri.name);
-                      const kcal = food ? Math.round((food.calories * ri.amount) / 100) : 0;
-                      return (
-                        <li key={i} className="flex justify-between text-xs text-gray-600">
-                          <span>{ri.name}</span>
-                          <span>{ri.amount}g — {kcal} kcal</span>
-                        </li>
-                      );
-                    })}
-                  </ul>
-                )}
-              </li>
-            );
-          })}
-        </ul>
+              );
+            })}
+          </div>
+
+          {/* デスクトップ: リスト (md+) */}
+          <ul className="hidden md:block rounded-2xl border border-gray-100 bg-white shadow-sm divide-y divide-gray-50">
+            {menus.map((menu) => {
+              const kcal = calcRecipeKcal(menu.recipe, foodMap);
+              const isOpen = expandedMenu === menu.name;
+              return (
+                <li key={menu.name}>
+                  <div className="flex items-center justify-between px-4 py-3">
+                    <button
+                      onClick={() => setExpandedMenu(isOpen ? null : menu.name)}
+                      className="flex flex-1 items-center gap-2 text-left"
+                    >
+                      {isOpen ? <ChevronUp size={15} className="text-gray-400" /> : <ChevronDown size={15} className="text-gray-400" />}
+                      <span className="text-sm font-medium text-gray-800">{menu.name}</span>
+                      <span className="text-xs text-gray-400">{menu.recipe.length} 品 / {kcal} kcal</span>
+                    </button>
+                    <div className="flex items-center gap-2">
+                      <button
+                        onClick={() => startEdit(menu)}
+                        className="rounded px-2 py-1 text-xs text-blue-500 hover:bg-blue-50"
+                      >
+                        編集
+                      </button>
+                      <button
+                        onClick={() => handleDelete(menu.name)}
+                        disabled={isPending}
+                        className="text-gray-300 hover:text-rose-500 disabled:opacity-40"
+                      >
+                        <Trash2 size={15} />
+                      </button>
+                    </div>
+                  </div>
+                  {isOpen && (
+                    <ul className="border-t border-gray-50 bg-gray-50 px-6 py-2 space-y-1">
+                      {menu.recipe.map((ri, i) => {
+                        const food = foodMap.get(ri.name);
+                        const itemKcal = food ? Math.round((food.calories * ri.amount) / 100) : 0;
+                        return (
+                          <li key={i} className="flex justify-between text-xs text-gray-600">
+                            <span>{ri.name}</span>
+                            <span>{ri.amount}g — {itemKcal} kcal</span>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- **FoodTable (search-first)**: flex+order で要素を並び替え、モバイルでは検索バーが最上位（`order-1`）、デスクトップでは従来通りセクションヘッダーが先頭（`md:order-1`）。タップターゲットも `py-2.5` に拡大
- **FoodTable (mobile cards)**: `md:hidden` カードリスト（食品名 / カテゴリバッジ / kcal 大字 / PFC）+ `hidden md:block` デスクトップテーブル
- **MenuTable (mobile cards)**: `md:hidden` カードビュー（メニュー名 / kcal 大字 / 品数 / タップで食材展開）+ `hidden md:block` デスクトップリスト。FoodTable と同じ slate パレット / rounded-2xl で統一
- **MenuTable (header)**: `text-sm font-semibold text-slate-700` + サブタイトル + `rounded-xl` ボタンで FoodTable と視覚的に揃える

## Test plan
- [ ] `npx tsc --noEmit` — no errors
- [ ] `npx jest --no-coverage` — 935 tests pass
- [ ] **モバイル (<768px)**: 検索バーが最上位に表示される（セクションヘッダーより上）
- [ ] **モバイル**: FoodTable 食品カードが name / category / kcal / PFC を表示
- [ ] **モバイル**: MenuTable メニューカードが name / kcal 大字 / 品数を表示、タップで食材展開
- [ ] **デスクトップ (≥768px)**: FoodTable ソート可能テーブル、MenuTable コンパクトリストが従来通り
- [ ] カテゴリ絞り込み / 検索 / load-more が両ビューで正常動作
- [ ] 編集フォーム (MenuTable) が変わらず動作

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)