### PR TITLE
refactor: getDelta 重複ロジックを recentLogsUtils に集約 (#196)

### DIFF
--- a/src/components/dashboard/RecentLogsCards.tsx
+++ b/src/components/dashboard/RecentLogsCards.tsx
@@ -18,6 +18,7 @@ import { ArrowDown, ArrowUp, Minus } from "lucide-react";
 import type { DashboardDailyLog } from "@/lib/supabase/types";
 import { DAY_TAGS, DAY_TAG_LABELS, DAY_TAG_BADGE_COLORS } from "@/lib/utils/dayTags";
 import { formatConditionSummary } from "@/lib/utils/trainingType";
+import { computeWeightDelta, buildRecentLogArrays } from "@/lib/utils/recentLogsUtils";
 
 interface RecentLogsCardsProps {
   logs: DashboardDailyLog[];
@@ -26,22 +27,7 @@ interface RecentLogsCardsProps {
 }
 
 export function RecentLogsCards({ logs, seasonMap, currentSeason }: RecentLogsCardsProps) {
-  const sorted = [...logs]
-    .filter((d) => d.weight !== null)
-    .sort((a, b) => b.log_date.localeCompare(a.log_date))
-    .slice(0, 14);
-
-  const ascending = [...logs]
-    .filter((d) => d.weight !== null)
-    .sort((a, b) => a.log_date.localeCompare(b.log_date));
-
-  function getDelta(log: DashboardDailyLog): number | null {
-    const idx = ascending.findIndex((d) => d.log_date === log.log_date);
-    if (idx <= 0) return null;
-    const prev = ascending[idx - 1];
-    if (prev.weight === null || log.weight === null) return null;
-    return log.weight - prev.weight;
-  }
+  const { sorted, ascending } = buildRecentLogArrays(logs);
 
   if (sorted.length === 0) {
     return (
@@ -52,7 +38,7 @@ export function RecentLogsCards({ logs, seasonMap, currentSeason }: RecentLogsCa
   return (
     <div className="divide-y divide-slate-50">
       {sorted.map((log) => {
-        const delta = getDelta(log);
+        const delta = computeWeightDelta(ascending, log);
         const DeltaIcon =
           delta === null ? null : delta > 0 ? ArrowUp : delta < 0 ? ArrowDown : Minus;
         const season = seasonMap?.get(log.log_date) ?? currentSeason;

--- a/src/components/dashboard/RecentLogsTable.tsx
+++ b/src/components/dashboard/RecentLogsTable.tsx
@@ -4,6 +4,7 @@ import { ArrowDown, ArrowUp, Minus } from "lucide-react";
 import type { DashboardDailyLog } from "@/lib/supabase/types";
 import { DAY_TAGS, DAY_TAG_LABELS, DAY_TAG_BADGE_COLORS } from "@/lib/utils/dayTags";
 import { formatConditionSummary } from "@/lib/utils/trainingType";
+import { computeWeightDelta, buildRecentLogArrays } from "@/lib/utils/recentLogsUtils";
 
 interface RecentLogsTableProps {
   logs: DashboardDailyLog[];
@@ -13,22 +14,7 @@ interface RecentLogsTableProps {
 }
 
 export function RecentLogsTable({ logs, embedded = false, seasonMap, currentSeason }: RecentLogsTableProps) {
-  const sorted = [...logs]
-    .filter((d) => d.weight !== null)
-    .sort((a, b) => b.log_date.localeCompare(a.log_date))
-    .slice(0, 14);
-
-  const ascending = [...logs]
-    .filter((d) => d.weight !== null)
-    .sort((a, b) => a.log_date.localeCompare(b.log_date));
-
-  function getDelta(log: DashboardDailyLog): number | null {
-    const idx = ascending.findIndex((d) => d.log_date === log.log_date);
-    if (idx <= 0) return null;
-    const prev = ascending[idx - 1];
-    if (prev.weight === null || log.weight === null) return null;
-    return log.weight - prev.weight;
-  }
+  const { sorted, ascending } = buildRecentLogArrays(logs);
 
   /** 直前ログとのカロリー差分。calories / 前回 calories いずれかが null なら null */
   function getCalDelta(log: DashboardDailyLog): number | null {
@@ -53,7 +39,7 @@ export function RecentLogsTable({ logs, embedded = false, seasonMap, currentSeas
         </thead>
         <tbody className="divide-y divide-slate-50">
           {sorted.map((log) => {
-            const delta = getDelta(log);
+            const delta = computeWeightDelta(ascending, log);
             const DeltaIcon = delta === null ? null : delta > 0 ? ArrowUp : delta < 0 ? ArrowDown : Minus;
             const conditionSummary = formatConditionSummary({
               had_bowel_movement: log.had_bowel_movement as boolean | null,

--- a/src/lib/utils/recentLogsUtils.ts
+++ b/src/lib/utils/recentLogsUtils.ts
@@ -1,0 +1,41 @@
+import type { DashboardDailyLog } from "@/lib/supabase/types";
+
+/**
+ * ログ配列（昇順ソート済み）と対象ログから体重差分を計算する。
+ *
+ * RecentLogsTable / RecentLogsCards で共通利用する。
+ * 直前の体重記録が存在しない場合、または体重が null の場合は null を返す。
+ *
+ * @param ascending - log_date 昇順でソート済みの DashboardDailyLog 配列
+ * @param log       - 差分を求めたいログエントリ
+ */
+export function computeWeightDelta(
+  ascending: DashboardDailyLog[],
+  log: DashboardDailyLog
+): number | null {
+  const idx = ascending.findIndex((d) => d.log_date === log.log_date);
+  if (idx <= 0) return null;
+  const prev = ascending[idx - 1];
+  if (prev.weight === null || log.weight === null) return null;
+  return log.weight - prev.weight;
+}
+
+/**
+ * ログ配列から表示用の sorted（降順 14件）と ascending（昇順）を生成する。
+ *
+ * 体重未記録（weight === null）のログは除外する。
+ */
+export function buildRecentLogArrays(logs: DashboardDailyLog[]): {
+  sorted: DashboardDailyLog[];
+  ascending: DashboardDailyLog[];
+} {
+  const ascending = [...logs]
+    .filter((d) => d.weight !== null)
+    .sort((a, b) => a.log_date.localeCompare(b.log_date));
+
+  const sorted = [...ascending]
+    .sort((a, b) => b.log_date.localeCompare(a.log_date))
+    .slice(0, 14);
+
+  return { sorted, ascending };
+}


### PR DESCRIPTION
## 概要
`RecentLogsTable` と `RecentLogsCards` で完全に重複していた `getDelta` / `sorted` / `ascending` ロジックを共通ユーティリティに抽出。

## 変更点

### 新規: `src/lib/utils/recentLogsUtils.ts`
- `computeWeightDelta(ascending, log)` — 前ログとの体重差分計算（旧 `getDelta`）
- `buildRecentLogArrays(logs)` — 表示用 sorted（降順14件）と ascending を生成

### 変更: `RecentLogsTable.tsx` / `RecentLogsCards.tsx`
- 重複していた `sorted` / `ascending` / `getDelta` を削除
- `buildRecentLogArrays` / `computeWeightDelta` をインポートして使用
- 表示ロジック・動作は変更なし

## 確認
- `npx tsc --noEmit`: エラー 0
- `npx jest --no-coverage`: 960 tests passed

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)