### PR TITLE
enhancement: TempFoodForm の label/input を htmlFor/id で関連付ける

### DIFF
--- a/src/components/meal/TempFoodForm.tsx
+++ b/src/components/meal/TempFoodForm.tsx
@@ -109,8 +109,9 @@ export function TempFoodForm({ onAdd }: TempFoodFormProps) {
 
       {/* 食品名 */}
       <div>
-        <label className="mb-1 block text-xs font-medium text-slate-500">食品名 <span className="text-rose-500">*</span></label>
+        <label htmlFor="temp-food-name" className="mb-1 block text-xs font-medium text-slate-500">食品名 <span className="text-rose-500">*</span></label>
         <input
+          id="temp-food-name"
           type="text"
           placeholder="例: サラダチキン (コンビニ)"
           value={form.name}
@@ -122,8 +123,9 @@ export function TempFoodForm({ onAdd }: TempFoodFormProps) {
 
       {/* グラム数（任意） */}
       <div>
-        <label className="mb-1 block text-xs font-medium text-slate-500">グラム数（任意）</label>
+        <label htmlFor="temp-food-grams" className="mb-1 block text-xs font-medium text-slate-500">グラム数（任意）</label>
         <input
+          id="temp-food-grams"
           type="number"
           min={0}
           placeholder="200"
@@ -138,8 +140,9 @@ export function TempFoodForm({ onAdd }: TempFoodFormProps) {
         <p className="mb-1.5 text-xs font-medium text-slate-500">栄養値（この食品の摂取量全体） <span className="text-rose-500">*</span></p>
         <div className="grid grid-cols-2 gap-2">
           <div>
-            <label className="mb-1 block text-[11px] text-slate-400">カロリー (kcal)</label>
+            <label htmlFor="temp-food-calories" className="mb-1 block text-[11px] text-slate-400">カロリー (kcal)</label>
             <input
+              id="temp-food-calories"
               type="number"
               min={0}
               placeholder="350"
@@ -150,8 +153,9 @@ export function TempFoodForm({ onAdd }: TempFoodFormProps) {
             {errors.calories && <p className="mt-1 text-xs text-rose-500">{errors.calories}</p>}
           </div>
           <div>
-            <label className="mb-1 block text-[11px] text-slate-400">たんぱく質 (g)</label>
+            <label htmlFor="temp-food-protein" className="mb-1 block text-[11px] text-slate-400">たんぱく質 (g)</label>
             <input
+              id="temp-food-protein"
               type="number"
               min={0}
               placeholder="25"
@@ -162,8 +166,9 @@ export function TempFoodForm({ onAdd }: TempFoodFormProps) {
             {errors.protein && <p className="mt-1 text-xs text-rose-500">{errors.protein}</p>}
           </div>
           <div>
-            <label className="mb-1 block text-[11px] text-slate-400">脂質 (g)</label>
+            <label htmlFor="temp-food-fat" className="mb-1 block text-[11px] text-slate-400">脂質 (g)</label>
             <input
+              id="temp-food-fat"
               type="number"
               min={0}
               placeholder="12"
@@ -174,8 +179,9 @@ export function TempFoodForm({ onAdd }: TempFoodFormProps) {
             {errors.fat && <p className="mt-1 text-xs text-rose-500">{errors.fat}</p>}
           </div>
           <div>
-            <label className="mb-1 block text-[11px] text-slate-400">炭水化物 (g)</label>
+            <label htmlFor="temp-food-carbs" className="mb-1 block text-[11px] text-slate-400">炭水化物 (g)</label>
             <input
+              id="temp-food-carbs"
               type="number"
               min={0}
               placeholder="30"


### PR DESCRIPTION
Closes #264

## 概要

`TempFoodForm` の全フィールドに `id` を付与し、対応する `<label>` に `htmlFor` を設定。ラベルのタップ/クリックで対応フィールドにフォーカスが移るようになり、モバイル操作性が向上する。

## 変更内容

全 6 フィールドに `id` と `htmlFor` を追加。

| フィールド | id |
|---|---|
| 食品名 | `temp-food-name` |
| グラム数 | `temp-food-grams` |
| カロリー | `temp-food-calories` |
| たんぱく質 | `temp-food-protein` |
| 脂質 | `temp-food-fat` |
| 炭水化物 | `temp-food-carbs` |

## 影響範囲

`TempFoodForm.tsx` のみ。ロジック・バリデーション・スタイルの変更なし。型チェック・全 983 テストパス。