### PR TITLE
enhancement: SettingsForm のアコーディオン開閉ボタンに aria-label を追加

### DIFF
--- a/src/components/settings/SettingsForm.tsx
+++ b/src/components/settings/SettingsForm.tsx
@@ -86,6 +86,7 @@ function FormSection({ id, title, subtitle, isOpen, onToggle, children, border =
           onClick={onToggle}
           aria-expanded={isOpen}
           aria-controls={panelId}
+          aria-label={`${title}を${isOpen ? "閉じる" : "開く"}`}
           className="sm:hidden ml-3 flex-shrink-0 rounded-lg p-1 text-slate-400 hover:bg-slate-50 hover:text-slate-600"
         >
           <ChevronDown
@@ -295,6 +296,7 @@ export function SettingsForm({ initialSettings, currentWeight = null }: Settings
             onClick={() => toggleSection("season")}
             aria-expanded={openSections.has("season")}
             aria-controls="settings-panel-season"
+            aria-label={`シーズン・コンテストを${openSections.has("season") ? "閉じる" : "開く"}`}
             className="sm:hidden ml-3 flex-shrink-0 rounded-lg p-1 text-slate-400 hover:bg-slate-50 hover:text-slate-600"
           >
             <ChevronDown


### PR DESCRIPTION
Closes #266

## 概要

`SettingsForm` のアコーディオン開閉ボタン（ChevronDown アイコンのみ）に `aria-label` を追加。スクリーンリーダーで「何のセクションを開閉するか」が伝わるようになる。

## 変更内容

2 箇所に `aria-label` を追加。

**① `FormSection` コンポーネントの共通ボタン（全セクション共通）**
```tsx
aria-label={`${title}を${isOpen ? "閉じる" : "開く"}`}
```

**② シーズン・コンテストのインラインボタン**
```tsx
aria-label={`シーズン・コンテストを${openSections.has("season") ? "閉じる" : "開く"}`}
```

## 影響範囲

`SettingsForm.tsx` の 2 箇所のみ。ロジック・スタイル変更なし。型チェック・全 983 テストパス。