### PR TITLE
fix: 一時食品フォームの grams NaN バグを修正

### DIFF
--- a/src/components/meal/TempFoodForm.tsx
+++ b/src/components/meal/TempFoodForm.tsx
@@ -65,7 +65,11 @@ export function TempFoodForm({ onAdd }: TempFoodFormProps) {
       return null;
     }
 
-    const grams = form.grams.trim() === "" ? 0 : Math.max(0, Math.round(Number(form.grams)));
+    const rawGrams = Number(form.grams);
+    const grams =
+      form.grams.trim() === "" || !Number.isFinite(rawGrams)
+        ? 0
+        : Math.max(0, Math.round(rawGrams));
 
     return {
       tempId: generateTempId(),


### PR DESCRIPTION
Closes #254

## 概要

`TempFoodForm` のグラム数フィールドに非数値を入力すると `grams: NaN` がカートに混入し、日次集計が壊れるバグを修正。

## 変更内容

`TempFoodForm.tsx` の `validate()` 内の grams 算出に `isFinite` チェックを追加。

```ts
// 修正前
const grams = form.grams.trim() === "" ? 0 : Math.max(0, Math.round(Number(form.grams)));

// 修正後
const rawGrams = Number(form.grams);
const grams =
  form.grams.trim() === "" || !Number.isFinite(rawGrams)
    ? 0
    : Math.max(0, Math.round(rawGrams));
```

## 判断理由

grams は任意フィールドのため、不正値は `0` にフォールバックする方針。エラー表示は不要。

## 影響範囲

`TempFoodForm.tsx` の 1 箇所のみ。型チェック・全 983 テストパス。