### PR TITLE
chore: regenerate types.ts from actual Supabase schema (#193)

### DIFF
--- a/src/components/foods/FoodTable.tsx
+++ b/src/components/foods/FoodTable.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo, useTransition } from "react";
 import { Trash2, Plus, Search, ChevronUp, ChevronDown, ChevronsUpDown } from "lucide-react";
-import type { FoodMaster } from "@/lib/supabase/types";
+import type { FoodMaster, TablesInsert } from "@/lib/supabase/types";
 import { parseStrictNumber } from "@/lib/utils/parseNumber";
 import { insertFood, deleteFood } from "@/app/actions/foods";
 
@@ -121,7 +121,7 @@ export function FoodTable({ initialFoods }: FoodTableProps) {
     setIsSaving(true);
     setError(null);
 
-    const payload: FoodMaster = {
+    const payload: TablesInsert<"food_master"> = {
       name: form.name.trim(),
       calories: parsedNums["calories"]!,
       protein: parsedNums["protein"]!,
@@ -135,7 +135,7 @@ export function FoodTable({ initialFoods }: FoodTableProps) {
     if (err) return setError(err);
 
     // 成功パス: リストを更新し、成功を表示してから1.2秒後に閉じる
-    setFoods((prev) => [...prev, payload].sort((a, b) => a.name.localeCompare(b.name)));
+    setFoods((prev) => [...prev, payload as FoodMaster].sort((a, b) => a.name.localeCompare(b.name)));
     setSaveSuccess(true);
     setTimeout(() => {
       setShowForm(false);

--- a/src/components/foods/MenuTable.tsx
+++ b/src/components/foods/MenuTable.tsx
@@ -20,7 +20,7 @@ interface EditingMenu {
 function calcRecipeKcal(items: RecipeItem[], foodMap: Map<string, FoodMaster>) {
   return items.reduce((sum, ri) => {
     const f = foodMap.get(ri.name);
-    return sum + (f ? Math.round((f.calories * ri.amount) / 100) : 0);
+    return sum + (f ? Math.round(((f.calories ?? 0) * ri.amount) / 100) : 0);
   }, 0);
 }
 
@@ -214,13 +214,13 @@ export function MenuTable({ initialMenus, foods }: MenuTableProps) {
                 .sort((a, b) => {
                   const fa = foodMap.get(a.name);
                   const fb = foodMap.get(b.name);
-                  const ka = fa ? Math.round((fa.calories * a.amount) / 100) : 0;
-                  const kb = fb ? Math.round((fb.calories * b.amount) / 100) : 0;
+                  const ka = fa ? Math.round(((fa.calories ?? 0) * a.amount) / 100) : 0;
+                  const kb = fb ? Math.round(((fb.calories ?? 0) * b.amount) / 100) : 0;
                   return kb - ka;
                 })
                 .map((ri) => {
                   const food = foodMap.get(ri.name);
-                  const kcal = food ? Math.round((food.calories * ri.amount) / 100) : 0;
+                  const kcal = food ? Math.round(((food.calories ?? 0) * ri.amount) / 100) : 0;
                   // 削除は元の items 配列のインデックスで行う
                   const originalIdx = editing.items.findIndex((i) => i.name === ri.name);
                   return (
@@ -313,7 +313,7 @@ export function MenuTable({ initialMenus, foods }: MenuTableProps) {
                     <div className="border-t border-slate-50 bg-slate-50 px-4 py-3 space-y-1.5">
                       {menu.recipe.map((ri, i) => {
                         const food = foodMap.get(ri.name);
-                        const itemKcal = food ? Math.round((food.calories * ri.amount) / 100) : 0;
+                        const itemKcal = food ? Math.round(((food.calories ?? 0) * ri.amount) / 100) : 0;
                         return (
                           <div key={i} className="flex justify-between text-xs text-slate-600">
                             <span>{ri.name}</span>
@@ -364,7 +364,7 @@ export function MenuTable({ initialMenus, foods }: MenuTableProps) {
                     <ul className="border-t border-gray-50 bg-gray-50 px-6 py-2 space-y-1">
                       {menu.recipe.map((ri, i) => {
                         const food = foodMap.get(ri.name);
-                        const itemKcal = food ? Math.round((food.calories * ri.amount) / 100) : 0;
+                        const itemKcal = food ? Math.round(((food.calories ?? 0) * ri.amount) / 100) : 0;
                         return (
                           <li key={i} className="flex justify-between text-xs text-gray-600">
                             <span>{ri.name}</span>

--- a/src/components/meal/Cart.tsx
+++ b/src/components/meal/Cart.tsx
@@ -15,7 +15,7 @@ interface CartProps {
 }
 
 function calcNutrient(food: FoodMaster, grams: number, key: keyof Pick<FoodMaster, "calories" | "protein" | "fat" | "carbs">) {
-  return Math.round((food[key] * grams) / 100);
+  return Math.round(((food[key] ?? 0) * grams) / 100);
 }
 
 export function calcCartTotals(items: CartItem[]) {

--- a/src/components/meal/MealLogger.test.ts
+++ b/src/components/meal/MealLogger.test.ts
@@ -40,7 +40,7 @@ describe("computeHasContent", () => {
   });
 
   it("カートにアイテムがある場合は true", () => {
-    const item = { food: { name: "chicken", calories: 165, protein: 31, fat: 3.6, carbs: 0, category: null }, grams: 100 };
+    const item = { food: { id: "test-id", name: "chicken", calories: 165, protein: 31, fat: 3.6, carbs: 0, category: null, created_at: null }, grams: 100 };
     expect(computeHasContent({ ...base, cartItems: [item] })).toBe(true);
   });
 

--- a/src/components/meal/MenuPicker.tsx
+++ b/src/components/meal/MenuPicker.tsx
@@ -44,7 +44,7 @@ export function MenuPicker({ foods, onAddSet }: MenuPickerProps) {
     if (!menu) return 0;
     return menu.recipe.reduce((sum, ri) => {
       const food = foodMap.get(ri.name);
-      return sum + (food ? Math.round((food.calories * ri.amount) / 100) : 0);
+      return sum + (food ? Math.round(((food.calories ?? 0) * ri.amount) / 100) : 0);
     }, 0);
   }
 

--- a/src/components/settings/SettingsForm.integration.test.tsx
+++ b/src/components/settings/SettingsForm.integration.test.tsx
@@ -228,8 +228,8 @@ describe("SettingsForm — 保存中ステータス", () => {
 describe("SettingsForm — 初期値の反映", () => {
   it("initialSettings の数値フィールドがフォームに反映される", () => {
     const settings: Setting[] = [
-      { key: "goal_weight", value_num: 60.5, value_str: null },
-      { key: "age",         value_num: 28,   value_str: null },
+      { key: "goal_weight", value_num: 60.5, value_str: null, updated_at: null },
+      { key: "age",         value_num: 28,   value_str: null, updated_at: null },
     ];
 
     render(<SettingsForm initialSettings={settings} />);
@@ -245,7 +245,7 @@ describe("SettingsForm — 初期値の反映", () => {
 
   it("initialSettings の文字列フィールドがフォームに反映される", () => {
     const settings: Setting[] = [
-      { key: "current_season", value_num: null, value_str: "2026_TokyoNovice" },
+      { key: "current_season", value_num: null, value_str: "2026_TokyoNovice", updated_at: null },
     ];
 
     render(<SettingsForm initialSettings={settings} />);

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -1,359 +1,515 @@
-/**
- * Supabase DB 型定義
- * 本番では `npx supabase gen types typescript --project-id <id> > src/lib/supabase/types.ts` で上書きすること。
- */
-
 export type Json =
   | string
   | number
   | boolean
   | null
   | { [key: string]: Json | undefined }
-  | Json[];
+  | Json[]
 
 export type Database = {
+  // Allows to automatically instantiate createClient with right options
+  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
+  __InternalSupabase: {
+    PostgrestVersion: "14.1"
+  }
   public: {
     Tables: {
-      forecast_backtest_runs: {
-        Row: {
-          id: string;
-          created_at: string;
-          model_name: string;
-          model_version: string | null;
-          horizons: number[];
-          train_min_date: string | null;
-          train_max_date: string | null;
-          n_source_rows: number;
-          notes: string | null;
-          config: Json;
-        };
-        Insert: {
-          id?: string;
-          created_at?: string;
-          model_name: string;
-          model_version?: string | null;
-          horizons: number[];
-          train_min_date?: string | null;
-          train_max_date?: string | null;
-          n_source_rows?: number;
-          notes?: string | null;
-          config?: Json;
-        };
-        Update: {
-          id?: string;
-          created_at?: string;
-          model_name?: string;
-          model_version?: string | null;
-          horizons?: number[];
-          train_min_date?: string | null;
-          train_max_date?: string | null;
-          n_source_rows?: number;
-          notes?: string | null;
-          config?: Json;
-        };
-        Relationships: [];
-      };
-      forecast_backtest_metrics: {
-        Row: {
-          id: string;
-          run_id: string;
-          model_name: string;
-          horizon_days: number;
-          mae: number;
-          rmse: number;
-          mape: number | null;
-          bias: number | null;
-          n_predictions: number;
-          computed_at: string;
-          extra: Json;
-        };
-        Insert: {
-          id?: string;
-          run_id: string;
-          model_name: string;
-          horizon_days: number;
-          mae: number;
-          rmse: number;
-          mape?: number | null;
-          bias?: number | null;
-          n_predictions?: number;
-          computed_at?: string;
-          extra?: Json;
-        };
-        Update: {
-          id?: string;
-          run_id?: string;
-          model_name?: string;
-          horizon_days?: number;
-          mae?: number;
-          rmse?: number;
-          mape?: number | null;
-          bias?: number | null;
-          n_predictions?: number;
-          computed_at?: string;
-          extra?: Json;
-        };
-        Relationships: [];
-      };
-      forecast_backtest_predictions: {
-        Row: {
-          id: string;
-          run_id: string;
-          model_name: string;
-          forecast_origin_date: string;
-          target_date: string;
-          horizon_days: number;
-          predicted_weight: number;
-          actual_weight: number;
-          error: number;
-          abs_error: number;
-          squared_error: number;
-          ape: number | null;
-        };
-        Insert: {
-          id?: string;
-          run_id: string;
-          model_name: string;
-          forecast_origin_date: string;
-          target_date: string;
-          horizon_days: number;
-          predicted_weight: number;
-          actual_weight: number;
-          error: number;
-          abs_error: number;
-          squared_error: number;
-          ape?: number | null;
-        };
-        Update: {
-          id?: string;
-          run_id?: string;
-          model_name?: string;
-          forecast_origin_date?: string;
-          target_date?: string;
-          horizon_days?: number;
-          predicted_weight?: number;
-          actual_weight?: number;
-          error?: number;
-          abs_error?: number;
-          squared_error?: number;
-          ape?: number | null;
-        };
-        Relationships: [];
-      };
-      daily_logs: {
-        Row: {
-          log_date: string;
-          weight: number | null;
-          calories: number | null;
-          protein: number | null;
-          fat: number | null;
-          carbs: number | null;
-          note: string | null;
-          is_cheat_day: boolean;
-          is_refeed_day: boolean;
-          is_eating_out: boolean;
-          is_travel_day: boolean;
-          /** @deprecated UIからの入力を廃止。既存データ互換のため型は残す。sleep_hours を使用すること。 */
-          is_poor_sleep: boolean;
-          // ── Phase 2.5 追加カラム ──
-          sleep_hours: number | null;
-          /** null=未記録, true=便通あり, false=便通なし */
-          had_bowel_movement: boolean | null;
-          /** 値: 'off' | 'chest' | 'back' | 'shoulders' | 'glutes_hamstrings' | 'quads' */
-          training_type: string | null;
-          /** 値: 'off' | 'office' | 'remote' */
-          work_mode: string | null;
-          /** training_type から導出 (quads/glutes_hamstrings → true, それ以外 → false, 未入力 → null) */
-          leg_flag: boolean | null;
-          /** 行の最終更新日時 (ISO 8601)。analytics stale 判定の基準として MAX(updated_at) を使用する */
-          updated_at: string;
-        };
-        Insert: {
-          log_date: string;
-          weight?: number | null;
-          calories?: number | null;
-          protein?: number | null;
-          fat?: number | null;
-          carbs?: number | null;
-          note?: string | null;
-          is_cheat_day?: boolean;
-          is_refeed_day?: boolean;
-          is_eating_out?: boolean;
-          is_travel_day?: boolean;
-          is_poor_sleep?: boolean;
-          sleep_hours?: number | null;
-          had_bowel_movement?: boolean | null;
-          training_type?: string | null;
-          work_mode?: string | null;
-          leg_flag?: boolean | null;
-          updated_at?: string;
-        };
-        Update: {
-          log_date?: string;
-          weight?: number | null;
-          calories?: number | null;
-          protein?: number | null;
-          fat?: number | null;
-          carbs?: number | null;
-          note?: string | null;
-          is_cheat_day?: boolean;
-          is_refeed_day?: boolean;
-          is_eating_out?: boolean;
-          is_travel_day?: boolean;
-          is_poor_sleep?: boolean;
-          sleep_hours?: number | null;
-          had_bowel_movement?: boolean | null;
-          training_type?: string | null;
-          work_mode?: string | null;
-          leg_flag?: boolean | null;
-          updated_at?: string;
-        };
-        Relationships: [];
-      };
-      food_master: {
-        Row: {
-          name: string;
-          protein: number;
-          fat: number;
-          carbs: number;
-          calories: number;
-          category: string | null;
-        };
-        Insert: {
-          name: string;
-          protein: number;
-          fat: number;
-          carbs: number;
-          calories: number;
-          category?: string | null;
-        };
-        Update: {
-          name?: string;
-          protein?: number;
-          fat?: number;
-          carbs?: number;
-          calories?: number;
-          category?: string | null;
-        };
-        Relationships: [];
-      };
-      menu_master: {
-        Row: {
-          name: string;
-          recipe: Json;
-        };
-        Insert: {
-          name: string;
-          recipe: Json;
-        };
-        Update: {
-          name?: string;
-          recipe?: Json;
-        };
-        Relationships: [];
-      };
-      settings: {
-        Row: {
-          key: string;
-          value_num: number | null;
-          value_str: string | null;
-        };
-        Insert: {
-          key: string;
-          value_num?: number | null;
-          value_str?: string | null;
-        };
-        Update: {
-          key?: string;
-          value_num?: number | null;
-          value_str?: string | null;
-        };
-        Relationships: [];
-      };
-      predictions: {
-        Row: {
-          id: number;
-          ds: string;
-          yhat: number;
-          model_version: string;
-          created_at: string;
-        };
-        Insert: {
-          id?: number;
-          ds: string;
-          yhat: number;
-          model_version: string;
-          created_at?: string;
-        };
-        Update: {
-          id?: number;
-          ds?: string;
-          yhat?: number;
-          model_version?: string;
-          created_at?: string;
-        };
-        Relationships: [];
-      };
       analytics_cache: {
         Row: {
-          metric_type: string;
-          payload: Json;
-          updated_at: string;
-        };
+          metric_type: string
+          payload: Json
+          updated_at: string
+        }
         Insert: {
-          metric_type: string;
-          payload: Json;
-          updated_at?: string;
-        };
+          metric_type: string
+          payload: Json
+          updated_at?: string
+        }
         Update: {
-          metric_type?: string;
-          payload?: Json;
-          updated_at?: string;
-        };
-        Relationships: [];
-      };
+          metric_type?: string
+          payload?: Json
+          updated_at?: string
+        }
+        Relationships: []
+      }
       career_logs: {
         Row: {
-          id: number;
-          log_date: string;
-          weight: number;
-          season: string;
-          target_date: string;
-          note: string | null;
-        };
+          id: number
+          log_date: string
+          note: string | null
+          season: string
+          target_date: string
+          weight: number
+        }
         Insert: {
-          id?: number;
-          log_date: string;
-          weight: number;
-          season: string;
-          target_date: string;
-          note?: string | null;
-        };
+          id?: number
+          log_date: string
+          note?: string | null
+          season: string
+          target_date: string
+          weight: number
+        }
         Update: {
-          id?: number;
-          log_date?: string;
-          weight?: number;
-          season?: string;
-          target_date?: string;
-          note?: string | null;
-        };
-        Relationships: [];
-      };
-    };
-    Views: Record<string, never>;
+          id?: number
+          log_date?: string
+          note?: string | null
+          season?: string
+          target_date?: string
+          weight?: number
+        }
+        Relationships: []
+      }
+      daily_logs: {
+        Row: {
+          calories: number | null
+          carbs: number | null
+          created_at: string | null
+          fat: number | null
+          had_bowel_movement: boolean | null
+          id: string
+          is_cheat_day: boolean
+          is_eating_out: boolean
+          is_poor_sleep: boolean | null
+          is_refeed_day: boolean
+          is_travel_day: boolean
+          leg_flag: boolean | null
+          log_date: string
+          note: string | null
+          protein: number | null
+          sleep_hours: number | null
+          training_type: string | null
+          updated_at: string
+          weight: number
+          work_mode: string | null
+        }
+        Insert: {
+          calories?: number | null
+          carbs?: number | null
+          created_at?: string | null
+          fat?: number | null
+          had_bowel_movement?: boolean | null
+          id?: string
+          is_cheat_day?: boolean
+          is_eating_out?: boolean
+          is_poor_sleep?: boolean | null
+          is_refeed_day?: boolean
+          is_travel_day?: boolean
+          leg_flag?: boolean | null
+          log_date: string
+          note?: string | null
+          protein?: number | null
+          sleep_hours?: number | null
+          training_type?: string | null
+          updated_at?: string
+          weight: number
+          work_mode?: string | null
+        }
+        Update: {
+          calories?: number | null
+          carbs?: number | null
+          created_at?: string | null
+          fat?: number | null
+          had_bowel_movement?: boolean | null
+          id?: string
+          is_cheat_day?: boolean
+          is_eating_out?: boolean
+          is_poor_sleep?: boolean | null
+          is_refeed_day?: boolean
+          is_travel_day?: boolean
+          leg_flag?: boolean | null
+          log_date?: string
+          note?: string | null
+          protein?: number | null
+          sleep_hours?: number | null
+          training_type?: string | null
+          updated_at?: string
+          weight?: number
+          work_mode?: string | null
+        }
+        Relationships: []
+      }
+      food_master: {
+        Row: {
+          calories: number | null
+          carbs: number | null
+          category: string | null
+          created_at: string | null
+          fat: number | null
+          id: string
+          name: string
+          protein: number | null
+        }
+        Insert: {
+          calories?: number | null
+          carbs?: number | null
+          category?: string | null
+          created_at?: string | null
+          fat?: number | null
+          id?: string
+          name: string
+          protein?: number | null
+        }
+        Update: {
+          calories?: number | null
+          carbs?: number | null
+          category?: string | null
+          created_at?: string | null
+          fat?: number | null
+          id?: string
+          name?: string
+          protein?: number | null
+        }
+        Relationships: []
+      }
+      forecast_backtest_metrics: {
+        Row: {
+          bias: number | null
+          computed_at: string
+          extra: Json
+          horizon_days: number
+          id: string
+          mae: number
+          mape: number | null
+          model_name: string
+          n_predictions: number
+          rmse: number
+          run_id: string
+        }
+        Insert: {
+          bias?: number | null
+          computed_at?: string
+          extra?: Json
+          horizon_days: number
+          id?: string
+          mae: number
+          mape?: number | null
+          model_name: string
+          n_predictions?: number
+          rmse: number
+          run_id: string
+        }
+        Update: {
+          bias?: number | null
+          computed_at?: string
+          extra?: Json
+          horizon_days?: number
+          id?: string
+          mae?: number
+          mape?: number | null
+          model_name?: string
+          n_predictions?: number
+          rmse?: number
+          run_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "forecast_backtest_metrics_run_id_fkey"
+            columns: ["run_id"]
+            isOneToOne: false
+            referencedRelation: "forecast_backtest_runs"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      forecast_backtest_predictions: {
+        Row: {
+          abs_error: number
+          actual_weight: number
+          ape: number | null
+          error: number
+          forecast_origin_date: string
+          horizon_days: number
+          id: string
+          model_name: string
+          predicted_weight: number
+          run_id: string
+          squared_error: number
+          target_date: string
+        }
+        Insert: {
+          abs_error: number
+          actual_weight: number
+          ape?: number | null
+          error: number
+          forecast_origin_date: string
+          horizon_days: number
+          id?: string
+          model_name: string
+          predicted_weight: number
+          run_id: string
+          squared_error: number
+          target_date: string
+        }
+        Update: {
+          abs_error?: number
+          actual_weight?: number
+          ape?: number | null
+          error?: number
+          forecast_origin_date?: string
+          horizon_days?: number
+          id?: string
+          model_name?: string
+          predicted_weight?: number
+          run_id?: string
+          squared_error?: number
+          target_date?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "forecast_backtest_predictions_run_id_fkey"
+            columns: ["run_id"]
+            isOneToOne: false
+            referencedRelation: "forecast_backtest_runs"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      forecast_backtest_runs: {
+        Row: {
+          config: Json
+          created_at: string
+          horizons: number[]
+          id: string
+          model_name: string
+          model_version: string | null
+          n_source_rows: number
+          notes: string | null
+          train_max_date: string | null
+          train_min_date: string | null
+        }
+        Insert: {
+          config?: Json
+          created_at?: string
+          horizons: number[]
+          id?: string
+          model_name: string
+          model_version?: string | null
+          n_source_rows?: number
+          notes?: string | null
+          train_max_date?: string | null
+          train_min_date?: string | null
+        }
+        Update: {
+          config?: Json
+          created_at?: string
+          horizons?: number[]
+          id?: string
+          model_name?: string
+          model_version?: string | null
+          n_source_rows?: number
+          notes?: string | null
+          train_max_date?: string | null
+          train_min_date?: string | null
+        }
+        Relationships: []
+      }
+      menu_master: {
+        Row: {
+          created_at: string | null
+          id: string
+          name: string
+          recipe: Json
+        }
+        Insert: {
+          created_at?: string | null
+          id?: string
+          name: string
+          recipe: Json
+        }
+        Update: {
+          created_at?: string | null
+          id?: string
+          name?: string
+          recipe?: Json
+        }
+        Relationships: []
+      }
+      predictions: {
+        Row: {
+          created_at: string
+          ds: string
+          id: number
+          model_version: string
+          yhat: number
+        }
+        Insert: {
+          created_at?: string
+          ds: string
+          id?: number
+          model_version: string
+          yhat: number
+        }
+        Update: {
+          created_at?: string
+          ds?: string
+          id?: number
+          model_version?: string
+          yhat?: number
+        }
+        Relationships: []
+      }
+      settings: {
+        Row: {
+          key: string
+          updated_at: string | null
+          value_num: number | null
+          value_str: string | null
+        }
+        Insert: {
+          key: string
+          updated_at?: string | null
+          value_num?: number | null
+          value_str?: string | null
+        }
+        Update: {
+          key?: string
+          updated_at?: string | null
+          value_num?: number | null
+          value_str?: string | null
+        }
+        Relationships: []
+      }
+    }
+    Views: {
+      [_ in never]: never
+    }
     Functions: {
       save_daily_log_partial: {
-        Args: {
-          p_log_date: string;
-          p_fields: Record<string, unknown>;
-        };
-        Returns: undefined;
-      };
-    };
-    Enums: Record<string, never>;
-    CompositeTypes: Record<string, never>;
-  };
-};
+        Args: { p_fields: Json; p_log_date: string }
+        Returns: undefined
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+}
+
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
+
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
+
+export type Tables<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
+    : never
+
+export type TablesInsert<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
+    : never
+
+export type TablesUpdate<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
+    : never
+
+export type Enums<
+  DefaultSchemaEnumNameOrOptions extends
+    | keyof DefaultSchema["Enums"]
+    | { schema: keyof DatabaseWithoutInternals },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
+> = DefaultSchemaEnumNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+    : never
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof DefaultSchema["CompositeTypes"]
+    | { schema: keyof DatabaseWithoutInternals },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
+> = PublicCompositeTypeNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never
+
+export const Constants = {
+  public: {
+    Enums: {},
+  },
+} as const
 
 // Convenience type aliases
 export type DailyLog = Database["public"]["Tables"]["daily_logs"]["Row"];

--- a/src/lib/utils/calcMacro.test.ts
+++ b/src/lib/utils/calcMacro.test.ts
@@ -4,12 +4,14 @@ import type { DailyLog } from "@/lib/supabase/types";
 
 function makeLog(log_date: string, overrides: Partial<DailyLog> = {}): DailyLog {
   return {
+    id:                "test-id",
     log_date,
     weight: 65.0,
     calories: 2000,
     protein: 150,
     fat: 50,
     carbs: 200,
+    created_at:        null,
     note: null,
     is_cheat_day:      false,
     is_refeed_day:     false,

--- a/src/lib/utils/calcReadiness.test.ts
+++ b/src/lib/utils/calcReadiness.test.ts
@@ -21,8 +21,10 @@ function makeDailyLog(
   overrides: Partial<DailyLog> = {}
 ): DailyLog {
   return {
+    id: "test-id",
     log_date,
-    weight,
+    weight: weight as number,
+    created_at: null,
     calories: null,
     protein: null,
     fat: null,

--- a/src/lib/utils/calendarUtils.test.ts
+++ b/src/lib/utils/calendarUtils.test.ts
@@ -9,10 +9,12 @@ import type { DailyLog } from "@/lib/supabase/types";
 
 // ── テストデータ工場 ─────────────────────────────────────────────────────────
 
-function makeLog(overrides: Partial<DailyLog> & { log_date: string }): DailyLog {
+function makeLog(overrides: Omit<Partial<DailyLog>, "weight"> & { log_date: string; weight?: number | null }): DailyLog {
   return {
+    id:                 "test-id",
     log_date:           overrides.log_date,
-    weight:             overrides.weight             ?? null,
+    weight:             (overrides.weight ?? null) as number,
+    created_at:         null,
     calories:           overrides.calories           ?? null,
     protein:            overrides.protein            ?? null,
     fat:                overrides.fat                ?? null,


### PR DESCRIPTION
## 概要
- `supabase gen types typescript` で `src/lib/supabase/types.ts` を実スキーマから再生成
- 生成ブロックの末尾に手動管理の型エイリアス群（`DailyLog`, `DashboardDailyLog`, `FoodMaster` 等）を温存
- スキーマ差分による型エラーを修正

## 変更点

### types.ts
- `__InternalSupabase.PostgrestVersion` の追加（supabase-js v2 の新形式）
- `food_master` に `id: string` / `created_at: string | null` が追加（旧手動定義では欠落していた）
- `daily_logs.weight` が `number | null` → `number`（DB 実態: NOT NULL）
- `daily_logs.calories/protein/fat/carbs` 等の nullable 列が正確に反映

### null-safety 修正
- `Cart.tsx`: `food[key] * grams` → `(food[key] ?? 0) * grams`
- `MenuTable.tsx`: カロリー計算箇所 (×5) に `?? 0` ガード追加
- `MenuPicker.tsx`: 同上

### 型アノテーション修正
- `FoodTable.tsx`: `payload: FoodMaster` → `TablesInsert<"food_master">`（Insert 型は id/created_at が省略可能）

### テスト修正
- 各テストファクトリに `id: "test-id"`, `created_at: null` を追加（新規必須フィールド）
- `SettingsForm.integration.test.tsx`: Setting モックに `updated_at: null` を追加
- `calendarUtils.test.ts`, `calcReadiness.test.ts`: null 体重のテストケースを型キャストで保持

## 確認
- `npx tsc --noEmit`: エラー 0
- `npx jest --no-coverage`: 960 tests passed

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)