### PR TITLE
fix: UI統一 — 表記ゆれ・小数桁・タッチターゲット・空状態・アクセシビリティ

### DIFF
--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -75,7 +75,7 @@ export default async function HistoryPage() {
   const isCut = settings.currentPhase !== "Bulk";
 
   return (
-    <PageShell title="キャリア比較">
+    <PageShell title="履歴">
 
       {/* Read error banners — graceful degradation: コンテンツはブロックしない */}
       {careerLogsResult.kind === "error" && (

--- a/src/app/macro/page.tsx
+++ b/src/app/macro/page.tsx
@@ -28,7 +28,7 @@ export default async function MacroPage() {
 
   if (logsResult.kind === "error") {
     return (
-      <PageShell title="栄養分析">
+      <PageShell title="栄養">
         <div className="rounded-2xl border border-rose-100 bg-rose-50 px-5 py-3 text-sm text-rose-700">
           ログデータの取得中にエラーが発生しました。ページを再読み込みしてください。
         </div>
@@ -40,7 +40,7 @@ export default async function MacroPage() {
 
   if (logs.length === 0) {
     return (
-      <PageShell title="栄養分析">
+      <PageShell title="栄養">
         <div className="rounded-xl border border-amber-100 bg-amber-50 p-4 text-sm text-amber-700">
           栄養データが記録されるとグラフが表示されます。
         </div>

--- a/src/app/tdee/page.tsx
+++ b/src/app/tdee/page.tsx
@@ -187,7 +187,7 @@ export default async function TdeePage() {
   }));
 
   return (
-    <PageShell title="TDEE・代謝分析">
+    <PageShell title="TDEE">
 
       {/* Read error banners — graceful degradation: コンテンツはブロックしない */}
       {rawLogsResult.kind === "error" && (

--- a/src/components/dashboard/GoalNavigator.tsx
+++ b/src/components/dashboard/GoalNavigator.tsx
@@ -103,7 +103,7 @@ function fmt1(v: number | null, fallback = "—"): string {
 
 function fmtRate2W(v: number | null, fallback = "—"): string {
   if (v === null) return fallback;
-  return `${v > 0 ? "+" : ""}${v.toFixed(2)} kg/2週`;
+  return `${v > 0 ? "+" : ""}${v.toFixed(1)} kg/2週`;
 }
 
 function fmtKcal(v: number | null, fallback = "—"): string {
@@ -114,7 +114,7 @@ function fmtKcal(v: number | null, fallback = "—"): string {
 /** 差の符号をわかりやすくラベル化 (kg/2週) */
 function paceGapLabel(gap: number | null, isCut: boolean): string {
   if (gap === null) return "—";
-  const abs = Math.abs(gap).toFixed(2);
+  const abs = Math.abs(gap).toFixed(1);
   if (Math.abs(gap) < 0.04) return "ほぼ一致";
   // Cut: gap > 0 = 遅れ, gap < 0 = 先行
   // Bulk: gap < 0 = 遅れ, gap > 0 = 先行
@@ -174,7 +174,7 @@ function buildReasonLabel(
     return "ペース差を算出できません";
   }
   const isBehind = isCut ? paceGap > 0 : paceGap < 0;
-  const absGap = Math.abs(paceGap).toFixed(2);
+  const absGap = Math.abs(paceGap).toFixed(1);
   if (isBehind) {
     return `必要ペースより ${absGap} kg/2週 遅いため、${kcalCorrection < 0 ? "" : "+"}${kcalCorrection.toLocaleString()} kcal/日 を推奨`;
   } else {
@@ -495,7 +495,7 @@ export function GoalNavigator({
                   }`}
                 >
                   {monthlyGoalProgress.deltaKg > 0 ? "+" : ""}
-                  {monthlyGoalProgress.deltaKg.toFixed(2)} kg
+                  {monthlyGoalProgress.deltaKg.toFixed(1)} kg
                 </span>
               </span>
             )}
@@ -506,7 +506,7 @@ export function GoalNavigator({
                 残必要ペース:{" "}
                 <span className="font-semibold tabular-nums text-slate-700">
                   {monthlyGoalProgress.requiredPaceKgPerWeek > 0 ? "+" : ""}
-                  {monthlyGoalProgress.requiredPaceKgPerWeek.toFixed(2)} kg/週
+                  {monthlyGoalProgress.requiredPaceKgPerWeek.toFixed(1)} kg/週
                 </span>
                 <span className="ml-1 text-[10px] text-slate-400">
                   (残{monthlyGoalProgress.daysToMonthEnd}日)

--- a/src/components/dashboard/KpiCards.tsx
+++ b/src/components/dashboard/KpiCards.tsx
@@ -110,7 +110,7 @@ export function KpiCards({ logs, settings }: KpiCardsProps) {
     slopePerWeek === null || Math.abs(slopePerWeek) < 0.05 ? "flat" : slopePerWeek > 0 ? "up" : "down";
   const trendLabel = slopePerWeek === null || Math.abs(slopePerWeek) < 0.05
     ? "横ばい"
-    : `${slopePerWeek > 0 ? "+" : ""}${slopePerWeek.toFixed(2)} kg/週`;
+    : `${slopePerWeek > 0 ? "+" : ""}${slopePerWeek.toFixed(1)} kg/週`;
 
   const goalReachResult = calcGoalReachDate(weight_7d_avg, slopePerDay30, goalWeight, todayStr);
   const goalReachDate = goalReachResult.date;

--- a/src/components/dashboard/LogsAndSummaryTabs.tsx
+++ b/src/components/dashboard/LogsAndSummaryTabs.tsx
@@ -77,7 +77,7 @@ export function LogsAndSummaryTabs({ logs, monthStats, seasonMap, currentSeason,
             {monthStats.length > 0
               ? <SeasonSummary stats={[...monthStats].reverse()} />
               : !monthlyGoalSummaryRows?.length && (
-                  <p className="py-6 text-center text-sm text-slate-400">データがありません</p>
+                  <p className="py-8 text-center text-sm text-slate-400">データがありません</p>
                 )
             }
             {/* 月次計画 vs 実績 */}

--- a/src/components/dashboard/MonthlyGoalTable.tsx
+++ b/src/components/dashboard/MonthlyGoalTable.tsx
@@ -114,7 +114,7 @@ export function MonthlyGoalTable({ rows, phase }: MonthlyGoalTableProps) {
                   {/* 差分 */}
                   <td className={`py-2 pr-3 text-right text-xs font-semibold tabular-nums ${diffColor(row.diffKg, isCut)}`}>
                     {row.diffKg !== null
-                      ? `${row.diffKg > 0 ? "+" : ""}${row.diffKg.toFixed(2)}`
+                      ? `${row.diffKg > 0 ? "+" : ""}${row.diffKg.toFixed(1)}`
                       : "—"}
                   </td>
                   {/* 状態 */}
@@ -124,7 +124,7 @@ export function MonthlyGoalTable({ rows, phase }: MonthlyGoalTableProps) {
                   {/* 累積ズレ */}
                   <td className={`py-2 pr-3 text-right text-xs tabular-nums ${diffColor(row.cumulativeGapKg, isCut)}`}>
                     {row.cumulativeGapKg !== null
-                      ? `${row.cumulativeGapKg > 0 ? "+" : ""}${row.cumulativeGapKg.toFixed(2)}`
+                      ? `${row.cumulativeGapKg > 0 ? "+" : ""}${row.cumulativeGapKg.toFixed(1)}`
                       : "—"}
                   </td>
                   {/* 翌月必要変化量 (sm 以上) */}

--- a/src/components/dashboard/RecentLogsCards.tsx
+++ b/src/components/dashboard/RecentLogsCards.tsx
@@ -31,7 +31,7 @@ export function RecentLogsCards({ logs, seasonMap, currentSeason }: RecentLogsCa
 
   if (sorted.length === 0) {
     return (
-      <p className="py-6 text-center text-sm text-slate-400">ログがありません</p>
+      <p className="py-8 text-center text-sm text-slate-400">ログがありません</p>
     );
   }
 

--- a/src/components/dashboard/WeeklyReviewCard.tsx
+++ b/src/components/dashboard/WeeklyReviewCard.tsx
@@ -83,7 +83,7 @@ function fmt0(v: number | null): string {
 }
 function fmtSigned1(v: number | null): string {
   if (v === null) return "—";
-  return `${v > 0 ? "+" : ""}${v.toFixed(2)}`;
+  return `${v > 0 ? "+" : ""}${v.toFixed(1)}`;
 }
 function fmtSignedKcal(v: number | null): string {
   if (v === null) return "—";

--- a/src/components/foods/FoodTable.tsx
+++ b/src/components/foods/FoodTable.tsx
@@ -338,7 +338,7 @@ export function FoodTable({ initialFoods }: FoodTableProps) {
                   className="flex-shrink-0 p-2 -mr-1 text-slate-300 hover:text-rose-500 disabled:opacity-40"
                   aria-label={`${food.name}を削除`}
                 >
-                  <Trash2 size={16} />
+                  <Trash2 size={15} />
                 </button>
               </div>
             ))

--- a/src/components/foods/MenuTable.tsx
+++ b/src/components/foods/MenuTable.tsx
@@ -230,7 +230,7 @@ export function MenuTable({ initialMenus, foods }: MenuTableProps) {
                         <span>{ri.amount}g</span>
                         <span className="text-gray-600 font-medium">{kcal} kcal</span>
                         <button onClick={() => removeItemFromEditing(originalIdx)} className="text-gray-300 hover:text-rose-500">
-                          <Trash2 size={13} />
+                          <Trash2 size={15} />
                         </button>
                       </div>
                     </li>
@@ -262,7 +262,7 @@ export function MenuTable({ initialMenus, foods }: MenuTableProps) {
 
       {/* ── メニュー一覧 ── */}
       {menus.length === 0 ? (
-        <p className="rounded-2xl border border-gray-100 bg-white p-8 text-center text-sm text-gray-400">
+        <p className="py-8 text-center text-sm text-slate-400">
           セットメニューが登録されていません
         </p>
       ) : (
@@ -304,7 +304,7 @@ export function MenuTable({ initialMenus, foods }: MenuTableProps) {
                         className="p-2 -mr-1 text-slate-300 hover:text-rose-500 disabled:opacity-40"
                         aria-label={`${menu.name}を削除`}
                       >
-                        <Trash2 size={16} />
+                        <Trash2 size={15} />
                       </button>
                     </div>
                   </div>

--- a/src/components/macro/MacroDailyTable.tsx
+++ b/src/components/macro/MacroDailyTable.tsx
@@ -36,7 +36,7 @@ export function MacroDailyTable({ data, calTarget = null }: MacroDailyTableProps
     return (
       <div className="rounded-2xl border border-gray-100 bg-white p-5 shadow-sm">
         <h2 className="mb-2 text-sm font-semibold text-gray-700">日次栄養内訳（直近 14 日）</h2>
-        <p className="text-sm text-gray-400">データがありません。</p>
+        <p className="py-8 text-center text-sm text-slate-400">データがありません</p>
       </div>
     );
   }

--- a/src/components/meal/Cart.tsx
+++ b/src/components/meal/Cart.tsx
@@ -116,7 +116,7 @@ export function Cart({ items, onChange }: CartProps) {
                 value={item.food.name in editingGrams ? editingGrams[item.food.name] : item.grams}
                 onChange={(e) => handleGramsChange(item.food.name, e.target.value)}
                 onBlur={() => handleGramsBlur(i, item.food.name)}
-                className="w-16 rounded border border-gray-200 px-2 py-2.5 text-right text-sm outline-none focus:border-blue-400"
+                className="w-20 rounded border border-gray-200 px-2 py-2.5 text-right text-sm outline-none focus:border-blue-400"
               />
               <span className="text-xs text-gray-400">g</span>
             </div>

--- a/src/components/meal/MealLogger.tsx
+++ b/src/components/meal/MealLogger.tsx
@@ -329,8 +329,8 @@ export function MealLogger({ sidebar = false, showHeader = true }: MealLoggerPro
                 onClick={() => { setWeight(null); setWeightTouched(true); }}
                 aria-label="体重を削除予定にする"
                 title="保存時にこの値を削除する"
-                className="absolute right-2.5 top-1/2 -translate-y-1/2 text-slate-300 hover:text-rose-400 transition-colors">
-                <X size={13} />
+                className="absolute right-1.5 top-1/2 -translate-y-1/2 p-1 text-slate-300 hover:text-rose-400 transition-colors">
+                <X size={15} />
               </button>
             )}
           </div>
@@ -372,8 +372,8 @@ export function MealLogger({ sidebar = false, showHeader = true }: MealLoggerPro
                 onClick={() => { setNote(null); setNoteTouched(true); }}
                 aria-label="メモを削除予定にする"
                 title="保存時にこの値を削除する"
-                className="absolute right-2.5 top-1/2 -translate-y-1/2 text-slate-300 hover:text-rose-400 transition-colors">
-                <X size={13} />
+                className="absolute right-1.5 top-1/2 -translate-y-1/2 p-1 text-slate-300 hover:text-rose-400 transition-colors">
+                <X size={15} />
               </button>
             )}
           </div>
@@ -455,8 +455,8 @@ export function MealLogger({ sidebar = false, showHeader = true }: MealLoggerPro
                   onClick={() => { setSleepHours(null); setSleepHoursTouched(true); }}
                   aria-label="睡眠時間を削除予定にする"
                   title="保存時にこの値を削除する"
-                  className="absolute right-2.5 top-1/2 -translate-y-1/2 text-slate-300 hover:text-rose-400 transition-colors">
-                  <X size={13} />
+                  className="absolute right-1.5 top-1/2 -translate-y-1/2 p-1 text-slate-300 hover:text-rose-400 transition-colors">
+                  <X size={15} />
                 </button>
               )}
             </div>

--- a/src/components/settings/SettingsForm.tsx
+++ b/src/components/settings/SettingsForm.tsx
@@ -73,14 +73,14 @@ interface FormSectionProps {
 
 function FormSection({ id, title, subtitle, isOpen, onToggle, children, border = true }: FormSectionProps) {
   const panelId = `settings-panel-${id}`;
+  const headingId = `settings-heading-${id}`;
   return (
     <div className={border ? "mt-5 border-t border-slate-100 pt-5" : ""}>
       <div className="flex items-start justify-between">
         <div>
-          <h2 className="text-sm font-semibold text-slate-700">{title}</h2>
+          <h2 id={headingId} className="text-sm font-semibold text-slate-700">{title}</h2>
           {subtitle && <p className="mt-0.5 text-xs text-slate-400">{subtitle}</p>}
         </div>
-        {/* アコーディオントグル: モバイルのみ表示。sm+ は常に展開 */}
         <button
           type="button"
           onClick={onToggle}
@@ -94,10 +94,10 @@ function FormSection({ id, title, subtitle, isOpen, onToggle, children, border =
           />
         </button>
       </div>
-      {/* sm+ では常に表示。モバイルでは isOpen でトグル */}
       <div
         id={panelId}
         role="region"
+        aria-labelledby={headingId}
         className={`mt-4 ${!isOpen ? "hidden sm:block" : ""}`}
       >
         {children}

--- a/src/components/tdee/TdeeDailyTable.tsx
+++ b/src/components/tdee/TdeeDailyTable.tsx
@@ -39,7 +39,7 @@ export function TdeeDailyTable({ data, phase = null }: TdeeDailyTableProps) {
     return (
       <div className="rounded-2xl border border-gray-100 bg-white p-5 shadow-sm">
         <h2 className="mb-2 text-sm font-semibold text-gray-700">日次 TDEE ログ（直近 14 日）</h2>
-        <p className="text-sm text-gray-400">データがありません。</p>
+        <p className="py-8 text-center text-sm text-slate-400">データがありません</p>
       </div>
     );
   }


### PR DESCRIPTION
## Summary

- **#223**: kg差分・ペース表示を `.toFixed(2)` → `.toFixed(1)` に統一（GoalNavigator / KpiCards / WeeklyReviewCard / MonthlyGoalTable）
- **#224**: PageShell title を NavBar ラベルに合わせて統一（「TDEE・代謝分析」→「TDEE」/「栄養分析」→「栄養」/「キャリア比較」→「履歴」）
- **#225**: MealLogger の X ボタンに `p-1` を追加しタッチターゲット拡大、アイコン size 13→15
- **#226**: Trash2 アイコンサイズを 15px に統一（FoodTable mobile 16→15 / MenuTable recipe 13→15・mobile 16→15）
- **#227**: データなし（空状態）表示を `py-8 text-center text-sm text-slate-400` に統一（5コンポーネント）
- **#228**: Cart グラム入力フィールドを `w-16` → `w-20` に拡大
- **#230**: SettingsForm の `role="region"` に `aria-labelledby` を追加

## Test plan
- [ ] ローカルで各画面を開き、NavBar と PageShell のタイトルが一致することを確認
- [ ] MealLogger で X ボタンのタップしやすさを確認
- [ ] FoodTable / MenuTable の削除ボタンサイズが均一になっていることを確認
- [ ] Cart でグラム入力フィールドの幅が広がっていることを確認
- [ ] データなし状態で各コンポーネントの空状態表示を確認
- [ ] `npx jest --no-coverage` がパスすることを確認

Closes #223, #224, #225, #226, #227, #228, #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)