### PR TITLE
fix: Macro ページのデータなし状態を graceful degradation に修正

### DIFF
--- a/src/app/macro/page.tsx
+++ b/src/app/macro/page.tsx
@@ -40,9 +40,11 @@ export default async function MacroPage() {
 
   if (logs.length === 0) {
     return (
-      <main className="flex min-h-svh items-center justify-center">
-        <p className="text-slate-400">データがありません。</p>
-      </main>
+      <PageShell title="栄養分析">
+        <div className="rounded-xl border border-amber-100 bg-amber-50 p-4 text-sm text-amber-700">
+          栄養データが記録されるとグラフが表示されます。
+        </div>
+      </PageShell>
     );
   }
 


### PR DESCRIPTION
## 概要

Macro ページで `logs.length === 0` のとき、画面全体をブロックして MobileBottomNav も消えていた問題を修正。

## 変更内容

- `src/app/macro/page.tsx` のデータなし状態の返却を修正
  - Before: `<main className="flex min-h-svh items-center justify-center">` で全画面占有
  - After: `<PageShell title="栄養分析">` 内に amber バナーを表示

## 判断理由

TDEE / History ページはすでに graceful degradation（空状態でも画面構造を維持）で実装されており、Macro ページだけが異なる実装になっていた。統一することでページ間の一貫性を確保。

## 影響範囲

- `src/app/macro/page.tsx` 1ファイルのみ
- 型チェック通過、テスト 960件全通過

## 補足

- MobileBottomNav やヘッダーは `PageShell` の外側でレンダリングされているため、PageShell を返すだけで自動的に維持される

Closes #204