### PR TITLE
fix: MobileBottomNav の More シートにフォーカストラップと scroll lock を追加

### DIFF
--- a/src/components/ui/MobileBottomNav.tsx
+++ b/src/components/ui/MobileBottomNav.tsx
@@ -33,8 +33,9 @@ export function MobileBottomNav() {
   const pathname = usePathname();
   const [moreOpen, setMoreOpen] = useState(false);
 
-  const triggerRef  = useRef<HTMLButtonElement>(null);
+  const triggerRef   = useRef<HTMLButtonElement>(null);
   const firstLinkRef = useRef<HTMLAnchorElement>(null);
+  const sheetRef     = useRef<HTMLDivElement>(null);
 
   const moreActive = MORE_ITEMS.some((item) => isActiveNav(pathname, item.href));
 
@@ -58,6 +59,45 @@ export function MobileBottomNav() {
     }
   }, [moreOpen]);
 
+  // body スクロール抑止: シート表示中に背景がスクロールしないようにする
+  useEffect(() => {
+    if (moreOpen) {
+      document.body.style.overflow = "hidden";
+    }
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [moreOpen]);
+
+  // フォーカストラップ: Tab / Shift+Tab でシート外へフォーカスが抜けないようにする
+  useEffect(() => {
+    if (!moreOpen) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== "Tab") return;
+      const sheet = sheetRef.current;
+      if (!sheet) return;
+      const focusable = Array.from(
+        sheet.querySelectorAll<HTMLElement>("a[href], button:not([disabled])")
+      );
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [moreOpen]);
+
   function closeSheet() {
     setMoreOpen(false);
     triggerRef.current?.focus();
@@ -76,6 +116,7 @@ export function MobileBottomNav() {
           />
           {/* sheet 本体。role="dialog" + aria-modal でスクリーンリーダーに認識させる */}
           <div
+            ref={sheetRef}
             role="dialog"
             aria-modal="true"
             aria-label="その他のページ"


### PR DESCRIPTION
## 概要

More シートを dialog として完成させるため、フォーカストラップと body scroll lock を追加した。
既存の Escape close・初回フォーカス移動・close 後の復帰はそのまま維持。

## 変更内容

- **`src/components/ui/MobileBottomNav.tsx`**
  - `sheetRef` を追加し sheet div に付与
  - body scroll lock: シート表示中に `overflow: hidden` を設定し、cleanup で `''` に戻す
  - フォーカストラップ: Tab / Shift+Tab がシート内の `a[href]` / `button` 要素を循環するよう制御、cleanup で `removeEventListener`

## 完了条件の確認

| 要件 | 状態 |
|---|---|
| Tab で背景へフォーカスが抜けない | ✅ フォーカストラップで制御 |
| シート表示中に body スクロールしない | ✅ `overflow: hidden` で抑止 |
| close 後にトリガーボタンへフォーカス復帰 | ✅ 既存実装を維持 |
| タップ操作 / Escape close を壊さない | ✅ 既存実装を維持 |

## 判断理由

- `sheetRef.current.querySelectorAll("a[href], button:not([disabled])")` でシート内の focusable 要素を動的に取得し、先頭と末尾の循環のみを制御するシンプルな実装を選択
- body scroll lock は `useEffect` + cleanup で確実に解放する設計
- デザイン・ナビ項目構成の変更はなし

## 補足

- フォーカストラップは `document.addEventListener` で実装（シート外の Tab も捕捉するため）
- Escape ハンドラーと同じパターンで cleanup を揃えた

Closes #245