### PR TITLE
feat: simplify forecast accuracy page for mobile (#179)

### DIFF
--- a/src/app/forecast-accuracy/page.tsx
+++ b/src/app/forecast-accuracy/page.tsx
@@ -11,7 +11,7 @@ export const revalidate = 3600; // 1時間キャッシュ (バッチは週1回)
 
 function ForecastTitle({ children }: { children?: React.ReactNode }) {
   return (
-    <div className="mb-4 flex items-center gap-2 md:mb-6">
+    <div className="mb-4 flex flex-wrap items-center gap-x-2 gap-y-1.5 md:mb-6">
       <BarChart2 size={20} className="text-blue-600" />
       <h1 className="text-xl font-bold text-slate-800">予測精度評価</h1>
       {children}
@@ -76,7 +76,7 @@ export default async function ForecastAccuracyPage() {
     <PageShell
       titleSlot={
         <ForecastTitle>
-          <span className="text-xs text-slate-400">データは週次バッチで更新されます</span>
+          <span className="hidden sm:inline text-xs text-slate-400">データは週次バッチで更新されます</span>
           <ForecastAccuracyRefreshButton />
         </ForecastTitle>
       }

--- a/src/components/charts/BacktestComparison.tsx
+++ b/src/components/charts/BacktestComparison.tsx
@@ -147,8 +147,47 @@ export function BacktestComparison({
         </div>
       )}
 
-      {/* ── 比較テーブル ── */}
-      <div className="overflow-x-auto">
+      {/* ── モバイル: horizon 別サマリーカード (md 未満) ── */}
+      <div className="md:hidden p-4 space-y-3">
+        {HORIZONS.map((h) => {
+          const dBest = dailyBest[h];
+          const sBest = sma7Best[h];
+          const nrPct = noiseReductionPct(dBest?.mae ?? null, sBest?.mae ?? null);
+          return (
+            <div key={h} className="rounded-xl border border-slate-100 bg-slate-50 px-4 py-3">
+              <p className="mb-2 text-xs font-bold text-slate-600">D+{h} 日先</p>
+              <div className="flex flex-wrap items-start gap-x-6 gap-y-2 text-xs">
+                {hasDailyData && dBest && (
+                  <div>
+                    <p className="mb-0.5 font-medium text-blue-500">単日評価 ★</p>
+                    <p className="font-semibold text-slate-700">{MODEL_LABELS[dBest.model] ?? dBest.model}</p>
+                    <p className="font-mono text-slate-500">MAE {fmt3(dBest.mae)}</p>
+                  </div>
+                )}
+                {hasSma7Data && sBest && (
+                  <div>
+                    <p className="mb-0.5 font-medium text-emerald-600">7日平均評価 ★</p>
+                    <p className="font-semibold text-slate-700">{MODEL_LABELS[sBest.model] ?? sBest.model}</p>
+                    <p className="font-mono text-slate-500">MAE {fmt3(sBest.mae)}</p>
+                  </div>
+                )}
+                {hasDailyData && hasSma7Data && nrPct !== null && (
+                  <div className="ml-auto text-right">
+                    <p className="mb-0.5 text-slate-400">ノイズ除去率</p>
+                    <p className={`text-base font-bold tabular-nums ${noiseReductionColor(nrPct)}`}>{nrPct}%</p>
+                  </div>
+                )}
+              </div>
+            </div>
+          );
+        })}
+        <p className="text-[10px] text-slate-400">
+          ★ = ホライズン別最良モデル / ノイズ除去率 = (1 − 7日均MAE ÷ 単日MAE) × 100%
+        </p>
+      </div>
+
+      {/* ── デスクトップ: 比較テーブル (md+) ── */}
+      <div className="hidden md:block overflow-x-auto">
         <table className="w-full min-w-[600px] text-sm">
           <thead>
             <tr className="border-b border-slate-100 bg-slate-50 text-xs font-semibold uppercase tracking-wide text-slate-400">
@@ -247,10 +286,10 @@ export function BacktestComparison({
             </tfoot>
           )}
         </table>
-      </div>
+      </div>{/* end hidden md:block */}
 
-      {/* ── フッター注記 ── */}
-      <div className="border-t border-slate-50 bg-slate-50 px-5 py-2.5 text-[11px] text-slate-400">
+      {/* ── フッター注記（デスクトップのみ）── */}
+      <div className="hidden md:block border-t border-slate-50 bg-slate-50 px-5 py-2.5 text-[11px] text-slate-400">
         <span>
           ★ = ホライズン別最良モデル / MAE: 平均絶対誤差 (kg) / ノイズ除去率 = (1 − 7日均MAE ÷ 単日MAE) × 100%
         </span>

--- a/src/components/charts/BacktestResults.integration.test.tsx
+++ b/src/components/charts/BacktestResults.integration.test.tsx
@@ -1,0 +1,213 @@
+/**
+ * BacktestResults / BacktestComparison mobile UI 結合テスト
+ *
+ * 検証内容:
+ * 1. Best model カードが sm:grid-cols-3 (モバイルで縦積み可能) レイアウトになっている
+ * 2. モバイル詳細カードが horizon ごとにレンダリングされる (md:hidden)
+ * 3. BacktestComparison のモバイル horizon サマリーカードが表示される (md:hidden)
+ * 4. ForecastAccuracyRefreshButton が refresh ボタンをレンダリングする
+ */
+
+// @jest-environment jest-environment-jsdom
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import type {
+  ForecastBacktestRun,
+  ForecastBacktestMetric,
+} from "@/lib/supabase/types";
+
+// recharts をモック
+jest.mock("recharts", () => ({
+  BarChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="recharts-bar-chart">{children}</div>
+  ),
+  Bar: () => <div data-testid="recharts-bar" />,
+  XAxis: () => <div data-testid="recharts-xaxis" />,
+  YAxis: () => <div data-testid="recharts-yaxis" />,
+  CartesianGrid: () => <div data-testid="recharts-grid" />,
+  Tooltip: () => <div data-testid="recharts-tooltip" />,
+  Legend: () => <div data-testid="recharts-legend" />,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="recharts-container">{children}</div>
+  ),
+}));
+
+// lucide-react をモック
+jest.mock("lucide-react", () => ({
+  AlertTriangle: () => <span data-testid="icon-alert" />,
+  AlertCircle: () => <span data-testid="icon-alert-circle" />,
+  TrendingUp: () => <span data-testid="icon-trending-up" />,
+  TrendingDown: () => <span data-testid="icon-trending-down" />,
+  Minus: () => <span data-testid="icon-minus" />,
+  Info: () => <span data-testid="icon-info" />,
+}));
+
+import { BacktestResults } from "@/components/charts/BacktestResults";
+import { BacktestComparison } from "@/components/charts/BacktestComparison";
+
+// ─── テストフィクスチャ ─────────────────────────────────────────────────────
+
+const MOCK_RUN: ForecastBacktestRun = {
+  id: "run-1",
+  series_type: "daily",
+  created_at: "2026-03-01T00:00:00Z",
+  train_min_date: "2025-01-01",
+  train_max_date: "2026-02-28",
+  n_source_rows: 200,
+  notes: null,
+};
+
+function makeMetric(
+  model: string,
+  horizon: number,
+  mae: number
+): ForecastBacktestMetric {
+  return {
+    id: `${model}-${horizon}`,
+    run_id: "run-1",
+    model_name: model,
+    horizon_days: horizon,
+    mae,
+    rmse: mae * 1.2,
+    mape: mae * 5,
+    bias: 0.01,
+    n_predictions: 30,
+  };
+}
+
+const MOCK_METRICS: ForecastBacktestMetric[] = [
+  makeMetric("NeuralProphet",   7,  0.345),
+  makeMetric("Naive",           7,  0.520),
+  makeMetric("MovingAverage7d", 7,  0.380),
+  makeMetric("LinearTrend30d",  7,  0.420),
+  makeMetric("EWLinearTrend",   7,  0.320), // best at 7d
+  makeMetric("NeuralProphet",   14, 0.410),
+  makeMetric("Naive",           14, 0.590),
+  makeMetric("MovingAverage7d", 14, 0.450),
+  makeMetric("LinearTrend30d",  14, 0.390), // best at 14d
+  makeMetric("EWLinearTrend",   14, 0.400),
+  makeMetric("NeuralProphet",   30, 0.480),
+  makeMetric("Naive",           30, 0.650),
+  makeMetric("MovingAverage7d", 30, 0.510),
+  makeMetric("LinearTrend30d",  30, 0.460), // best at 30d
+  makeMetric("EWLinearTrend",   30, 0.470),
+];
+
+// ─── BacktestResults ─────────────────────────────────────────────────────────
+
+describe("BacktestResults", () => {
+  it("ベストモデルカードが sm:grid-cols-3 レイアウトになっている", () => {
+    const { container } = render(
+      <BacktestResults run={MOCK_RUN} metrics={MOCK_METRICS} />
+    );
+    // Best model カードのグリッド wrapper
+    const grid = container.querySelector(".sm\\:grid-cols-3");
+    expect(grid).not.toBeNull();
+  });
+
+  it("ベストモデルカードが horizon ごとに表示される", () => {
+    render(<BacktestResults run={MOCK_RUN} metrics={MOCK_METRICS} />);
+    // 7日先 / 14日先 / 30日先 — それぞれ「最良モデル」テキスト
+    expect(screen.getAllByText(/日先 — 最良モデル/)).toHaveLength(3);
+  });
+
+  it("モバイル詳細カードが horizon ごとに見出しを表示する", () => {
+    render(<BacktestResults run={MOCK_RUN} metrics={MOCK_METRICS} />);
+    // md:hidden 内の h3 "X 日先"
+    // Tailwind のクラスは DOM に存在する (非表示はブラウザ側で制御)
+    expect(screen.getAllByText("7 日先").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("14 日先").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("30 日先").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("モバイル詳細カードで 7日先の最良モデル (EW Linear Trend) がランク1位に表示される", () => {
+    const { container } = render(
+      <BacktestResults run={MOCK_RUN} metrics={MOCK_METRICS} />
+    );
+    // md:hidden のモバイルカードセクション
+    const mobileSection = container.querySelector(".md\\:hidden.space-y-3");
+    expect(mobileSection).not.toBeNull();
+    // 7日先カードの最初のランク行に "1" と "EW Linear Trend" が存在する
+    const rankCells = mobileSection!.querySelectorAll(".bg-blue-50");
+    // 各 horizon で best=blue-50、best モデルが 3つ存在する
+    expect(rankCells.length).toBe(3);
+  });
+
+  it("デスクトップ詳細テーブルが hidden md:block ラッパー内にある", () => {
+    const { container } = render(
+      <BacktestResults run={MOCK_RUN} metrics={MOCK_METRICS} />
+    );
+    const desktopTable = container.querySelector(".hidden.md\\:block table");
+    expect(desktopTable).not.toBeNull();
+  });
+
+  it("metrics が空でもクラッシュしない", () => {
+    expect(() =>
+      render(<BacktestResults run={MOCK_RUN} metrics={[]} />)
+    ).not.toThrow();
+  });
+});
+
+// ─── BacktestComparison ───────────────────────────────────────────────────────
+
+const DAILY_METRICS: ForecastBacktestMetric[] = [
+  makeMetric("NeuralProphet",   7,  0.345),
+  makeMetric("EWLinearTrend",   7,  0.320),
+  makeMetric("NeuralProphet",   14, 0.410),
+  makeMetric("EWLinearTrend",   14, 0.390),
+  makeMetric("NeuralProphet",   30, 0.480),
+  makeMetric("LinearTrend30d",  30, 0.460),
+];
+
+const SMA7_METRICS: ForecastBacktestMetric[] = [
+  makeMetric("NeuralProphet",   7,  0.210),
+  makeMetric("EWLinearTrend",   7,  0.200),
+  makeMetric("NeuralProphet",   14, 0.280),
+  makeMetric("EWLinearTrend",   14, 0.260),
+  makeMetric("NeuralProphet",   30, 0.320),
+  makeMetric("LinearTrend30d",  30, 0.300),
+];
+
+describe("BacktestComparison", () => {
+  it("dailyMetrics も sma7Metrics も空のときは null をレンダリングする", () => {
+    const { container } = render(
+      <BacktestComparison dailyMetrics={[]} sma7Metrics={[]} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("モバイル horizon サマリーカードが 3 件 (D+7/D+14/D+30) 表示される", () => {
+    render(
+      <BacktestComparison dailyMetrics={DAILY_METRICS} sma7Metrics={SMA7_METRICS} />
+    );
+    expect(screen.getByText("D+7 日先")).toBeTruthy();
+    expect(screen.getByText("D+14 日先")).toBeTruthy();
+    expect(screen.getByText("D+30 日先")).toBeTruthy();
+  });
+
+  it("モバイルサマリーが md:hidden ラッパー内にある", () => {
+    const { container } = render(
+      <BacktestComparison dailyMetrics={DAILY_METRICS} sma7Metrics={SMA7_METRICS} />
+    );
+    const mobileSection = container.querySelector(".md\\:hidden.p-4");
+    expect(mobileSection).not.toBeNull();
+    // D+7 見出しが含まれている
+    expect(mobileSection!.textContent).toContain("D+7 日先");
+  });
+
+  it("デスクトップ比較テーブルが hidden md:block ラッパー内にある", () => {
+    const { container } = render(
+      <BacktestComparison dailyMetrics={DAILY_METRICS} sma7Metrics={SMA7_METRICS} />
+    );
+    const desktopTable = container.querySelector(".hidden.md\\:block table");
+    expect(desktopTable).not.toBeNull();
+  });
+
+  it("単日データのみのときモバイルカードが単日評価 ★ を表示する", () => {
+    render(
+      <BacktestComparison dailyMetrics={DAILY_METRICS} sma7Metrics={[]} />
+    );
+    expect(screen.getAllByText("単日評価 ★").length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/components/charts/BacktestResults.tsx
+++ b/src/components/charts/BacktestResults.tsx
@@ -104,7 +104,7 @@ export function BacktestResults({ run, metrics }: Props) {
       </div>
 
       {/* Horizon 別 Best モデル */}
-      <div className="grid grid-cols-3 gap-3">
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
         {HORIZONS.map((h) => {
           const winner = best[h];
           const cfg = winner ? MODEL_CONFIG[winner] : null;
@@ -112,7 +112,7 @@ export function BacktestResults({ run, metrics }: Props) {
           return (
             <div
               key={h}
-              className="rounded-xl border border-slate-100 bg-white p-4 shadow-sm text-center"
+              className="rounded-xl border border-slate-100 bg-white p-4 shadow-sm"
             >
               <p className="text-xs text-slate-400 mb-1">{h} 日先 — 最良モデル</p>
               <p
@@ -153,7 +153,8 @@ export function BacktestResults({ run, metrics }: Props) {
             />
             <Legend
               formatter={(name: string) => MODEL_CONFIG[name]?.label ?? name}
-              wrapperStyle={{ fontSize: 12 }}
+              wrapperStyle={{ fontSize: 11 }}
+              iconSize={10}
             />
             {MODEL_ORDER.map((model) => (
               <Bar
@@ -168,8 +169,59 @@ export function BacktestResults({ run, metrics }: Props) {
         </ResponsiveContainer>
       </div>
 
-      {/* 詳細指標テーブル */}
-      <div className="rounded-xl border border-slate-100 bg-white p-4 shadow-sm overflow-x-auto">
+      {/* 詳細指標テーブル — モバイル: horizon 別ランクカード */}
+      <div className="md:hidden space-y-3">
+        <h2 className="text-sm font-semibold text-slate-700">詳細指標（ホライズン別）</h2>
+        {HORIZONS.map((h) => {
+          const ranked = MODEL_ORDER
+            .map((model) => ({
+              model,
+              metric: metrics.find((x) => x.horizon_days === h && x.model_name === model),
+            }))
+            .filter((x): x is { model: string; metric: typeof metrics[number] } => x.metric !== undefined)
+            .sort((a, b) => a.metric.mae - b.metric.mae);
+          return (
+            <div key={h} className="rounded-xl border border-slate-100 bg-white p-4 shadow-sm">
+              <h3 className="mb-2.5 text-sm font-semibold text-slate-700">{h} 日先</h3>
+              <div className="space-y-1.5">
+                {ranked.map(({ model, metric }, rank) => {
+                  const cfg = MODEL_CONFIG[model];
+                  const isBest = rank === 0;
+                  return (
+                    <div
+                      key={model}
+                      className={`flex items-center justify-between rounded-lg px-3 py-2 ${isBest ? "bg-blue-50" : "bg-slate-50"}`}
+                    >
+                      <div className="flex items-center gap-2 min-w-0">
+                        <span className="w-4 flex-shrink-0 text-xs text-slate-400">{rank + 1}</span>
+                        <span
+                          className="h-2 w-2 flex-shrink-0 rounded-full"
+                          style={{ backgroundColor: cfg?.color ?? "#94a3b8" }}
+                        />
+                        <span className={`truncate text-xs font-medium ${isBest ? "text-blue-700" : "text-slate-600"}`}>
+                          {cfg?.label ?? model}
+                        </span>
+                      </div>
+                      <div className="flex items-center gap-3 flex-shrink-0 text-xs">
+                        <span className={`font-mono tabular-nums ${isBest ? "font-bold text-blue-600" : "text-slate-600"}`}>
+                          MAE {fmt(metric.mae)}
+                        </span>
+                        <span className="text-slate-400 tabular-nums font-mono">
+                          <BiasIcon bias={metric.bias ?? null} />
+                        </span>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+              <p className="mt-2 text-[10px] text-slate-400">MAE (kg) 昇順 / Bias: 上振れ↑ 下振れ↓ 中立 —</p>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* 詳細指標テーブル — デスクトップ: フル指標テーブル */}
+      <div className="hidden md:block rounded-xl border border-slate-100 bg-white p-4 shadow-sm overflow-x-auto">
         <h2 className="mb-3 text-sm font-semibold text-slate-700">詳細指標テーブル</h2>
         <table className="w-full min-w-max text-xs">
           <thead>


### PR DESCRIPTION
## 変更概要

1. **タイトル行のモバイル整理** — `ForecastTitle` を `flex-wrap` に変更、サブタイトルを `hidden sm:inline` で折りたたみ。モバイルでタイトルと更新ボタンが一行に収まるよう調整
2. **Best model カードの縦積み** — `grid-cols-3` → `grid-cols-1 sm:grid-cols-3`。モバイルでは横3列から縦1列へ
3. **詳細指標テーブルのモバイルカード化** — `md:hidden` でホライズン別ランクカード（MAE昇順）を表示。横スクロール依存を解消。デスクトップは `hidden md:block` で既存の全指標テーブルを維持
4. **BacktestComparison のモバイルサマリー追加** — `md:hidden` でD+7/D+14/D+30ごとの最良モデル（単日/7日均）とノイズ除去率をカード表示。デスクトップは `hidden md:block` で既存の比較テーブルを維持
5. **テスト追加** — `BacktestResults.integration.test.tsx` (11件): Best model レイアウト、モバイルカード、デスクトップテーブル、空データのエッジケース

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `src/app/forecast-accuracy/page.tsx` | ForecastTitle flex-wrap化、subtitle hidden sm:inline |
| `src/components/charts/BacktestResults.tsx` | Best model縦積み、詳細テーブルmd:hidden/md:block分岐、Legend iconSize |
| `src/components/charts/BacktestComparison.tsx` | md:hidden horizon サマリーカード追加、desktopテーブルhidden md:block化 |
| `src/components/charts/BacktestResults.integration.test.tsx` | 新規: 11テスト |

## mobile UI の変更内容

- **Best model**: `grid-cols-1 sm:grid-cols-3` で縦積みに。各カードで horizon + best model名 + MAE が一目で分かる
- **詳細表のモバイル表現**: horizon ごとのカード (7日先/14日先/30日先) にモデルを MAE 昇順でランク表示。1位は blue-50 背景でハイライト
- **BacktestComparison のモバイル要約**: D+7〜30 別カードで「どのモデルが単日/7日均でベストか」と「ノイズ除去率」を提示
- **リフレッシュボタン**: flex-wrap により title と同一行で右端に配置。狭い画面でも wrap して2行目に落ちるだけ

## desktop への影響

- **維持した点**: 全指標テーブル (MAE/RMSE/MAPE/Bias/n)、BacktestComparison の全モデル×全horizon比較テーブル、ノイズ除去率行、フッター注記はすべて `hidden md:block` で維持
- **分岐のみ**: md:hidden / hidden md:block の CSS分岐のみ。ロジック変更なし

## テスト結果

- **lint**: `npm run lint` 通過
- **test**: `npx jest --no-coverage` → 946 tests, 39 suites (全pass)
- **新規テスト 11件**: BacktestResults best model grid layout、mobile detail cards per horizon、desktop table in hidden md:block wrapper、BacktestComparison mobile summary cards、empty data edge cases
- **目視確認幅**: iPhone SE (375px)、iPhone 14 (390px)、iPad (768px)、desktop (1280px)

## 残課題

- チャート(MAE比較バーチャート)の凡例は Recharts の制約上 CSS分岐が難しいため、`iconSize=10` + `fontSize=11` の軽量調整に留めた。5モデル分の凡例テキストが極狭幅 (320px未満) で切れる可能性は残る
- バックテスト自体のロジック・モデル追加はスコープ外 (Issue要件通り)

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)