### PR TITLE
fix: Cart の grams input と削除ボタンのタップターゲットを拡大

### DIFF
--- a/src/components/meal/Cart.tsx
+++ b/src/components/meal/Cart.tsx
@@ -116,13 +116,13 @@ export function Cart({ items, onChange }: CartProps) {
                 value={item.food.name in editingGrams ? editingGrams[item.food.name] : item.grams}
                 onChange={(e) => handleGramsChange(item.food.name, e.target.value)}
                 onBlur={() => handleGramsBlur(i, item.food.name)}
-                className="w-16 rounded border border-gray-200 px-2 py-1 text-right text-sm outline-none focus:border-blue-400"
+                className="w-16 rounded border border-gray-200 px-2 py-2.5 text-right text-sm outline-none focus:border-blue-400"
               />
               <span className="text-xs text-gray-400">g</span>
             </div>
             <button
               onClick={() => remove(i)}
-              className="ml-1 text-gray-300 hover:text-rose-500"
+              className="ml-1 p-2 text-gray-300 hover:text-rose-500"
               aria-label="削除"
             >
               <Trash2 size={15} />


### PR DESCRIPTION
## 概要

`Cart.tsx` の grams 入力欄（高さ約28px）と削除ボタンのタップターゲットが推奨サイズを下回っていた問題を修正。

## 変更内容

`src/components/meal/Cart.tsx`

| 要素 | Before | After |
|------|--------|-------|
| grams input | `py-1`（約28px） | `py-2.5`（約36px） |
| 削除ボタン | パディングなし | `p-2` 追加（タップ領域拡大） |

## 影響範囲

- `src/components/meal/Cart.tsx` 1ファイルのみ
- `normalizeGrams` 等のロジックは無変更
- 型チェック通過、テスト 960件全通過

Closes #206