### PR TITLE
fix: Settings の currentWeight を最新の非 null 体重から算出する

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -20,9 +20,13 @@ export default async function SettingsPage() {
   const logs = logsResult.kind === "ok" ? logsResult.data : [];
   const qualityReport = calcDataQuality(logs);
 
-  // 最新の記録体重 (最新 log_date のもの)。月次目標計画の起点体重として使用。
+  // 最新の非 null 体重。月次目標計画の起点体重として使用。
+  // 最新 log_date のレコードに weight がなくても、過去の記録があれば計画 UI が機能する。
   const currentWeight =
-    [...logs].sort((a, b) => a.log_date.localeCompare(b.log_date)).at(-1)?.weight ?? null;
+    [...logs]
+      .sort((a, b) => a.log_date.localeCompare(b.log_date))
+      .findLast((l) => l.weight !== null)
+      ?.weight ?? null;
 
   return (
     <PageShell title="設定">


### PR DESCRIPTION
## 概要

Settings ページで月次目標計画の起点に使う `currentWeight` を、
最新 `log_date` のレコードの `weight` から「最新の非 null 体重」に変更した。

## 変更内容

- **`src/app/settings/page.tsx`** (1 行変更)
  - `at(-1)?.weight` → `findLast((l) => l.weight !== null)?.weight` に変更
  - `logs` は日付昇順でソート済みなので `findLast` で末尾から最初の非 null を探す

## 判断理由

- 最新日にメモや睡眠だけ記録して体重を入力しなかった場合、従来は `currentWeight = null` になり月次目標計画 UI が機能しなかった
- 過去の体重記録があれば計画の起点体重として使えるはずなので、非 null の最新値を使う方が適切
- 差分は 1 行の修正のみで、月次目標アルゴリズム自体への影響はない

## 補足

- `logs` は `fetchDailyLogsForSettings()` から取得し、`log_date` 昇順でソート済み
- 体重記録が 1 件もない場合のみ `currentWeight` が `null` になる（従来通り）

Closes #244