### PR TITLE
fix: 一時食品の栄養値 Math.round 整数化を廃止し小数を保持する

### DIFF
--- a/src/components/meal/TempFoodForm.tsx
+++ b/src/components/meal/TempFoodForm.tsx
@@ -23,12 +23,12 @@ const emptyForm = {
 
 type FormField = keyof typeof emptyForm;
 
-/** 数値フィールドのバリデーション: 空文字 NG、負数 NG、非数値 NG */
+/** 数値フィールドのバリデーション: 空文字 NG、負数 NG、非数値 NG。小数は保持する。 */
 function parseNonNegative(value: string): number | null {
   if (value.trim() === "") return null;
   const n = Number(value);
   if (!Number.isFinite(n) || n < 0) return null;
-  return Math.round(n);
+  return n;
 }
 
 export function TempFoodForm({ onAdd }: TempFoodFormProps) {


### PR DESCRIPTION
Closes #255

## 概要

`parseNonNegative()` の `Math.round` を削除し、栄養値の小数を保持するよう修正。

## 変更内容

`TempFoodForm.tsx` の `parseNonNegative()` から `Math.round` を削除。

```ts
// 修正前
return Math.round(n);

// 修正後
return n; // 小数を保持
```

## 判断理由

通常食品（food_master）は小数のまま保持して `calcNutrient` で計算するのに対し、一時食品だけ入力段階で整数化されていた。`Math.round` を削除することで挙動を揃える。`calcCartTotals` の合算側は変更不要。

## 影響範囲

`TempFoodForm.tsx` の 1 箇所のみ。型チェック・全 983 テストパス。