### PR TITLE
enhancement: daily_logs の数値カラムに DB CHECK 制約を追加

### DIFF
--- a/supabase/migrations/20260323000000_add_numeric_check_constraints_to_daily_logs.sql
+++ b/supabase/migrations/20260323000000_add_numeric_check_constraints_to_daily_logs.sql
@@ -1,0 +1,55 @@
+-- daily_logs の数値カラムに DB レベルの CHECK 制約を追加する
+--
+-- 目的:
+--   Server Action (saveDailyLog) 側でバリデーションを実施しているが、
+--   どの経路からでも壊れたデータが入らないよう DB 制約で二重に保証する。
+--
+-- 制約範囲は saveDailyLog.ts のバリデーション値と一致させる:
+--   weight      : 0〜300 kg
+--   calories    : 0〜99999 kcal
+--   protein     : 0〜99999 g
+--   fat         : 0〜99999 g
+--   carbs       : 0〜99999 g
+--   sleep_hours : 0〜24 h
+--
+-- NULL は未記録を意味するため制約の対象外とする。
+-- PostgreSQL の CHECK 制約は NULL に対して UNKNOWN を返し通過するため、
+-- IS NULL OR (...) のガードは記述上の明示化が目的。
+--
+-- 冪等性: DROP CONSTRAINT IF EXISTS で既存制約を削除してから追加する。
+
+ALTER TABLE daily_logs
+  DROP CONSTRAINT IF EXISTS daily_logs_weight_check;
+ALTER TABLE daily_logs
+  ADD CONSTRAINT daily_logs_weight_check
+    CHECK (weight IS NULL OR (weight >= 0 AND weight <= 300));
+
+ALTER TABLE daily_logs
+  DROP CONSTRAINT IF EXISTS daily_logs_calories_check;
+ALTER TABLE daily_logs
+  ADD CONSTRAINT daily_logs_calories_check
+    CHECK (calories IS NULL OR (calories >= 0 AND calories <= 99999));
+
+ALTER TABLE daily_logs
+  DROP CONSTRAINT IF EXISTS daily_logs_protein_check;
+ALTER TABLE daily_logs
+  ADD CONSTRAINT daily_logs_protein_check
+    CHECK (protein IS NULL OR (protein >= 0 AND protein <= 99999));
+
+ALTER TABLE daily_logs
+  DROP CONSTRAINT IF EXISTS daily_logs_fat_check;
+ALTER TABLE daily_logs
+  ADD CONSTRAINT daily_logs_fat_check
+    CHECK (fat IS NULL OR (fat >= 0 AND fat <= 99999));
+
+ALTER TABLE daily_logs
+  DROP CONSTRAINT IF EXISTS daily_logs_carbs_check;
+ALTER TABLE daily_logs
+  ADD CONSTRAINT daily_logs_carbs_check
+    CHECK (carbs IS NULL OR (carbs >= 0 AND carbs <= 99999));
+
+ALTER TABLE daily_logs
+  DROP CONSTRAINT IF EXISTS daily_logs_sleep_hours_check;
+ALTER TABLE daily_logs
+  ADD CONSTRAINT daily_logs_sleep_hours_check
+    CHECK (sleep_hours IS NULL OR (sleep_hours >= 0 AND sleep_hours <= 24));


### PR DESCRIPTION
Closes #268

## 概要

`daily_logs` の数値カラム 6 件に DB レベルの CHECK 制約を追加。Server Action のバリデーション範囲と一致させ、どの経路からでも壊れたデータが入らないよう二重に保証する。

## 変更内容

新規マイグレーション: `20260323000000_add_numeric_check_constraints_to_daily_logs.sql`

| カラム | 制約範囲 | Server Action と一致 |
|---|---|---|
| `weight` | 0〜300 kg | ✅ |
| `calories` | 0〜99999 kcal | ✅ |
| `protein` | 0〜99999 g | ✅ |
| `fat` | 0〜99999 g | ✅ |
| `carbs` | 0〜99999 g | ✅ |
| `sleep_hours` | 0〜24 h | ✅ |

- NULL は未記録を意味するため制約対象外（`IS NULL OR (...)` の形式）
- `DROP CONSTRAINT IF EXISTS` で冪等性を確保

## 確認結果

- `supabase db push` 成功
- 既存データはすべて制約通過（push 時にエラーなし）
- 型チェック・全 983 テストパス