### PR TITLE
feat: ForecastChart のデータなし状態に説明プレースホルダーを追加

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -236,7 +236,7 @@ export default async function DashboardPage() {
           />
           <WeeklyReviewCard data={weeklyReview} phase={phase} enrichedAvailability={enrichedAvailability} />
           <DataQualityBadge report={qualityReport} />
-          {predictions.length > 0 && (
+          {predictions.length > 0 ? (
             <ForecastChart
               logs={logs}
               predictions={predictions}
@@ -249,6 +249,11 @@ export default async function DashboardPage() {
                   : undefined
               }
             />
+          ) : (
+            <div className="rounded-2xl border border-amber-100 bg-amber-50 p-5 text-sm text-amber-700">
+              <p className="mb-1 font-semibold">体重予測グラフ</p>
+              <p>ML バッチ（predict.py）が実行されると表示されます。毎日 AM 3:00 JST に自動実行されます。</p>
+            </div>
           )}
           <LogsAndSummaryTabs
             logs={logs}


### PR DESCRIPTION
## 概要

`predictions` が空のときグラフエリアが無言で消えていた問題を修正。ML バッチ未実行の理由を説明する amber バナーを表示する。

## 変更内容

`src/app/page.tsx`

```diff
- {predictions.length > 0 && (
-   <ForecastChart ... />
- )}
+ {predictions.length > 0 ? (
+   <ForecastChart ... />
+ ) : (
+   <div className="rounded-2xl border border-amber-100 bg-amber-50 p-5 ...">
+     <p>体重予測グラフ</p>
+     <p>ML バッチ（predict.py）が実行されると表示されます。毎日 AM 3:00 JST に自動実行されます。</p>
+   </div>
+ )}
```

## 影響範囲

- `src/app/page.tsx` 1ファイルのみ
- 型チェック通過、テスト 960件全通過

Closes #205