### PR TITLE
feat: 食事ログで食品DB未登録の一時食品を追加できるようにする

### DIFF
--- a/src/components/meal/Cart.tsx
+++ b/src/components/meal/Cart.tsx
@@ -4,10 +4,30 @@ import { useState } from "react";
 import { Trash2 } from "lucide-react";
 import type { FoodMaster } from "@/lib/supabase/types";
 
-export interface CartItem {
-  food: FoodMaster;
+/**
+ * 食品DB未登録の一時食品。
+ * - grams: 摂取グラム数（表示用）
+ * - calories / protein / fat / carbs: 今回の摂取量そのものの値（100g換算ではない）
+ * - tempId: セッション内の一意識別子（同名食品を複数追加できるようにするため）
+ */
+export interface TempFoodItem {
+  tempId: string;
+  name: string;
   grams: number;
+  calories: number;
+  protein: number;
+  fat: number;
+  carbs: number;
 }
+
+/**
+ * CartItem は通常食品（food_master 由来）と一時食品の discriminated union。
+ * - kind: "regular" — food_master に登録済み。grams を変えると栄養値が再計算される。
+ * - kind: "temp"    — その日だけの一時食品。栄養値はユーザーが直接入力した摂取量そのもの。
+ */
+export type CartItem =
+  | { kind: "regular"; food: FoodMaster; grams: number }
+  | { kind: "temp"; food: TempFoodItem };
 
 interface CartProps {
   items: CartItem[];
@@ -20,12 +40,24 @@ function calcNutrient(food: FoodMaster, grams: number, key: keyof Pick<FoodMaste
 
 export function calcCartTotals(items: CartItem[]) {
   return items.reduce(
-    (acc, { food, grams }) => ({
-      calories: acc.calories + calcNutrient(food, grams, "calories"),
-      protein: acc.protein + calcNutrient(food, grams, "protein"),
-      fat: acc.fat + calcNutrient(food, grams, "fat"),
-      carbs: acc.carbs + calcNutrient(food, grams, "carbs"),
-    }),
+    (acc, item) => {
+      if (item.kind === "regular") {
+        return {
+          calories: acc.calories + calcNutrient(item.food, item.grams, "calories"),
+          protein:  acc.protein  + calcNutrient(item.food, item.grams, "protein"),
+          fat:      acc.fat      + calcNutrient(item.food, item.grams, "fat"),
+          carbs:    acc.carbs    + calcNutrient(item.food, item.grams, "carbs"),
+        };
+      } else {
+        // 一時食品: ユーザーが入力した摂取量をそのまま合算する
+        return {
+          calories: acc.calories + item.food.calories,
+          protein:  acc.protein  + item.food.protein,
+          fat:      acc.fat      + item.food.fat,
+          carbs:    acc.carbs    + item.food.carbs,
+        };
+      }
+    },
     { calories: 0, protein: 0, fat: 0, carbs: 0 }
   );
 }
@@ -51,10 +83,10 @@ export function Cart({ items, onChange }: CartProps) {
   const totals = calcCartTotals(items);
 
   // 編集中の grams を string で一時保持する（food.name → string）。
-  // キーに index ではなく food.name（cart 内で一意）を使うことで、
+  // キーに index ではなく food.name（通常食品は cart 内で一意）を使うことで、
   // 行削除後の index ずれによる対応崩れを防ぐ。
+  // 一時食品はこの map を使用しない（grams は TempFoodItem 内に固定値として保持）。
   // onChange では文字列のまま保持し、blur 時に正規化して親へ反映する。
-  // これにより「全消し → 再入力」時に 0 に潰されず、自然に打ち直せる。
   const [editingGrams, setEditingGrams] = useState<Record<string, string>>({});
 
   function handleGramsChange(foodName: string, value: string) {
@@ -65,8 +97,11 @@ export function Cart({ items, onChange }: CartProps) {
     const raw = editingGrams[foodName];
     if (raw === undefined) return; // 未編集ならスキップ
 
-    const grams = normalizeGrams(raw, items[index].grams);
-    const next = items.map((item, i) => (i === index ? { ...item, grams } : item));
+    const item = items[index];
+    if (item.kind !== "regular") return; // 一時食品は grams 編集なし
+
+    const grams = normalizeGrams(raw, item.grams);
+    const next = items.map((it, i) => (i === index ? { ...it, grams } : it));
     onChange(next);
 
     setEditingGrams((prev) => {
@@ -77,12 +112,14 @@ export function Cart({ items, onChange }: CartProps) {
   }
 
   function remove(index: number) {
-    const foodName = items[index].food.name;
-    setEditingGrams((prev) => {
-      const updated = { ...prev };
-      delete updated[foodName];
-      return updated;
-    });
+    const item = items[index];
+    if (item.kind === "regular") {
+      setEditingGrams((prev) => {
+        const updated = { ...prev };
+        delete updated[item.food.name];
+        return updated;
+      });
+    }
     onChange(items.filter((_, i) => i !== index));
   }
 
@@ -97,38 +134,68 @@ export function Cart({ items, onChange }: CartProps) {
   return (
     <div className="flex flex-col gap-3">
       <ul className="flex flex-col gap-2">
-        {items.map((item, i) => (
-          <li key={item.food.name} className="flex items-center gap-2 rounded-lg border border-gray-100 bg-white px-3 py-2">
-            <div className="flex-1 min-w-0">
-              <p className="truncate text-sm font-medium text-gray-800">{item.food.name}</p>
-              <p className="text-xs text-gray-400">
-                {calcNutrient(item.food, item.grams, "calories")} kcal &nbsp;|&nbsp;
-                P {calcNutrient(item.food, item.grams, "protein")}g&nbsp;
-                F {calcNutrient(item.food, item.grams, "fat")}g&nbsp;
-                C {calcNutrient(item.food, item.grams, "carbs")}g
-              </p>
-            </div>
-            <div className="flex items-center gap-1">
-              <input
-                type="number"
-                min={0}
-                max={9999}
-                value={item.food.name in editingGrams ? editingGrams[item.food.name] : item.grams}
-                onChange={(e) => handleGramsChange(item.food.name, e.target.value)}
-                onBlur={() => handleGramsBlur(i, item.food.name)}
-                className="w-20 rounded border border-gray-200 px-2 py-2.5 text-right text-sm outline-none focus:border-blue-400"
-              />
-              <span className="text-xs text-gray-400">g</span>
-            </div>
-            <button
-              onClick={() => remove(i)}
-              className="ml-1 p-2 text-gray-300 hover:text-rose-500"
-              aria-label="削除"
-            >
-              <Trash2 size={15} />
-            </button>
-          </li>
-        ))}
+        {items.map((item, i) => {
+          if (item.kind === "regular") {
+            return (
+              <li key={`regular-${item.food.name}`} className="flex items-center gap-2 rounded-lg border border-gray-100 bg-white px-3 py-2">
+                <div className="flex-1 min-w-0">
+                  <p className="truncate text-sm font-medium text-gray-800">{item.food.name}</p>
+                  <p className="text-xs text-gray-400">
+                    {calcNutrient(item.food, item.grams, "calories")} kcal &nbsp;|&nbsp;
+                    P {calcNutrient(item.food, item.grams, "protein")}g&nbsp;
+                    F {calcNutrient(item.food, item.grams, "fat")}g&nbsp;
+                    C {calcNutrient(item.food, item.grams, "carbs")}g
+                  </p>
+                </div>
+                <div className="flex items-center gap-1">
+                  <input
+                    type="number"
+                    min={0}
+                    max={9999}
+                    value={item.food.name in editingGrams ? editingGrams[item.food.name] : item.grams}
+                    onChange={(e) => handleGramsChange(item.food.name, e.target.value)}
+                    onBlur={() => handleGramsBlur(i, item.food.name)}
+                    className="w-20 rounded border border-gray-200 px-2 py-2.5 text-right text-sm outline-none focus:border-blue-400"
+                  />
+                  <span className="text-xs text-gray-400">g</span>
+                </div>
+                <button
+                  onClick={() => remove(i)}
+                  className="ml-1 p-2 text-gray-300 hover:text-rose-500"
+                  aria-label="削除"
+                >
+                  <Trash2 size={15} />
+                </button>
+              </li>
+            );
+          } else {
+            // 一時食品: 栄養値は入力済み固定値。grams は表示のみ。
+            return (
+              <li key={`temp-${item.food.tempId}`} className="flex items-center gap-2 rounded-lg border border-amber-100 bg-amber-50 px-3 py-2">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-1.5">
+                    <p className="truncate text-sm font-medium text-gray-800">{item.food.name}</p>
+                    <span className="flex-shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold bg-amber-200 text-amber-800">一時</span>
+                  </div>
+                  <p className="text-xs text-gray-400">
+                    {item.food.calories} kcal &nbsp;|&nbsp;
+                    P {item.food.protein}g&nbsp;
+                    F {item.food.fat}g&nbsp;
+                    C {item.food.carbs}g
+                    {item.food.grams > 0 && <>&nbsp;·&nbsp;{item.food.grams}g</>}
+                  </p>
+                </div>
+                <button
+                  onClick={() => remove(i)}
+                  className="ml-1 p-2 text-gray-300 hover:text-rose-500"
+                  aria-label="削除"
+                >
+                  <Trash2 size={15} />
+                </button>
+              </li>
+            );
+          }
+        })}
       </ul>
 
       {/* 合計行 */}

--- a/src/components/meal/FoodPicker.tsx
+++ b/src/components/meal/FoodPicker.tsx
@@ -4,17 +4,19 @@ import { useState, useMemo } from "react";
 import { Search, Plus, Check } from "lucide-react";
 import { useFoodList } from "@/lib/hooks/useFoodList";
 import { MenuPicker } from "./MenuPicker";
+import { TempFoodForm } from "./TempFoodForm";
 import type { FoodMaster } from "@/lib/supabase/types";
-import type { CartItem } from "./Cart";
+import type { CartItem, TempFoodItem } from "./Cart";
 
 interface FoodPickerProps {
   onAdd: (food: FoodMaster) => void;
   onAddSet: (items: CartItem[]) => void;
+  onAddTemp: (food: TempFoodItem) => void;
 }
 
-type Tab = "single" | "set";
+type Tab = "single" | "set" | "temp";
 
-export function FoodPicker({ onAdd, onAddSet }: FoodPickerProps) {
+export function FoodPicker({ onAdd, onAddSet, onAddTemp }: FoodPickerProps) {
   const { data: foods = [], isLoading } = useFoodList();
   const [query, setQuery] = useState("");
   const [tab, setTab] = useState<Tab>("single");
@@ -55,11 +57,17 @@ export function FoodPicker({ onAdd, onAddSet }: FoodPickerProps) {
     return result.slice(0, 30);
   }, [foods, query, category]);
 
+  const TAB_LABELS: Record<Tab, string> = {
+    single: "単品",
+    set: "[SET] セット",
+    temp: "一時食品",
+  };
+
   return (
     <div className="flex flex-col gap-2">
-      {/* 単品 / セット タブ */}
+      {/* 単品 / セット / 一時食品 タブ */}
       <div role="tablist" className="flex rounded-lg border border-slate-200 bg-slate-50 p-0.5">
-        {(["single", "set"] as Tab[]).map((t) => (
+        {(["single", "set", "temp"] as Tab[]).map((t) => (
           <button
             key={t}
             id={`foodpicker-tab-${t}`}
@@ -73,7 +81,7 @@ export function FoodPicker({ onAdd, onAddSet }: FoodPickerProps) {
                 : "text-slate-400 hover:text-slate-600"
             }`}
           >
-            {t === "single" ? "単品" : "[SET] セット"}
+            {TAB_LABELS[t]}
           </button>
         ))}
       </div>
@@ -81,6 +89,10 @@ export function FoodPicker({ onAdd, onAddSet }: FoodPickerProps) {
       {tab === "set" ? (
         <div role="tabpanel" id="foodpicker-panel-set" aria-labelledby="foodpicker-tab-set">
           <MenuPicker foods={foods} onAddSet={onAddSet} />
+        </div>
+      ) : tab === "temp" ? (
+        <div role="tabpanel" id="foodpicker-panel-temp" aria-labelledby="foodpicker-tab-temp">
+          <TempFoodForm onAdd={onAddTemp} />
         </div>
       ) : (
         <div role="tabpanel" id="foodpicker-panel-single" aria-labelledby="foodpicker-tab-single">

--- a/src/components/meal/MealLogger.test.ts
+++ b/src/components/meal/MealLogger.test.ts
@@ -40,7 +40,7 @@ describe("computeHasContent", () => {
   });
 
   it("カートにアイテムがある場合は true", () => {
-    const item = { food: { id: "test-id", name: "chicken", calories: 165, protein: 31, fat: 3.6, carbs: 0, category: null, created_at: null }, grams: 100 };
+    const item = { kind: "regular" as const, food: { id: "test-id", name: "chicken", calories: 165, protein: 31, fat: 3.6, carbs: 0, category: null, created_at: null }, grams: 100 };
     expect(computeHasContent({ ...base, cartItems: [item] })).toBe(true);
   });
 

--- a/src/components/meal/MealLogger.tsx
+++ b/src/components/meal/MealLogger.tsx
@@ -5,7 +5,7 @@ import { CheckCircle2, AlertCircle, Loader2, PenLine, X, Undo2 } from "lucide-re
 import { saveDailyLog } from "@/app/actions/saveDailyLog";
 import { FoodPicker } from "./FoodPicker";
 import { Cart, calcCartTotals } from "./Cart";
-import type { CartItem } from "./Cart";
+import type { CartItem, TempFoodItem } from "./Cart";
 import type { FoodMaster, DailyLog } from "@/lib/supabase/types";
 import { toJstDateStr } from "@/lib/utils/date";
 import {
@@ -183,13 +183,18 @@ export function MealLogger({ sidebar = false, showHeader = true }: MealLoggerPro
   function addFood(food: FoodMaster) {
     setCartEverHadItems(true);
     setCartItems((prev) => {
-      const existing = prev.findIndex((item) => item.food.name === food.name);
+      const existing = prev.findIndex(
+        (item) => item.kind === "regular" && item.food.name === food.name
+      );
       if (existing >= 0) {
-        return prev.map((item, i) =>
-          i === existing ? { ...item, grams: item.grams + 100 } : item
-        );
+        return prev.map((item, i) => {
+          if (i === existing && item.kind === "regular") {
+            return { ...item, grams: item.grams + 100 };
+          }
+          return item;
+        });
       }
-      return [...prev, { food, grams: 100 }];
+      return [...prev, { kind: "regular" as const, food, grams: 100 }];
     });
   }
 
@@ -198,15 +203,26 @@ export function MealLogger({ sidebar = false, showHeader = true }: MealLoggerPro
     setCartItems((prev) => {
       const next = [...prev];
       for (const item of items) {
-        const existing = next.findIndex((c) => c.food.name === item.food.name);
+        if (item.kind !== "regular") continue;
+        const existing = next.findIndex(
+          (c) => c.kind === "regular" && c.food.name === item.food.name
+        );
         if (existing >= 0) {
-          next[existing] = { ...next[existing], grams: next[existing].grams + item.grams };
+          const existingItem = next[existing];
+          if (existingItem.kind === "regular") {
+            next[existing] = { ...existingItem, grams: existingItem.grams + item.grams };
+          }
         } else {
           next.push(item);
         }
       }
       return next;
     });
+  }
+
+  function addTempFood(food: TempFoodItem) {
+    setCartEverHadItems(true);
+    setCartItems((prev) => [...prev, { kind: "temp" as const, food }]);
   }
 
   async function handleSave() {
@@ -553,7 +569,7 @@ export function MealLogger({ sidebar = false, showHeader = true }: MealLoggerPro
       {/* 食品検索 */}
       <div>
         <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">食品を追加</p>
-        <FoodPicker onAdd={addFood} onAddSet={addFromMenu} />
+        <FoodPicker onAdd={addFood} onAddSet={addFromMenu} onAddTemp={addTempFood} />
       </div>
 
       {/* カート */}

--- a/src/components/meal/MenuPicker.tsx
+++ b/src/components/meal/MenuPicker.tsx
@@ -33,7 +33,7 @@ export function MenuPicker({ foods, onAddSet }: MenuPickerProps) {
     const items: CartItem[] = menu.recipe.flatMap((ri) => {
       const food = foodMap.get(ri.name);
       if (!food) return [];
-      return [{ food, grams: ri.amount }];
+      return [{ kind: "regular" as const, food, grams: ri.amount }];
     });
 
     if (items.length > 0) onAddSet(items);

--- a/src/components/meal/TempFoodForm.tsx
+++ b/src/components/meal/TempFoodForm.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useState } from "react";
+import { Plus } from "lucide-react";
+import type { TempFoodItem } from "./Cart";
+
+interface TempFoodFormProps {
+  onAdd: (food: TempFoodItem) => void;
+}
+
+function generateTempId(): string {
+  return `temp-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+const emptyForm = {
+  name: "",
+  grams: "",
+  calories: "",
+  protein: "",
+  fat: "",
+  carbs: "",
+};
+
+type FormField = keyof typeof emptyForm;
+
+/** 数値フィールドのバリデーション: 空文字 NG、負数 NG、非数値 NG */
+function parseNonNegative(value: string): number | null {
+  if (value.trim() === "") return null;
+  const n = Number(value);
+  if (!Number.isFinite(n) || n < 0) return null;
+  return Math.round(n);
+}
+
+export function TempFoodForm({ onAdd }: TempFoodFormProps) {
+  const [form, setForm] = useState(emptyForm);
+  const [errors, setErrors] = useState<Partial<Record<FormField, string>>>({});
+
+  function setField(field: FormField, value: string) {
+    setForm((prev) => ({ ...prev, [field]: value }));
+    if (errors[field]) {
+      setErrors((prev) => ({ ...prev, [field]: undefined }));
+    }
+  }
+
+  function validate(): TempFoodItem | null {
+    const next: Partial<Record<FormField, string>> = {};
+
+    if (form.name.trim() === "") {
+      next.name = "食品名を入力してください";
+    }
+    const calories = parseNonNegative(form.calories);
+    if (calories === null) next.calories = "0以上の数値を入力してください";
+
+    const protein = parseNonNegative(form.protein);
+    if (protein === null) next.protein = "0以上の数値を入力してください";
+
+    const fat = parseNonNegative(form.fat);
+    if (fat === null) next.fat = "0以上の数値を入力してください";
+
+    const carbs = parseNonNegative(form.carbs);
+    if (carbs === null) next.carbs = "0以上の数値を入力してください";
+
+    if (Object.keys(next).length > 0) {
+      setErrors(next);
+      return null;
+    }
+
+    const grams = form.grams.trim() === "" ? 0 : Math.max(0, Math.round(Number(form.grams)));
+
+    return {
+      tempId: generateTempId(),
+      name: form.name.trim(),
+      grams,
+      calories: calories!,
+      protein: protein!,
+      fat: fat!,
+      carbs: carbs!,
+    };
+  }
+
+  function handleSubmit() {
+    const food = validate();
+    if (!food) return;
+    onAdd(food);
+    setForm(emptyForm);
+    setErrors({});
+  }
+
+  const inputCls =
+    "w-full rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-800 outline-none transition-colors focus:border-blue-400 focus:bg-white focus:ring-2 focus:ring-blue-100 placeholder:text-slate-400";
+  const errorInputCls =
+    "w-full rounded-xl border border-rose-300 bg-rose-50 px-3 py-2 text-sm text-slate-800 outline-none transition-colors focus:border-rose-400 focus:bg-white focus:ring-2 focus:ring-rose-100 placeholder:text-slate-400";
+
+  return (
+    <div className="flex flex-col gap-3 rounded-xl border border-amber-200 bg-amber-50 p-3">
+      <p className="text-xs text-amber-700 font-medium">
+        食品DBに登録しない一時食品。摂取量の栄養値を直接入力してください。
+      </p>
+
+      {/* 食品名 */}
+      <div>
+        <label className="mb-1 block text-xs font-medium text-slate-500">食品名 <span className="text-rose-500">*</span></label>
+        <input
+          type="text"
+          placeholder="例: ローソン チキン南蛮"
+          value={form.name}
+          onChange={(e) => setField("name", e.target.value)}
+          className={errors.name ? errorInputCls : inputCls}
+        />
+        {errors.name && <p className="mt-1 text-xs text-rose-500">{errors.name}</p>}
+      </div>
+
+      {/* グラム数（任意） */}
+      <div>
+        <label className="mb-1 block text-xs font-medium text-slate-500">グラム数（任意）</label>
+        <input
+          type="number"
+          min={0}
+          placeholder="200"
+          value={form.grams}
+          onChange={(e) => setField("grams", e.target.value)}
+          className={inputCls}
+        />
+      </div>
+
+      {/* 栄養値（摂取量そのもの） */}
+      <div>
+        <p className="mb-1.5 text-xs font-medium text-slate-500">栄養値（この食品の摂取量全体） <span className="text-rose-500">*</span></p>
+        <div className="grid grid-cols-2 gap-2">
+          <div>
+            <label className="mb-1 block text-[11px] text-slate-400">カロリー (kcal)</label>
+            <input
+              type="number"
+              min={0}
+              placeholder="350"
+              value={form.calories}
+              onChange={(e) => setField("calories", e.target.value)}
+              className={errors.calories ? errorInputCls : inputCls}
+            />
+            {errors.calories && <p className="mt-1 text-xs text-rose-500">{errors.calories}</p>}
+          </div>
+          <div>
+            <label className="mb-1 block text-[11px] text-slate-400">たんぱく質 (g)</label>
+            <input
+              type="number"
+              min={0}
+              placeholder="25"
+              value={form.protein}
+              onChange={(e) => setField("protein", e.target.value)}
+              className={errors.protein ? errorInputCls : inputCls}
+            />
+            {errors.protein && <p className="mt-1 text-xs text-rose-500">{errors.protein}</p>}
+          </div>
+          <div>
+            <label className="mb-1 block text-[11px] text-slate-400">脂質 (g)</label>
+            <input
+              type="number"
+              min={0}
+              placeholder="12"
+              value={form.fat}
+              onChange={(e) => setField("fat", e.target.value)}
+              className={errors.fat ? errorInputCls : inputCls}
+            />
+            {errors.fat && <p className="mt-1 text-xs text-rose-500">{errors.fat}</p>}
+          </div>
+          <div>
+            <label className="mb-1 block text-[11px] text-slate-400">炭水化物 (g)</label>
+            <input
+              type="number"
+              min={0}
+              placeholder="30"
+              value={form.carbs}
+              onChange={(e) => setField("carbs", e.target.value)}
+              className={errors.carbs ? errorInputCls : inputCls}
+            />
+            {errors.carbs && <p className="mt-1 text-xs text-rose-500">{errors.carbs}</p>}
+          </div>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        onClick={handleSubmit}
+        className="flex items-center justify-center gap-1.5 rounded-xl bg-amber-500 px-4 py-2 text-sm font-semibold text-white hover:bg-amber-600"
+      >
+        <Plus size={14} />
+        一時食品として追加
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #252

## Summary

食事ログ入力時に、食品DBに未登録の一時食品をその日のカートに追加し、保存時に日次合計（calories / protein / fat / carbs）へ反映できるようにします。

**今回のスコープ**
- 入力時: 一時食品を名前・栄養値で追加し、通常食品と混在してカートに入れられる
- 保存時: `calcCartTotals` が通常食品・一時食品を合算し、`daily_logs` の日次集計に反映される
- 食品DB（`food_master`）への書き込みは一切なし

**スコープ外（別 Issue）**
- 保存後の食事明細の再表示・再編集（現状は通常食品も同様に未対応。MealLogger の「カートはマクロ値から復元不可のためリセット」という前提は維持）
- 一時食品を食品DBへ昇格登録する機能
- 一時食品のテンプレート化・お気に入り

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `src/components/meal/Cart.tsx` | CartItem 型拡張、calcCartTotals 更新、Cart 表示更新 |
| `src/components/meal/TempFoodForm.tsx` | **新規** 一時食品入力フォーム |
| `src/components/meal/FoodPicker.tsx` | 「一時食品」タブ追加、onAddTemp prop 追加 |
| `src/components/meal/MenuPicker.tsx` | CartItem 生成時に `kind: "regular"` を明示 |
| `src/components/meal/MealLogger.tsx` | addTempFood ハンドラ追加、既存ハンドラを kind: "regular" に更新 |
| `src/components/meal/MealLogger.test.ts` | CartItem に `kind` フィールドを追加 |

## 仕様判断

**型**
- `CartItem = { kind: "regular"; food: FoodMaster; grams: number } | { kind: "temp"; food: TempFoodItem }`
- 通常食品と一時食品の差をコード上で明示（discriminated union）

**栄養値の扱い**
- 通常食品: `(per100g × grams) / 100`（既存と同じ）
- 一時食品: ユーザーが入力した摂取量そのもの（kcal / P / F / C）を合算。市販品・外食では総カロリーがわかることが多いため 100g 換算不要

**UI 識別**
- Cart の一時食品行: アンバー背景 +「一時」バッジで通常食品と視覚的に区別

## Test plan

- [x] TypeScript 型チェック: `npx tsc --noEmit` → エラーなし
- [x] 全テスト: 983 passed (jest --no-coverage)
- [ ] 通常食品の追加・保存が従来どおり動く
- [ ] 一時食品の追加が動く（「一時食品」タブ → フォーム入力 → カートに追加）
- [ ] 一時食品が Cart に「一時」バッジ付きで表示される
- [ ] 通常食品と一時食品が混在しても合計値が正しく計算される
- [ ] 保存後に daily_logs.calories/protein/fat/carbs に一時食品の栄養値が反映される
- [ ] food_master に新規レコードが増えない

🤖 Generated with [Claude Code](https://claude.com/claude-code)