### PR TITLE
fix: default タブの Y 軸ラベルを 5kg 主要 + 3kg 補助目盛りに修正

### DIFF
--- a/src/lib/utils/forecastUtils.test.ts
+++ b/src/lib/utils/forecastUtils.test.ts
@@ -182,12 +182,32 @@ describe("buildYAxisConfig", () => {
     }
   });
 
-  it("default: 5 の倍数のみラベルを返し、それ以外は空文字", () => {
+  it("default: 5kg 倍数（主要）と 3kg 倍数（補助）にラベルを返す", () => {
     const { formatter } = buildYAxisConfig("default", 55.0, 75.0);
+    // 主要目盛り (5kg倍数)
     expect(formatter(60)).toBe("60kg");
     expect(formatter(65)).toBe("65kg");
+    expect(formatter(70)).toBe("70kg");
+    // 補助目盛り (3kg倍数)
+    expect(formatter(63)).toBe("63kg");
+    expect(formatter(66)).toBe("66kg");
+    expect(formatter(69)).toBe("69kg");
+    expect(formatter(72)).toBe("72kg");
+    // それ以外は空文字
     expect(formatter(61)).toBe("");
-    expect(formatter(63)).toBe("");
+    expect(formatter(62)).toBe("");
+    expect(formatter(64)).toBe("");
+    expect(formatter(67)).toBe("");
+    expect(formatter(68)).toBe("");
+    expect(formatter(71)).toBe("");
+  });
+
+  it("default: 典型レンジ(58-73)で最大ラベル間隔が 3kg 以下になる", () => {
+    const { ticks, formatter } = buildYAxisConfig("default", 58.0, 73.0);
+    const labeled = ticks.filter((t) => formatter(t) !== "");
+    for (let i = 1; i < labeled.length; i++) {
+      expect(labeled[i] - labeled[i - 1]).toBeLessThanOrEqual(3);
+    }
   });
 
   it("yMin が step の倍数でない場合、切り上げた値から tick が始まる", () => {

--- a/src/lib/utils/forecastUtils.ts
+++ b/src/lib/utils/forecastUtils.ts
@@ -96,7 +96,8 @@ export type RangeTab = "default" | "7d" | "31d" | "60d";
  * - 7d:      0.5kg 刻み、全ラベル表示
  * - 31d:     1kg 刻み、全ラベル表示
  * - 60d:     1kg 刻み、全ラベル表示
- * - default: 1kg 刻み、5kg 倍数のみラベル表示（密度抑制）
+ * - default: 1kg 刻み、5kg 倍数（主要目盛り）+ 3kg 倍数（補助目盛り）でラベル表示
+ *            → ~3kg 間隔でラベルが並び「kg 表示が消える」レンジを防ぐ
  */
 export function buildYAxisConfig(
   rangeTab: RangeTab,
@@ -104,7 +105,6 @@ export function buildYAxisConfig(
   yMax: number
 ): { ticks: number[]; formatter: (v: number) => string } {
   const step = rangeTab === "7d" ? 0.5 : 1;
-  const labelEvery = rangeTab === "default" ? 5 : 0;
 
   const tickStart = Math.round(Math.ceil(yMin / step) * step * 10) / 10;
   const ticks: number[] = [];
@@ -113,7 +113,11 @@ export function buildYAxisConfig(
   }
 
   const formatter = (v: number): string => {
-    if (labelEvery > 0 && Math.round(v) % labelEvery !== 0) return "";
+    if (rangeTab === "default") {
+      // 5kg 主要目盛り OR 3kg 補助目盛りのみラベル表示（~3kg 間隔を保証）
+      const vi = Math.round(v);
+      if (vi % 5 !== 0 && vi % 3 !== 0) return "";
+    }
     return v % 1 === 0 ? `${v}kg` : `${v.toFixed(1)}kg`;
   };
 


### PR DESCRIPTION
## 問題

#190 (Issue #189) で実装した `buildYAxisConfig` の `default` タブが「5kg 倍数のみラベル表示」となっており、表示レンジによってはラベルがほぼ出ない（消えたように見える）ケースが発生。

## 修正内容

`default` タブのフォーマッタを以下のルールに変更:
- **5kg 倍数**（60, 65, 70...）→ 主要目盛りとして必ずラベル表示
- **3kg 倍数**（63, 66, 69, 72...）→ 補助目盛りとして追加表示
- それ以外 → 空文字（tick 線のみ）

典型レンジ(58〜73kg)での最大ラベル間隔: ~3kg を保証。

## テスト

- 5kg/3kg 倍数の具体値でラベル有無を検証
- 典型レンジで最大間隔 ≤ 3kg を検証（回帰テスト）
- 全 24 件通過 / `npx tsc --noEmit` クリア

Fixes #189 (追加修正)

🤖 Generated with [Claude Code](https://claude.com/claude-code)