### PR TITLE
refactor: ml-pipeline の print() を logger.info() に置き換え

### DIFF
--- a/ml-pipeline/import_history.py
+++ b/ml-pipeline/import_history.py
@@ -52,7 +52,7 @@ def load_csv(path: str) -> list[dict]:
 
 def main() -> None:
     if len(sys.argv) < 2:
-        print(__doc__)
+        logger.info("%s", __doc__)
         sys.exit(1)
 
     csv_path = sys.argv[1]


### PR DESCRIPTION
## 概要

`ml-pipeline/import_history.py` に残存していた `print(__doc__)` を `logger.info()` に置き換え、CLAUDE.md の Python コーディング規約（print デバッグ禁止）に準拠させた。

## 変更内容

`ml-pipeline/import_history.py` L55

```diff
- print(__doc__)
+ logger.info("%s", __doc__)
```

`logging.basicConfig` と `logger = logging.getLogger(__name__)` は同ファイル L23-24 に既に設定済みのため追加変更不要。

## 影響範囲

- `ml-pipeline/import_history.py` 1行のみ
- 他の ml-pipeline ファイルに `print()` は存在しないことを確認済み

Closes #197