### PR TITLE
docs: README / CLAUDE.md の「zod」記載を実装に合わせて修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ body-comp-tracker-v2/
 │   │   ├── domain/
 │   │   │   └── settings.ts         # AppSettings 型 + DB rows → AppSettings mapper
 │   │   ├── schemas/
-│   │   │   └── settingsSchema.ts   # settings 保存用 zod schema (Server Action と共有)
+│   │   │   └── settingsSchema.ts   # settings 保存用バリデーション schema (Server Action と共有)
 │   │   ├── analytics/
 │   │   │   └── status.ts           # AnalyticsAvailability 型 (fresh/stale/unavailable/error)
 │   │   ├── hooks/                  # Client-side hooks (useDailyLogs 等)
@@ -187,7 +187,7 @@ body-comp-tracker-v2/
 
 ### 設定 (settings)
 - 保存: `src/app/settings/actions.ts` の Server Action を通じて行う
-  - バリデーションは `src/lib/schemas/settingsSchema.ts` (zod) で実施
+  - バリデーションは `src/lib/schemas/settingsSchema.ts`（TypeScript の型 + 手書きバリデーション関数）で実施
   - schema は Server Action と Client の両方から参照される
 - 読み取り: `fetchSettings()` → `AppSettings` に変換して利用する
   - `AppSettings` の型定義は `src/lib/domain/settings.ts` に集約

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ ForecastChart（`src/components/charts/ForecastChart.tsx`）は 3 タブ（7日 
 ### 設定（Settings）
 
 - 目標体重・大会日付・TDEE 設定などを管理
-- 保存は Server Action + shared schema（zod）で一元処理
+- 保存は Server Action + shared schema（settingsSchema.ts）で一元処理
 - 読み取りは typed domain model（AppSettings）に変換して利用
 - UI integration test（jsdom）で保存導線・fallback 導線を自動検証
 - **月次目標計画セクション（MonthlyGoalPlanSection）**: `buildMonthlyGoalPlan` を使い、大会日・目標体重から月末目標を自動配分してプレビュー表示
@@ -210,7 +210,7 @@ ForecastChart（`src/components/charts/ForecastChart.tsx`）は 3 タブ（7日 
 
 | 項目 | 内容 |
 |---|---|
-| settings 統一 | Server Action + shared schema（zod）で保存。typed AppSettings で読み取り |
+| settings 統一 | Server Action + shared schema（settingsSchema.ts）で保存。typed AppSettings で読み取り |
 | query layer | Supabase read 系ロジックを `src/lib/queries/` に集約。主要クエリは `QueryResult<T>` で状態を明示し、補助的なクエリ（career_logs-for-dashboard / predictions 等）はベストエフォートで空配列フォールバック。意図を JSDoc に明記 |
 | UI integration tests | 保存導線・fallback 導線を jsdom ベースで自動検証 |
 


### PR DESCRIPTION
## 概要

`settingsSchema.ts` は zod を使用していないが、README と CLAUDE.md に「zod」と記載されていた誤りを修正。

## 変更内容

**`README.md`** (2箇所)
- `shared schema（zod）` → `shared schema（settingsSchema.ts）`

**`CLAUDE.md`** (2箇所)
- ディレクトリツリーのコメント: `settings 保存用 zod schema` → `settings 保存用バリデーション schema`
- 実装原則セクション: `（zod）で実施` → `（TypeScript の型 + 手書きバリデーション関数）で実施`

## 判断理由

`settingsSchema.ts` は `parseStrictNumber` / range check / regex による手書きバリデーションで実装されており、`package.json` にも zod の依存はない。ドキュメントと実装の乖離を解消した。

## 影響範囲

- `README.md` / `CLAUDE.md` のみ（コード変更なし）

Closes #202