### PR TITLE
refactor: FoodTable / MenuTable の CRUD 操作を Server Action に移行

### DIFF
--- a/src/app/actions/foods.ts
+++ b/src/app/actions/foods.ts
@@ -1,0 +1,56 @@
+"use server";
+
+import { createClient } from "@/lib/supabase/server";
+import type { Database, Json } from "@/lib/supabase/types";
+import type { RecipeItem } from "@/lib/supabase/types";
+
+type FoodMasterInsert = Database["public"]["Tables"]["food_master"]["Insert"];
+
+export type FoodActionResult = { error: string | null };
+
+/** food_master への insert */
+export async function insertFood(payload: FoodMasterInsert): Promise<FoodActionResult> {
+  const supabase = createClient();
+  const { error } = await supabase.from("food_master").insert(payload);
+  return { error: error?.message ?? null };
+}
+
+/** food_master からの delete（name が PK） */
+export async function deleteFood(name: string): Promise<FoodActionResult> {
+  const supabase = createClient();
+  const { error } = await supabase.from("food_master").delete().eq("name", name);
+  return { error: error?.message ?? null };
+}
+
+/** menu_master への insert（新規作成） */
+export async function insertMenu(payload: {
+  name: string;
+  recipe: RecipeItem[];
+}): Promise<FoodActionResult> {
+  const supabase = createClient();
+  const { error } = await supabase.from("menu_master").insert({
+    name: payload.name,
+    recipe: payload.recipe as unknown as Json,
+  });
+  return { error: error?.message ?? null };
+}
+
+/** menu_master の update（originalName で対象行を特定） */
+export async function updateMenu(
+  originalName: string,
+  payload: { name: string; recipe: RecipeItem[] }
+): Promise<FoodActionResult> {
+  const supabase = createClient();
+  const { error } = await supabase
+    .from("menu_master")
+    .update({ name: payload.name, recipe: payload.recipe as unknown as Json })
+    .eq("name", originalName);
+  return { error: error?.message ?? null };
+}
+
+/** menu_master からの delete（name が PK） */
+export async function deleteMenu(name: string): Promise<FoodActionResult> {
+  const supabase = createClient();
+  const { error } = await supabase.from("menu_master").delete().eq("name", name);
+  return { error: error?.message ?? null };
+}

--- a/src/components/foods/FoodTable.tsx
+++ b/src/components/foods/FoodTable.tsx
@@ -2,9 +2,9 @@
 
 import { useState, useMemo, useTransition } from "react";
 import { Trash2, Plus, Search, ChevronUp, ChevronDown, ChevronsUpDown } from "lucide-react";
-import { createClient } from "@/lib/supabase/client";
 import type { FoodMaster } from "@/lib/supabase/types";
 import { parseStrictNumber } from "@/lib/utils/parseNumber";
+import { insertFood, deleteFood } from "@/app/actions/foods";
 
 interface FoodTableProps {
   initialFoods: FoodMaster[];
@@ -129,11 +129,10 @@ export function FoodTable({ initialFoods }: FoodTableProps) {
       carbs: parsedNums["carbs"]!,
       category: form.category.trim() || null,
     };
-    const supabase = createClient();
-    const { error: err } = await supabase.from("food_master").insert(payload as never);
+    const { error: err } = await insertFood(payload);
 
     setIsSaving(false);
-    if (err) return setError(err.message);
+    if (err) return setError(err);
 
     // 成功パス: リストを更新し、成功を表示してから1.2秒後に閉じる
     setFoods((prev) => [...prev, payload].sort((a, b) => a.name.localeCompare(b.name)));
@@ -150,8 +149,7 @@ export function FoodTable({ initialFoods }: FoodTableProps) {
 
   function handleDelete(name: string) {
     startTransition(async () => {
-      const supabase = createClient();
-      const { error: err } = await supabase.from("food_master").delete().eq("name", name as never);
+      const { error: err } = await deleteFood(name);
       if (!err) setFoods((prev) => prev.filter((f) => f.name !== name));
     });
   }

--- a/src/components/foods/MenuTable.tsx
+++ b/src/components/foods/MenuTable.tsx
@@ -2,9 +2,9 @@
 
 import { useState, useMemo, useTransition } from "react";
 import { Plus, Trash2, Save, ChevronDown, ChevronUp, X } from "lucide-react";
-import { createClient } from "@/lib/supabase/client";
 import type { FoodMaster, RecipeItem } from "@/lib/supabase/types";
 import type { MenuEntry } from "@/lib/hooks/useMenuList";
+import { insertMenu, updateMenu, deleteMenu } from "@/app/actions/foods";
 
 interface MenuTableProps {
   initialMenus: MenuEntry[];
@@ -94,22 +94,15 @@ export function MenuTable({ initialMenus, foods }: MenuTableProps) {
     setIsSaving(true);
     setSaveError(null);
 
-    const supabase = createClient();
     const nextName = editing.name.trim();
     const payload = { name: nextName, recipe: editing.items };
 
-    let error;
-    if (editing.originalName === null) {
-      ({ error } = await supabase.from("menu_master").insert(payload as never));
-    } else {
-      ({ error } = await supabase
-        .from("menu_master")
-        .update(payload as never)
-        .eq("name", editing.originalName as never));
-    }
+    const { error } = editing.originalName === null
+      ? await insertMenu(payload)
+      : await updateMenu(editing.originalName, payload);
 
     setIsSaving(false);
-    if (error) return setSaveError(error.message);
+    if (error) return setSaveError(error);
 
     setMenus((prev) => {
       const filtered = prev.filter((m) => m.name !== editing.originalName && m.name !== payload.name);
@@ -128,8 +121,7 @@ export function MenuTable({ initialMenus, foods }: MenuTableProps) {
 
   function handleDelete(name: string) {
     startTransition(async () => {
-      const supabase = createClient();
-      const { error } = await supabase.from("menu_master").delete().eq("name", name as never);
+      const { error } = await deleteMenu(name);
       if (!error) setMenus((prev) => prev.filter((m) => m.name !== name));
     });
   }


### PR DESCRIPTION
## 概要

`FoodTable.tsx` / `MenuTable.tsx` が Client Component 内で直接 Supabase を呼んでいた箇所を Server Action に移行。

## 変更内容

**新規: `src/app/actions/foods.ts`**

| 関数 | 操作 |
|------|------|
| `insertFood(payload)` | food_master INSERT |
| `deleteFood(name)` | food_master DELETE |
| `insertMenu(payload)` | menu_master INSERT |
| `updateMenu(originalName, payload)` | menu_master UPDATE |
| `deleteMenu(name)` | menu_master DELETE |

**`src/components/foods/FoodTable.tsx`**
- `import { createClient }` を除去
- `insertFood` / `deleteFood` を import して利用
- `as never` キャストを除去

**`src/components/foods/MenuTable.tsx`**
- `import { createClient }` を除去
- `insertMenu` / `updateMenu` / `deleteMenu` を import して利用
- `as never` キャストを除去

## 判断理由

CLAUDE.md「Server Components をデフォルトにする」「保存は Server Action を通じて行う」に準拠。`as never` は `supabase-js v2` のジェネリクス型推論の制約を回避するためのキャストで、Server Action 内では型を明示できるため除去した。`RecipeItem[]` → `Json` のキャストは `as unknown as Json` で型安全化。

## 影響範囲

- 新規: `src/app/actions/foods.ts`
- 変更: `FoodTable.tsx` / `MenuTable.tsx`（動作は同等）
- 型チェック通過、テスト 960件全通過

## 補足

統合テストの追加は #198 として別 Issue で管理。

Closes #195