### PR TITLE
fix: ForecastChart 60d タブの表示窓を 61日から正しく 60日に修正

### DIFF
--- a/src/components/charts/ForecastChart.tsx
+++ b/src/components/charts/ForecastChart.tsx
@@ -91,10 +91,10 @@ export function ForecastChart({
     viewStartStr = addDaysStr(latestLogDate, -30) ?? today; // 最新測定日を含む31日間
     viewEndStr = latestLogDate;
   } else if (rangeTab === "60d") {
-    // 60d: 30日前を起点に固定60日窓（start + 60日で終端固定）
+    // 60d: 30日前を起点に固定60日窓（start から 59日後 = inclusive で60日）
     // 「直近1ヶ月の実績 + 近未来予測」を一定スパンで確認できるビュー
     viewStartStr = addDaysStr(latestLogDate, -30) ?? today;
-    viewEndStr = addDaysStr(viewStartStr, 60) ?? today;
+    viewEndStr = addDaysStr(viewStartStr, 59) ?? today;
   } else {
     // default: 45日前〜 contestDate+15 (なければ lastForecastDate / lastEwDate の最大)
     viewStartStr = addDaysStr(today, -45) ?? today;


### PR DESCRIPTION
## 概要

ForecastChart の 60d タブで `addDaysStr(start, 60)` としていたため、`dateRangeStr` の両端 inclusive 仕様により実際は 61日分表示されていたバグを修正。

## 変更内容

`src/components/charts/ForecastChart.tsx` L97

```diff
- viewEndStr = addDaysStr(viewStartStr, 60) ?? today;
+ viewEndStr = addDaysStr(viewStartStr, 59) ?? today;
```

コメントも `start + 60日で終端固定` → `start から 59日後 = inclusive で60日` に修正。

## 判断理由

`dateRangeStr(start, end)` は `while (cur <= end)` の両端 inclusive。`start + 60` を end にすると start〜end = 61要素になる。7d タブ (`addDaysStr(-6)`) / 31d タブ (`addDaysStr(-30)`) も同様に N-1 オフセットで実装されており、60d も `59` に揃えるのが正しい。

## 影響範囲

- `src/components/charts/ForecastChart.tsx` 1行のみ
- 型チェック通過、テスト 960件全通過

Closes #201