### PR TITLE
chore: layout.tsx に robots noindex を追加 (#274)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,7 @@ import { BottomSpacer } from "@/components/ui/BottomSpacer";
 export const metadata: Metadata = {
   title: "Body Composition Tracker",
   description: "コンテスト向け体重・栄養管理ダッシュボード",
+  robots: { index: false, follow: false },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary

- `metadata.robots = { index: false, follow: false }` を追加
- 全ページに `<meta name="robots" content="noindex,nofollow">` が出力される
- 体重・睡眠・便通等の機微情報が検索エンジンにインデックスされるリスクを排除

## Test plan

- [x] `npm run build` 正常完了

Closes #274