### PR TITLE
enhancement: FoodPicker タブラベルを短縮してモバイル表示を改善

### DIFF
--- a/src/components/meal/FoodPicker.tsx
+++ b/src/components/meal/FoodPicker.tsx
@@ -59,8 +59,8 @@ export function FoodPicker({ onAdd, onAddSet, onAddTemp }: FoodPickerProps) {
 
   const TAB_LABELS: Record<Tab, string> = {
     single: "単品",
-    set: "[SET] セット",
-    temp: "一時食品",
+    set: "セット",
+    temp: "一時",
   };
 
   return (


### PR DESCRIPTION
Closes #258

## 概要

3 タブ構成の `FoodPicker` で「[SET] セット」が長く、モバイルで窮屈になる可能性があったため、ラベルを短縮した。

## 変更内容

`TAB_LABELS` の値のみ変更。`Tab` 型・内部ロジック・`aria-controls` / `id` は変更なし。

| 変更前 | 変更後 |
|---|---|
| `[SET] セット` | `セット` |
| `一時食品` | `一時` |

## 影響範囲

`FoodPicker.tsx` の `TAB_LABELS` 1 箇所のみ。型チェック・全 983 テストパス。