### PR TITLE
fix: monthly_plan_overrides 保存前に JSON 検証を追加

### DIFF
--- a/src/lib/schemas/settingsSchema.ts
+++ b/src/lib/schemas/settingsSchema.ts
@@ -252,10 +252,23 @@ export function parseSettings(input: SettingsInput): ParseSettingsResult {
   }
 
   // ── monthly_plan_overrides ────────────────────────────────────────────────
-  // JSON 文字列として保持する。内容バリデーションは MonthlyGoalPlanSection 側で完結している。
+  // JSON 配列文字列として保持する。保存前に JSON としてパース可能かを検証する。
   {
     const raw = (input.monthly_plan_overrides ?? "").trim();
-    records.push({ key: "monthly_plan_overrides", value_num: null, value_str: raw !== "" ? raw : null });
+    if (raw !== "") {
+      try {
+        const parsed = JSON.parse(raw);
+        if (!Array.isArray(parsed)) {
+          errors.push({ field: "monthly_plan_overrides", message: "月次計画データの形式が不正です" });
+        } else {
+          records.push({ key: "monthly_plan_overrides", value_num: null, value_str: raw });
+        }
+      } catch {
+        errors.push({ field: "monthly_plan_overrides", message: "月次計画データの JSON が不正です" });
+      }
+    } else {
+      records.push({ key: "monthly_plan_overrides", value_num: null, value_str: null });
+    }
   }
 
   if (errors.length > 0) return { ok: false, errors };


### PR DESCRIPTION
## Summary
- 設定保存時に `monthly_plan_overrides` の JSON パースを事前検証するようにした
- 不正 JSON または配列以外の値であればバリデーションエラーを返す

## Before / After

**Before**: 文字列をそのまま DB に保存 → domain 層の `JSON.parse` が silent に null を返し設定がロスト

**After**: スキーマ層で `JSON.parse` を実行し、不正なら `{ ok: false, errors }` を返す

## Test plan
- [ ] 正常な JSON 配列文字列は保存できること
- [ ] 不正 JSON は "月次計画データの JSON が不正です" エラーになること
- [ ] 配列以外の JSON（オブジェクト等）は "月次計画データの形式が不正です" エラーになること
- [ ] 空文字列は null として保存されること
- [ ] `npx jest --no-coverage` がパスすること

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)