### PR TITLE
fix: buildYAxisConfig を固定 step ベースに単純化（7d=0.5/31d=1/60d=2/default=3）

### DIFF
--- a/src/components/charts/ForecastChart.tsx
+++ b/src/components/charts/ForecastChart.tsx
@@ -151,6 +151,7 @@ export function ForecastChart({
   const yMax = Math.ceil((dataMax + yPad) * 10) / 10;
 
   // Y軸 tick 配列とラベルフォーマッタ（buildYAxisConfig に委譲）
+  // step: 7d=0.5kg / 31d=1kg / 60d=2kg / default=3kg（固定間隔・全ラベル表示）
   const { ticks: yTicks, formatter: yTickFormatter } = buildYAxisConfig(rangeTab, yMin, yMax);
 
   return (

--- a/src/lib/utils/forecastUtils.test.ts
+++ b/src/lib/utils/forecastUtils.test.ts
@@ -134,98 +134,89 @@ describe("buildForecastMap", () => {
 
 // ─── buildYAxisConfig ─────────────────────────────────────────────────────────
 
+/** tick 配列の隣接差がすべて step に等しいことを検証するヘルパー */
+function assertUniformStep(ticks: number[], step: number) {
+  for (let i = 1; i < ticks.length; i++) {
+    expect(ticks[i] - ticks[i - 1]).toBeCloseTo(step);
+  }
+}
+
 describe("buildYAxisConfig", () => {
-  it("7d: 0.5kg 刻みの tick 配列を返す", () => {
+  // ── 7d: 0.5kg 刻み ──────────────────────────────────────────────────────────
+  it("7d: tick が 0.5kg 均一間隔になる", () => {
     const { ticks } = buildYAxisConfig("7d", 68.0, 71.0);
-    // 68.0, 68.5, 69.0, ... 71.0
     expect(ticks[0]).toBeCloseTo(68.0);
-    expect(ticks[1]).toBeCloseTo(68.5);
-    // 隣接差が 0.5
-    for (let i = 1; i < ticks.length; i++) {
-      expect(ticks[i] - ticks[i - 1]).toBeCloseTo(0.5);
-    }
+    assertUniformStep(ticks, 0.5);
   });
 
   it("7d: 全 tick でラベルを返す（空文字なし）", () => {
     const { ticks, formatter } = buildYAxisConfig("7d", 68.0, 70.0);
-    for (const t of ticks) {
-      expect(formatter(t)).not.toBe("");
-    }
+    for (const t of ticks) expect(formatter(t)).not.toBe("");
   });
 
-  it("7d: 0.5kg 刻みのラベル形式 (整数は kg、小数は .1f + kg)", () => {
+  it("7d: 整数は 'Nkg'、小数は 'N.1kg' 形式", () => {
     const { formatter } = buildYAxisConfig("7d", 68.0, 69.0);
     expect(formatter(68.0)).toBe("68kg");
     expect(formatter(68.5)).toBe("68.5kg");
     expect(formatter(69.0)).toBe("69kg");
   });
 
-  it("31d: 1kg 刻みの tick 配列を返す", () => {
-    const { ticks } = buildYAxisConfig("31d", 67.0, 71.0);
+  it("7d: yMin が 0.5 の倍数でない場合、切り上げた値から tick が始まる", () => {
+    const { ticks } = buildYAxisConfig("7d", 68.3, 70.0);
+    expect(ticks[0]).toBeCloseTo(68.5);
+  });
+
+  // ── 31d: 1kg 刻み ───────────────────────────────────────────────────────────
+  it("31d: tick が 1kg 均一間隔になる", () => {
+    const { ticks } = buildYAxisConfig("31d", 67.0, 72.0);
     expect(ticks[0]).toBeCloseTo(67.0);
-    for (let i = 1; i < ticks.length; i++) {
-      expect(ticks[i] - ticks[i - 1]).toBeCloseTo(1.0);
-    }
+    assertUniformStep(ticks, 1);
   });
 
   it("31d: 全 tick でラベルを返す（空文字なし）", () => {
     const { ticks, formatter } = buildYAxisConfig("31d", 65.0, 72.0);
-    for (const t of ticks) {
-      expect(formatter(t)).not.toBe("");
-    }
+    for (const t of ticks) expect(formatter(t)).not.toBe("");
+  });
+
+  // ── 60d: 2kg 刻み ───────────────────────────────────────────────────────────
+  it("60d: tick が 2kg 均一間隔になる", () => {
+    const { ticks } = buildYAxisConfig("60d", 63.0, 73.0);
+    expect(ticks[0]).toBeCloseTo(64.0); // ceil(63/2)*2 = 64
+    assertUniformStep(ticks, 2);
   });
 
   it("60d: 全 tick でラベルを返す（空文字なし）", () => {
     const { ticks, formatter } = buildYAxisConfig("60d", 63.0, 73.0);
-    for (const t of ticks) {
-      expect(formatter(t)).not.toBe("");
-    }
+    for (const t of ticks) expect(formatter(t)).not.toBe("");
   });
 
-  it("default: ラベルが均一間隔になる（OR 条件による不規則間隔なし）", () => {
-    // range=15kg → rawStep=3 → labelStep=3 → 3kg 均一
-    const { ticks, formatter } = buildYAxisConfig("default", 58.0, 73.0);
-    const labeled = ticks.filter((t) => formatter(t) !== "");
-    expect(labeled.length).toBeGreaterThanOrEqual(3);
-    const gaps = labeled.slice(1).map((v, i) => Math.round((v - labeled[i]) * 10) / 10);
-    // 全ての間隔が同じ値（均一）
-    expect(new Set(gaps).size).toBe(1);
+  it("60d: yMin が 2 の倍数のとき yMin から tick が始まる", () => {
+    const { ticks } = buildYAxisConfig("60d", 62.0, 72.0);
+    expect(ticks[0]).toBeCloseTo(62.0);
   });
 
-  it("default: 広いレンジ(55-75=20kg)では 5kg 均一間隔", () => {
-    const { ticks, formatter } = buildYAxisConfig("default", 55.0, 75.0);
-    const labeled = ticks.filter((t) => formatter(t) !== "");
-    // step=5 → 55,60,65,70,75
-    expect(formatter(60)).toBe("60kg");
-    expect(formatter(65)).toBe("65kg");
-    expect(formatter(70)).toBe("70kg");
-    expect(formatter(62)).toBe("");
-    expect(formatter(63)).toBe("");
-    const gaps = labeled.slice(1).map((v, i) => v - labeled[i]);
-    expect(new Set(gaps).size).toBe(1); // 均一
-    expect(gaps[0]).toBe(5);
+  // ── default: 3kg 刻み ────────────────────────────────────────────────────────
+  it("default: tick が 3kg 均一間隔になる", () => {
+    const { ticks } = buildYAxisConfig("default", 58.0, 73.0);
+    assertUniformStep(ticks, 3);
   });
 
-  it("default: 中間レンジ(58-73=15kg)では 3kg 均一間隔", () => {
-    const { ticks, formatter } = buildYAxisConfig("default", 58.0, 73.0);
-    const labeled = ticks.filter((t) => formatter(t) !== "");
-    const gaps = labeled.slice(1).map((v, i) => v - labeled[i]);
-    expect(new Set(gaps).size).toBe(1); // 均一
-    expect(gaps[0]).toBe(3);
+  it("default: 全 tick でラベルを返す（空文字なし）", () => {
+    const { ticks, formatter } = buildYAxisConfig("default", 58.0, 75.0);
+    for (const t of ticks) expect(formatter(t)).not.toBe("");
   });
 
-  it("default: 狭いレンジ(63-68=5kg)では 1kg 均一間隔", () => {
-    const { ticks, formatter } = buildYAxisConfig("default", 63.0, 68.0);
-    const labeled = ticks.filter((t) => formatter(t) !== "");
-    expect(labeled.length).toBeGreaterThanOrEqual(4);
-    const gaps = labeled.slice(1).map((v, i) => v - labeled[i]);
-    expect(new Set(gaps).size).toBe(1); // 均一
-    expect(gaps[0]).toBe(1);
+  it("default: yMin が 3 の倍数でない場合、切り上げた値から tick が始まる", () => {
+    // ceil(58/3)*3 = 60
+    const { ticks } = buildYAxisConfig("default", 58.0, 73.0);
+    expect(ticks[0]).toBeCloseTo(60.0);
+    assertUniformStep(ticks, 3);
   });
 
-  it("yMin が step の倍数でない場合、切り上げた値から tick が始まる", () => {
-    // yMin=68.3, step=0.5 → 最初の tick は 68.5
-    const { ticks } = buildYAxisConfig("7d", 68.3, 70.0);
-    expect(ticks[0]).toBeCloseTo(68.5);
+  it("default: 広いレンジ(55-75)でも 3kg 均一間隔", () => {
+    const { ticks } = buildYAxisConfig("default", 55.0, 75.0);
+    assertUniformStep(ticks, 3);
+    // 55,60,65,70,75 は 3kg 倍数にならないものも ticks に含まれない（3kg 刻みのみ）
+    expect(ticks[0]).toBeCloseTo(57.0); // ceil(55/3)*3 = 57
   });
 });

--- a/src/lib/utils/forecastUtils.ts
+++ b/src/lib/utils/forecastUtils.ts
@@ -91,20 +91,28 @@ export type RangeTab = "default" | "7d" | "31d" | "60d";
 /**
  * buildYAxisConfig
  *
- * rangeTab に応じた Y 軸 tick 配列とラベルフォーマッタを返す。
+ * rangeTab ごとに固定 step で tick 配列を生成し、全ラベル表示する。
+ * 空文字 formatter による間引きや動的 step 選択は行わない。
  *
- * - 7d:      0.5kg 刻み、全ラベル表示
- * - 31d:     1kg 刻み、全ラベル表示
- * - 60d:     1kg 刻み、全ラベル表示
- * - default: 1kg 刻み、レンジに応じた均一ラベル間隔（約5ラベルを目標に 1/2/3/5/10kg から選択）
- *            → 不規則な OR 条件を使わず、常に等間隔ラベルを保証
+ * | tab     | step  |
+ * |---------|-------|
+ * | 7d      | 0.5kg |
+ * | 31d     | 1kg   |
+ * | 60d     | 2kg   |
+ * | default | 3kg   |
  */
 export function buildYAxisConfig(
   rangeTab: RangeTab,
   yMin: number,
   yMax: number
 ): { ticks: number[]; formatter: (v: number) => string } {
-  const step = rangeTab === "7d" ? 0.5 : 1;
+  const stepMap: Record<RangeTab, number> = {
+    "7d":      0.5,
+    "31d":     1,
+    "60d":     2,
+    "default": 3,
+  };
+  const step = stepMap[rangeTab];
 
   const tickStart = Math.round(Math.ceil(yMin / step) * step * 10) / 10;
   const ticks: number[] = [];
@@ -112,20 +120,8 @@ export function buildYAxisConfig(
     ticks.push(v);
   }
 
-  // default タブ: レンジ ÷ 5 を目安に「人間が読みやすいキリの良い数値」へ丸める
-  // niceSteps から rawStep 以上の最小値を選ぶことで ~5 ラベルを確保しつつ均一間隔を保証
-  let labelStep = 0; // 0 = 全ラベル表示
-  if (rangeTab === "default") {
-    const range = yMax - yMin;
-    const rawStep = range / 5;
-    const niceSteps = [1, 2, 3, 5, 10];
-    labelStep = niceSteps.find((s) => s >= rawStep) ?? 10;
-  }
-
-  const formatter = (v: number): string => {
-    if (labelStep > 0 && Math.round(v) % labelStep !== 0) return "";
-    return v % 1 === 0 ? `${v}kg` : `${v.toFixed(1)}kg`;
-  };
+  const formatter = (v: number): string =>
+    v % 1 === 0 ? `${v}kg` : `${v.toFixed(1)}kg`;
 
   return { ticks, formatter };
 }


### PR DESCRIPTION
## 変更概要

動的 step 選択・OR 条件・空文字 formatter を全廃し、タブごとの固定 step で tick 生成＋全ラベル表示するだけの実装に単純化。

## 最終 step 一覧

| tab     | step  | 変更前           |
|---------|-------|-----------------|
| 7d      | 0.5kg | 0.5kg（変更なし） |
| 31d     | 1kg   | 1kg（変更なし）   |
| 60d     | **2kg** | 1kg            |
| default | **3kg** | 動的（1/2/3/5/10kg）または 3kg/5kg OR 条件 |

## buildYAxisConfig の変更

```typescript
// Before: 動的 niceStep 選択 + 空文字 formatter で間引き
const labelStep = niceSteps.find(s => s >= range / 5) ?? 10;
formatter = v => labelStep > 0 && v % labelStep !== 0 ? "" : `${v}kg`

// After: stepMap から固定 step を取得し、tick 配列を均一生成・全ラベル表示
const step = stepMap[rangeTab]; // { 7d:0.5, 31d:1, 60d:2, default:3 }
formatter = v => v % 1 === 0 ? `${v}kg` : `${v.toFixed(1)}kg`
```

## テスト更新

- 各タブの均一間隔を `assertUniformStep` ヘルパーで検証
- 「空文字なし」「yMin 切り上げ」「広いレンジでも 3kg 均一」などケースを整備
- 計 28 件全通過 / `npx tsc --noEmit` クリア / 全 960 件通過

Fixes #189 (追加修正)

🤖 Generated with [Claude Code](https://claude.com/claude-code)