### PR TITLE
feat: had_bowel_movement 三状態化完了 + is_poor_sleep 廃止型を除去

### DIFF
--- a/src/app/actions/__tests__/saveDailyLog.test.ts
+++ b/src/app/actions/__tests__/saveDailyLog.test.ts
@@ -92,9 +92,9 @@ describe("buildUpdatePayload — undefined/null/値の区別", () => {
   });
 
   test("boolean true もペイロードに含まれる", () => {
-    const payload = buildUpdatePayload({ is_cheat_day: true, is_poor_sleep: true });
+    const payload = buildUpdatePayload({ is_cheat_day: true, is_refeed_day: true });
     expect(payload.is_cheat_day).toBe(true);
-    expect(payload.is_poor_sleep).toBe(true);
+    expect(payload.is_refeed_day).toBe(true);
   });
 
   test("全フィールド undefined → 空ペイロード", () => {
@@ -113,7 +113,7 @@ describe("buildUpdatePayload — undefined/null/値の区別", () => {
       is_cheat_day: true,
       is_refeed_day: false,
       is_eating_out: false,
-      is_poor_sleep: false,
+      is_travel_day: false,
     } as const;
     const payload = buildUpdatePayload(input);
     expect(Object.keys(payload)).toHaveLength(10);

--- a/src/app/actions/buildUpdatePayload.ts
+++ b/src/app/actions/buildUpdatePayload.ts
@@ -28,7 +28,6 @@ export function buildUpdatePayload(
   if (input.is_refeed_day !== undefined) payload.is_refeed_day = input.is_refeed_day;
   if (input.is_eating_out !== undefined) payload.is_eating_out = input.is_eating_out;
   if (input.is_travel_day !== undefined) payload.is_travel_day = input.is_travel_day;
-  if (input.is_poor_sleep !== undefined) payload.is_poor_sleep = input.is_poor_sleep;
 
   // Phase 2.5 新規フィールド
   if (input.sleep_hours !== undefined)         payload.sleep_hours         = input.sleep_hours;

--- a/src/app/actions/saveDailyLog.ts
+++ b/src/app/actions/saveDailyLog.ts
@@ -26,8 +26,6 @@ export type SaveDailyLogInput = {
   is_refeed_day?: boolean;
   is_eating_out?: boolean;
   is_travel_day?: boolean;
-  /** @deprecated UIからの入力廃止。既存データとの互換のため型には残す。 */
-  is_poor_sleep?: boolean;
   // ── Phase 2.5 追加 ──
   sleep_hours?: number | null;
   /** null = 明示クリア（未記録に戻す） */


### PR DESCRIPTION
## Summary

### #235 — had_bowel_movement 三状態化
DB migration (`20260315000000_nullable_had_bowel_movement.sql`) は適用済み。
実装面（MealLogger / csvParser / buildUpdatePayload）も正しく三状態に対応済みであることを確認。
追加コード変更なし。

### #234 — is_poor_sleep 廃止型の除去
- `SaveDailyLogInput` から `@deprecated is_poor_sleep` フィールドを削除
- `buildUpdatePayload.ts` から `is_poor_sleep` の処理行を削除
- `saveDailyLog.test.ts` の `is_poor_sleep` 参照を除去し代替テストに更新

**残存する `is_poor_sleep` 参照（変更なし）:**
- `types.ts` — 生成型のため DB カラムが残る限り維持
- `calcWeeklyReview.ts` — 既存データ集計のため維持
- `csvParser.ts` — CSV インポート互換のため維持
- `dayTags.ts` — 表示ラベル用に維持

## Test plan
- [ ] `npx jest --no-coverage` がパスすること（68件全通過確認済み）
- [ ] MealLogger で had_bowel_movement を選択しない場合、DB に null が入ること

Closes #234, #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)