### PR TITLE
fix: Cart item の key からインデックスを除去し food.name のみに統一

### DIFF
--- a/src/components/meal/Cart.tsx
+++ b/src/components/meal/Cart.tsx
@@ -98,7 +98,7 @@ export function Cart({ items, onChange }: CartProps) {
     <div className="flex flex-col gap-3">
       <ul className="flex flex-col gap-2">
         {items.map((item, i) => (
-          <li key={`${item.food.name}-${i}`} className="flex items-center gap-2 rounded-lg border border-gray-100 bg-white px-3 py-2">
+          <li key={item.food.name} className="flex items-center gap-2 rounded-lg border border-gray-100 bg-white px-3 py-2">
             <div className="flex-1 min-w-0">
               <p className="truncate text-sm font-medium text-gray-800">{item.food.name}</p>
               <p className="text-xs text-gray-400">


### PR DESCRIPTION
## Summary
コメントで「index ではなく food.name を使う」と明記されていたが、実装では `${food.name}-${i}` とインデックスを付加していた。コメントと実装を一致させる 1 行修正。

## 動作への影響
なし（input が controlled のため key 変更による表示崩れは発生しない）

## Test plan
- [ ] `npx jest --no-coverage` がパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)