### PR TITLE
fix: KpiCards の現在体重を calcReadiness.current_weight に統一 (#272)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -224,7 +224,7 @@ export default async function DashboardPage() {
         </p>
       ) : logs.length > 0 ? (
         <>
-          <KpiCards logs={logs} settings={settings} avgTdee={latestTdee} />
+          <KpiCards logs={logs} settings={settings} avgTdee={latestTdee} currentWeight={readinessMetrics.current_weight} />
           <GoalNavigator
             metrics={readinessMetrics}
             phase={phase}

--- a/src/components/dashboard/KpiCards.tsx
+++ b/src/components/dashboard/KpiCards.tsx
@@ -11,6 +11,7 @@ interface KpiCardsProps {
   logs: DashboardDailyLog[];
   settings: AppSettings;
   avgTdee: number | null;
+  currentWeight: number | null;
 }
 
 interface KpiCardProps {
@@ -54,12 +55,8 @@ function KpiCard({ label, value, unit, sub, icon, accent, iconColor, trendDir, t
   );
 }
 
-export function KpiCards({ logs, settings }: KpiCardsProps) {
+export function KpiCards({ logs, settings, currentWeight }: KpiCardsProps) {
   const sorted = [...logs].sort((a, b) => a.log_date.localeCompare(b.log_date));
-  const latest = sorted[sorted.length - 1];
-
-  // --- 現在体重（最新の生体重。目標到達予定の計算には使わない）---
-  const currentWeight = latest?.weight ?? null;
 
   // --- 基準日 (todayStr) ---
   // 以降の全暦日計算で共通して使う。JST 固定で UTC サーバー上でもズレない。


### PR DESCRIPTION
## Summary

- `KpiCards` の「現在体重」が `sorted.last?.weight`（最終行のweight、nullの可能性あり）を参照していた問題を修正
- `calcReadiness.current_weight`（最新の非 null 体重）を props で受け取る形に統一
- 最新ログが体重なしでも、直前の体重を正しく表示するようになる

## 変更内容

| ファイル | 変更 |
|---|---|
| `KpiCards.tsx` | `currentWeight` を props 化、`latest` のローカル計算を削除 |
| `page.tsx` | `readinessMetrics.current_weight` を `KpiCards` に渡すよう追加 |

## Test plan

- [x] 全テスト 993 件パス
- [x] `tsc --noEmit` エラーなし

Closes #272