### PR TITLE
fix: 成功・警告色のテキストカラーバリアントを統一

### DIFF
--- a/src/app/forecast-accuracy/page.tsx
+++ b/src/app/forecast-accuracy/page.tsx
@@ -117,7 +117,7 @@ export default async function ForecastAccuracyPage() {
               <span className="ml-2 text-xs font-normal text-slate-400">
                 ({sma7Run.created_at.slice(0, 10)} 実行)
               </span>
-              <span className="ml-2 rounded-full bg-emerald-100 px-2 py-0.5 text-[11px] font-semibold text-emerald-700">
+              <span className="ml-2 rounded-full bg-emerald-100 px-2 py-0.5 text-[11px] font-semibold text-emerald-600">
                 ノイズ除去済み
               </span>
             </h2>
@@ -133,7 +133,7 @@ export default async function ForecastAccuracyPage() {
           </div>
         ) : (
           /* sma7 未実行の場合の誘導 */
-          <div className="rounded-xl border border-dashed border-emerald-200 bg-emerald-50 p-5 text-sm text-emerald-700">
+          <div className="rounded-xl border border-dashed border-emerald-200 bg-emerald-50 p-5 text-sm text-emerald-600">
             <p className="font-semibold">7日平均ベース評価を追加するには:</p>
             <code className="mt-2 block rounded bg-emerald-100 px-3 py-1.5 text-xs font-mono">
               python ml-pipeline/backtest.py --series-type sma7

--- a/src/components/charts/BacktestComparison.tsx
+++ b/src/components/charts/BacktestComparison.tsx
@@ -248,7 +248,7 @@ export function BacktestComparison({
                         >
                           {hasSma7Data ? fmt3(sma7Mae) : "—"}
                           {isSma7Best && hasSma7Data && (
-                            <span className="ml-1 text-[9px] text-emerald-400">★</span>
+                            <span className="ml-1 text-[9px] text-emerald-600">★</span>
                           )}
                         </td>
                       </Fragment>

--- a/src/components/charts/BacktestResults.tsx
+++ b/src/components/charts/BacktestResults.tsx
@@ -301,8 +301,8 @@ export function BacktestResults({ run, metrics }: Props) {
       {/* 指標の読み方 */}
       <div className="rounded-xl border border-amber-100 bg-amber-50 p-4">
         <div className="flex items-start gap-2">
-          <Info size={16} className="mt-0.5 flex-shrink-0 text-amber-500" />
-          <div className="space-y-1 text-xs text-amber-800">
+          <Info size={16} className="mt-0.5 flex-shrink-0 text-amber-600" />
+          <div className="space-y-1 text-xs text-amber-600">
             <p className="font-semibold">指標の読み方</p>
             <p>
               <strong>MAE</strong> = 予測と実測の平均絶対誤差 (kg)。例えば MAE=0.5 なら平均 ±0.5 kg の誤差。

--- a/src/components/charts/FactorAnalysis.tsx
+++ b/src/components/charts/FactorAnalysis.tsx
@@ -45,7 +45,7 @@ function confidenceLevel(sampleCount: number): "high" | "medium" | "low" {
 }
 
 const CONFIDENCE_CFG = {
-  high:   { label: "参考度: 高",   className: "text-emerald-700 bg-emerald-50 border-emerald-200" },
+  high:   { label: "参考度: 高",   className: "text-emerald-600 bg-emerald-50 border-emerald-200" },
   medium: { label: "参考度: 中",   className: "text-amber-700  bg-amber-50  border-amber-200"   },
   low:    { label: "参考度: 低め", className: "text-rose-600   bg-rose-50   border-rose-200"     },
 };
@@ -82,7 +82,7 @@ export function FactorAnalysisPlaceholder({
         </div>
       ) : (
         <div className="rounded-xl border border-amber-100 bg-amber-50 px-4 py-4">
-          <p className="text-sm font-medium text-amber-800">分析結果がまだありません</p>
+          <p className="text-sm font-medium text-amber-600">分析結果がまだありません</p>
           <p className="mt-1.5 text-xs text-amber-700">
             ML バッチ（analyze.py）が実行されると結果が表示されます。
             GitHub Actions の日次 cron（毎日 AM 3:00 JST）で自動実行されます。
@@ -160,7 +160,7 @@ const STABILITY_CFG: Record<
   StabilityLabel,
   { label: string; className: string; tooltip: string } | null
 > = {
-  high:        { label: "安定", className: "text-emerald-700 bg-emerald-50 border-emerald-200", tooltip: "重要度がデータの変動に対して安定しています" },
+  high:        { label: "安定", className: "text-emerald-600 bg-emerald-50 border-emerald-200", tooltip: "重要度がデータの変動に対して安定しています" },
   medium:      { label: "中程度", className: "text-amber-700 bg-amber-50 border-amber-200",    tooltip: "ある程度安定していますが解釈には注意が必要です" },
   low:         { label: "不安定", className: "text-rose-600 bg-rose-50 border-rose-200",       tooltip: "データの揺らぎで重要度が変わりやすく、強い解釈は避けてください" },
   unavailable: null,  // バッジ非表示

--- a/src/components/dashboard/GoalNavigator.tsx
+++ b/src/components/dashboard/GoalNavigator.tsx
@@ -260,7 +260,7 @@ export function GoalNavigator({
             className={`rounded-full px-2.5 py-0.5 text-[11px] font-bold ${
               isCut
                 ? "bg-blue-100 text-blue-700"
-                : "bg-emerald-100 text-emerald-700"
+                : "bg-emerald-100 text-emerald-600"
             }`}
           >
             {phase}
@@ -516,7 +516,7 @@ export function GoalNavigator({
 
             {/* 警告あり補足 */}
             {monthlyGoalProgress.hasWarnings && (
-              <span className="text-[10px] text-amber-500">⚠ 計画に警告あり</span>
+              <span className="text-[10px] text-amber-600">⚠ 計画に警告あり</span>
             )}
           </div>
         </div>

--- a/src/components/dashboard/KpiCards.tsx
+++ b/src/components/dashboard/KpiCards.tsx
@@ -30,7 +30,7 @@ function KpiCard({ label, value, unit, sub, icon, accent, iconColor, trendDir, t
   const isGood = trendDir === undefined || trendDir === "flat"
     ? null
     : trendDir === trendPositive;
-  const trendColor = isGood === null ? "text-slate-400" : isGood ? "text-emerald-500" : "text-rose-500";
+  const trendColor = isGood === null ? "text-slate-400" : isGood ? "text-emerald-600" : "text-rose-500";
 
   return (
     <div className="relative overflow-hidden rounded-2xl border border-slate-100 bg-white p-5 shadow-sm transition-shadow hover:shadow-md">
@@ -159,7 +159,7 @@ export function KpiCards({ logs, settings }: KpiCardsProps) {
             goalReachDate
               ? "text-teal-600"
               : goalReachLabel === "達成済み ✓"
-              ? "text-emerald-500"
+              ? "text-emerald-600"
               : "text-slate-400"
           }`}>
             {goalReachLabel}

--- a/src/components/dashboard/WeeklyReviewCard.tsx
+++ b/src/components/dashboard/WeeklyReviewCard.tsx
@@ -49,7 +49,7 @@ const STAGNATION_CONFIG: Record<
 > = {
   advancing: {
     label: "順調",
-    color: "text-emerald-700",
+    color: "text-emerald-600",
     bg: "bg-emerald-50 border-emerald-200",
     icon: CheckCircle2,
   },

--- a/src/components/history/SeasonComparisonAccordion.tsx
+++ b/src/components/history/SeasonComparisonAccordion.tsx
@@ -241,11 +241,11 @@ export function SeasonComparisonAccordion({
       {/* ── 凡例 ── */}
       <div className="flex flex-wrap items-center gap-4 border-t border-slate-50 bg-slate-50 px-5 py-2 text-[11px] text-slate-400">
         <span className="flex items-center gap-1">
-          <TrendingDown size={11} className="text-emerald-500" />
+          <TrendingDown size={11} className="text-emerald-600" />
           {isCut ? "今季が前回より軽い（先行）" : "今季が前回より重い（先行）"}
         </span>
         <span className="flex items-center gap-1">
-          <TrendingUp size={11} className="text-amber-500" />
+          <TrendingUp size={11} className="text-amber-600" />
           {isCut ? "今季が前回より重い（遅れ）" : "今季が前回より軽い（遅れ）"}
         </span>
       </div>

--- a/src/components/history/SeasonComparisonTable.tsx
+++ b/src/components/history/SeasonComparisonTable.tsx
@@ -243,11 +243,11 @@ export function SeasonComparisonTable({
       {/* ── 凡例 ── */}
       <div className="flex flex-wrap items-center gap-4 border-t border-slate-50 bg-slate-50 px-5 py-2 text-[11px] text-slate-400">
         <span className="flex items-center gap-1">
-          <TrendingDown size={11} className="text-emerald-500" />
+          <TrendingDown size={11} className="text-emerald-600" />
           {isCut ? "今季が前回より軽い (先行)" : "今季が前回より重い (先行)"}
         </span>
         <span className="flex items-center gap-1">
-          <TrendingUp size={11} className="text-amber-500" />
+          <TrendingUp size={11} className="text-amber-600" />
           {isCut ? "今季が前回より重い (遅れ)" : "今季が前回より軽い (遅れ)"}
         </span>
         <span className="ml-auto">

--- a/src/components/history/TodayWindowComparison.tsx
+++ b/src/components/history/TodayWindowComparison.tsx
@@ -70,8 +70,8 @@ function diffColorClass(ahead: boolean | null): string {
 
 function DiffIcon({ ahead }: { ahead: boolean | null }) {
   if (ahead === null) return <Minus size={12} className="text-slate-300" />;
-  if (ahead) return <TrendingDown size={12} className="text-emerald-500" />;
-  return <TrendingUp size={12} className="text-amber-500" />;
+  if (ahead) return <TrendingDown size={12} className="text-emerald-600" />;
+  return <TrendingUp size={12} className="text-amber-600" />;
 }
 
 // ─── 自動所見生成 ────────────────────────────────────────────────────────────
@@ -294,11 +294,11 @@ export function TodayWindowComparison({
       {/* ── 凡例 ── */}
       <div className="flex flex-wrap items-center gap-4 border-t border-slate-50 bg-slate-50 px-5 py-2 text-[11px] text-slate-400">
         <span className="flex items-center gap-1">
-          <TrendingDown size={11} className="text-emerald-500" />
+          <TrendingDown size={11} className="text-emerald-600" />
           {isCut ? "今季が前回より軽い（先行）" : "今季が前回より重い（先行）"}
         </span>
         <span className="flex items-center gap-1">
-          <TrendingUp size={11} className="text-amber-500" />
+          <TrendingUp size={11} className="text-amber-600" />
           {isCut ? "今季が前回より重い（遅れ）" : "今季が前回より軽い（遅れ）"}
         </span>
         <span className="ml-auto text-slate-300">ウィンドウ ±{windowDays}日</span>

--- a/src/components/history/YearOverYearSummary.tsx
+++ b/src/components/history/YearOverYearSummary.tsx
@@ -62,8 +62,8 @@ function diffColor(ahead: boolean | null): string {
 /** diff のアイコン */
 function DiffIcon({ ahead }: { ahead: boolean | null }) {
   if (ahead === null) return <Minus size={12} className="text-slate-300" />;
-  if (ahead) return <TrendingDown size={12} className="text-emerald-500" />;
-  return <TrendingUp size={12} className="text-amber-500" />;
+  if (ahead) return <TrendingDown size={12} className="text-emerald-600" />;
+  return <TrendingUp size={12} className="text-amber-600" />;
 }
 
 // ─── 自動所見生成 ────────────────────────────────────────────────────────────

--- a/src/components/macro/MacroKpiCards.tsx
+++ b/src/components/macro/MacroKpiCards.tsx
@@ -36,18 +36,18 @@ function getPaceInfo(rate: number, isBulk: boolean): PaceInfo {
   if (isBulk) {
     if (rate < -1.5) return { label: "減少しすぎています",  note: "増量方針から外れている可能性があります",     color: "text-rose-500"    };
     if (rate < -1.0) return { label: "減少傾向です",        note: "摂取量不足の可能性があります",               color: "text-rose-500"    };
-    if (rate < -0.5) return { label: "やや減少しています",  note: "増量にはやや不足気味です",                   color: "text-amber-500"   };
-    if (rate < -0.1) return { label: "やや緩やかです",      note: "もう少し増量幅を出せる可能性があります",     color: "text-amber-500"   };
-    if (rate < +0.1) return { label: "横ばいです",          note: "維持寄りで、増量としては控えめです",         color: "text-amber-500"   };
+    if (rate < -0.5) return { label: "やや減少しています",  note: "増量にはやや不足気味です",                   color: "text-amber-600"   };
+    if (rate < -0.1) return { label: "やや緩やかです",      note: "もう少し増量幅を出せる可能性があります",     color: "text-amber-600"   };
+    if (rate < +0.1) return { label: "横ばいです",          note: "維持寄りで、増量としては控えめです",         color: "text-amber-600"   };
     if (rate < +0.5) return { label: "適正ペースです",      note: "良いペースで進んでいます",                   color: "text-emerald-600" };
     return             { label: "増量が速すぎます",         note: "脂肪増加が大きくなる可能性があります",       color: "text-rose-500"    };
   }
   // Cut（デフォルト）
   if (rate < -1.5) return { label: "減量が速すぎます",    note: "筋量維持や回復に影響する可能性があります",   color: "text-rose-500"    };
-  if (rate < -1.0) return { label: "やや速めです",        note: "コンディション低下に注意してください",       color: "text-amber-500"   };
+  if (rate < -1.0) return { label: "やや速めです",        note: "コンディション低下に注意してください",       color: "text-amber-600"   };
   if (rate < -0.5) return { label: "適正ペースです",      note: "良いペースで進んでいます",                   color: "text-emerald-600" };
-  if (rate < -0.1) return { label: "やや緩やかです",      note: "もう少し減量幅を出せる可能性があります",     color: "text-amber-500"   };
-  if (rate < +0.1) return { label: "横ばいです",          note: "摂取量または活動量の調整余地があります",     color: "text-amber-500"   };
+  if (rate < -0.1) return { label: "やや緩やかです",      note: "もう少し減量幅を出せる可能性があります",     color: "text-amber-600"   };
+  if (rate < +0.1) return { label: "横ばいです",          note: "摂取量または活動量の調整余地があります",     color: "text-amber-600"   };
   if (rate < +0.5) return { label: "やや増加しています",  note: "減量方針から少し外れている可能性があります", color: "text-rose-500"    };
   return             { label: "増加しています",           note: "摂取量や特殊日の影響を確認してください",     color: "text-rose-500"    };
 }

--- a/src/components/meal/MealLogger.tsx
+++ b/src/components/meal/MealLogger.tsx
@@ -408,7 +408,7 @@ export function MealLogger({ sidebar = false, showHeader = true }: MealLoggerPro
           {hydratedLog.protein  !== null && <span> / P {hydratedLog.protein}g</span>}
           {hydratedLog.fat      !== null && <span> / F {hydratedLog.fat}g</span>}
           {hydratedLog.carbs    !== null && <span> / C {hydratedLog.carbs}g</span>}
-          <span className="ml-1 text-amber-500">（更新する場合はカートから追加）</span>
+          <span className="ml-1 text-amber-600">（更新する場合はカートから追加）</span>
         </div>
       )}
 

--- a/src/components/settings/ImportSection.tsx
+++ b/src/components/settings/ImportSection.tsx
@@ -148,7 +148,7 @@ export function ImportSection() {
                 <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">インポート内容</p>
                 <div className="grid grid-cols-3 gap-3 text-center">
                   <div className="rounded-lg bg-emerald-50 px-2 py-2">
-                    <p className="text-lg font-bold text-emerald-700">{preflight.newCount.toLocaleString()}</p>
+                    <p className="text-lg font-bold text-emerald-600">{preflight.newCount.toLocaleString()}</p>
                     <p className="text-xs text-emerald-600">新規追加</p>
                   </div>
                   <div className={`rounded-lg px-2 py-2 ${preflight.updateCount > 0 ? "bg-amber-50" : "bg-slate-50"}`}>
@@ -302,7 +302,7 @@ export function ImportSection() {
 
           {/* 結果 */}
           {result === "success" && (
-            <div className="flex items-center gap-2 rounded-xl bg-emerald-50 border border-emerald-100 px-4 py-3 text-sm font-medium text-emerald-700">
+            <div className="flex items-center gap-2 rounded-xl bg-emerald-50 border border-emerald-100 px-4 py-3 text-sm font-medium text-emerald-600">
               <CheckCircle2 size={16} />
               {parsed.rows.length.toLocaleString()} 件をインポートしました（既存データは上書き）
             </div>

--- a/src/components/settings/MonthlyGoalPlanSection.tsx
+++ b/src/components/settings/MonthlyGoalPlanSection.tsx
@@ -158,7 +158,7 @@ function PrereqMessage({
       {icon === "info" ? (
         <Info size={14} className="shrink-0 text-slate-400" />
       ) : (
-        <AlertTriangle size={14} className="shrink-0 text-amber-500" />
+        <AlertTriangle size={14} className="shrink-0 text-amber-600" />
       )}
       <span>{children}</span>
     </div>


### PR DESCRIPTION
## Summary

- `text-emerald-400` / `text-emerald-500` / `text-emerald-700` → `text-emerald-600` に統一（15箇所）
- `text-amber-500` / `text-amber-800` → `text-amber-600` に統一（18箇所）

## ルール

| セマンティクス | テキスト色 |
|---|---|
| 成功（saved / ok） | `emerald-600` |
| 警告（info / pending） | `amber-600`（バナー系は `amber-700` 維持） |
| エラー（error / danger） | `rose-600` |
| 削除予定（delete-pending） | `rose-500` |

## 除外
- ホバー・フォーカス色（`hover:text-*` / `focus:text-*`）
- バナー系の `text-amber-700`（`bg-amber-50` と組み合わせる用途）
- ボタンの `bg-emerald-600 text-white`（UI コンポーネントとして別物）

## Test plan
- [ ] `npx jest --no-coverage` がパスすること
- [ ] 各画面で成功・警告メッセージの色が視覚的に適切であることを確認

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)