### PR TITLE
fix: guard readiness pace when contest date is too close

### DIFF
--- a/src/components/dashboard/GoalNavigator.tsx
+++ b/src/components/dashboard/GoalNavigator.tsx
@@ -27,7 +27,7 @@ import {
   CalendarDays,
 } from "lucide-react";
 import type { ReadinessMetrics } from "@/lib/utils/calcReadiness";
-import { calcGoalStatus, calcKcalCorrection } from "@/lib/utils/calcReadiness";
+import { calcGoalStatus, calcKcalCorrection, PACE_CALC_MIN_DAYS } from "@/lib/utils/calcReadiness";
 import type { MonthlyGoalProgress } from "@/lib/utils/calcMonthlyGoalProgress";
 
 interface GoalNavigatorProps {
@@ -76,6 +76,12 @@ const STATUS_CONFIG = {
     color: "text-slate-500",
     bg: "bg-slate-50 border-slate-200",
     icon: HelpCircle,
+  },
+  contest_imminent: {
+    label: "大会直前",
+    color: "text-slate-600",
+    bg: "bg-slate-50 border-slate-200",
+    icon: CalendarDays,
   },
   unknown: {
     label: "データ不足",
@@ -205,8 +211,13 @@ export function GoalNavigator({
   // 必要ペース: calcReadiness の required_rate_kg_per_2weeks を参照
   // ただし 7d avg ベースで再計算（calcReadiness は current_weight ベース）
   const daysLeft2W = metrics.days_to_contest;
+
+  // 大会直前フラグ: PACE_CALC_MIN_DAYS 未満では週次ペースが非現実的な値になるため算出しない
+  const isTooCloseToContest =
+    daysLeft2W !== null && daysLeft2W >= 0 && daysLeft2W < PACE_CALC_MIN_DAYS;
+
   const requiredRateKg2W =
-    remainingKg !== null && daysLeft2W !== null && daysLeft2W > 0
+    remainingKg !== null && daysLeft2W !== null && daysLeft2W >= PACE_CALC_MIN_DAYS
       ? (-remainingKg / daysLeft2W) * 14
       : null;
 
@@ -369,6 +380,12 @@ export function GoalNavigator({
                 : "text-emerald-600"
             }
           />
+          {/* 大会直前 fallback: PACE_CALC_MIN_DAYS 未満では週次ペース算出不可 */}
+          {isTooCloseToContest && (
+            <p className="mt-1 text-[11px] text-slate-400">
+              大会まで {daysLeft2W} 日のためペース算出なし
+            </p>
+          )}
         </div>
 
         <Divider />

--- a/src/lib/utils/calcReadiness.test.ts
+++ b/src/lib/utils/calcReadiness.test.ts
@@ -9,7 +9,14 @@
  *   - 残り週数 (daysLeft / 7) の表示値
  */
 
-import { calcReadiness, calcRequiredPacePerTwoWeeks, calcActualPacePerTwoWeeks, calcGoalReachDate } from "./calcReadiness";
+import {
+  calcReadiness,
+  calcRequiredPacePerTwoWeeks,
+  calcActualPacePerTwoWeeks,
+  calcGoalReachDate,
+  calcGoalStatus,
+  PACE_CALC_MIN_DAYS,
+} from "./calcReadiness";
 import type { DailyLog } from "@/lib/supabase/types";
 
 // ─── テスト用ヘルパー ──────────────────────────────────────────────────────────
@@ -318,6 +325,146 @@ describe("calcGoalReachDate", () => {
     const r = calcGoalReachDate(65.0, 5 / 14, 70.0, today);
     expect(r.status).toBe("projected");
     expect(r.date).toBe("2026-03-29");
+  });
+});
+
+// ─── calcReadiness: 大会直前ガード (PACE_CALC_MIN_DAYS) ──────────────────────
+
+describe("calcReadiness 大会直前ガード", () => {
+  const today = "2026-03-15";
+
+  function buildLogs(n: number): DailyLog[] {
+    return Array.from({ length: n }, (_, i) => {
+      const date = daysAgo(today, n - 1 - i);
+      return makeDailyLog(date, 70 - i * 0.05);
+    });
+  }
+
+  test("PACE_CALC_MIN_DAYS 定数は 7", () => {
+    expect(PACE_CALC_MIN_DAYS).toBe(7);
+  });
+
+  test("days_to_contest = 1 → required_rate は null (非現実的なペースを出さない)", () => {
+    const logs = buildLogs(14);
+    const metrics = calcReadiness(
+      logs,
+      { contest_date: daysAgo(today, -1), goal_weight: 68 }, // 明日
+      today
+    );
+    expect(metrics.required_rate_kg_per_week).toBeNull();
+    expect(metrics.required_rate_kg_per_2weeks).toBeNull();
+  });
+
+  test("days_to_contest = 3 → required_rate は null", () => {
+    const logs = buildLogs(14);
+    const metrics = calcReadiness(
+      logs,
+      { contest_date: daysAgo(today, -3), goal_weight: 68 },
+      today
+    );
+    expect(metrics.required_rate_kg_per_week).toBeNull();
+    expect(metrics.required_rate_kg_per_2weeks).toBeNull();
+  });
+
+  test("days_to_contest = 6 (PACE_CALC_MIN_DAYS - 1) → required_rate は null", () => {
+    const logs = buildLogs(14);
+    const metrics = calcReadiness(
+      logs,
+      { contest_date: daysAgo(today, -6), goal_weight: 68 },
+      today
+    );
+    expect(metrics.required_rate_kg_per_week).toBeNull();
+    expect(metrics.required_rate_kg_per_2weeks).toBeNull();
+  });
+
+  test("days_to_contest = 7 (PACE_CALC_MIN_DAYS) → required_rate は非 null", () => {
+    const logs = buildLogs(14);
+    const metrics = calcReadiness(
+      logs,
+      { contest_date: daysAgo(today, -7), goal_weight: 68 },
+      today
+    );
+    // 7日 = 1週間 → weeksLeft = 1, required = (68 - current) / 1
+    expect(metrics.required_rate_kg_per_week).not.toBeNull();
+    expect(metrics.required_rate_kg_per_2weeks).not.toBeNull();
+  });
+
+  test("days_to_contest = 14 → required_rate は通常通り計算される", () => {
+    const logs = buildLogs(14);
+    const metrics = calcReadiness(
+      logs,
+      { contest_date: daysAgo(today, -14), goal_weight: 68 },
+      today
+    );
+    expect(metrics.required_rate_kg_per_week).not.toBeNull();
+    // current ≈ 70 - 13*0.05 = 69.35, goal = 68 → remaining ≈ 1.35
+    // weeks = 14/7 = 2 → required ≈ -1.35/2 ≈ -0.675 kg/週
+    expect(metrics.required_rate_kg_per_week).toBeCloseTo(-1.35 / 2, 1);
+  });
+});
+
+// ─── calcGoalStatus ───────────────────────────────────────────────────────────
+
+describe("calcGoalStatus", () => {
+  // ── contest_imminent ──
+  test("daysToContest = 0 (大会当日) → contest_imminent", () => {
+    expect(calcGoalStatus(-1.0, -1.0, 2.0, 0)).toBe("contest_imminent");
+  });
+
+  test("daysToContest = 1 → contest_imminent", () => {
+    expect(calcGoalStatus(-1.0, -1.0, 2.0, 1)).toBe("contest_imminent");
+  });
+
+  test("daysToContest = 3 → contest_imminent", () => {
+    expect(calcGoalStatus(-1.0, -1.0, 2.0, 3)).toBe("contest_imminent");
+  });
+
+  test("daysToContest = PACE_CALC_MIN_DAYS - 1 = 6 → contest_imminent", () => {
+    expect(calcGoalStatus(-1.0, -1.0, 2.0, PACE_CALC_MIN_DAYS - 1)).toBe("contest_imminent");
+  });
+
+  test("daysToContest = PACE_CALC_MIN_DAYS = 7 → contest_imminent にならない", () => {
+    const result = calcGoalStatus(-1.0, -1.0, 2.0, PACE_CALC_MIN_DAYS);
+    expect(result).not.toBe("contest_imminent");
+  });
+
+  test("daysToContest = 14 → contest_imminent にならない", () => {
+    const result = calcGoalStatus(-1.0, -1.0, 2.0, 14);
+    expect(result).not.toBe("contest_imminent");
+  });
+
+  // 目標達成済みなら days < PACE_CALC_MIN_DAYS でも achieved を優先
+  test("残り3日 + 目標達成済み → achieved (contest_imminent より優先)", () => {
+    expect(calcGoalStatus(-0.1, -1.0, 0.1, 3)).toBe("achieved");
+  });
+
+  // ── no_contest ──
+  test("daysToContest が null → no_contest", () => {
+    expect(calcGoalStatus(-1.0, -1.0, 2.0, null)).toBe("no_contest");
+  });
+
+  test("daysToContest が負 (過去) → no_contest", () => {
+    expect(calcGoalStatus(-1.0, -1.0, 2.0, -1)).toBe("no_contest");
+  });
+
+  // ── 通常ケース ──
+  test("ratio >= 1.0 → on_track", () => {
+    // actual = -1.2, required = -1.0 → ratio = 1.2 ≥ 1.0
+    expect(calcGoalStatus(-1.2, -1.0, 2.0, 30)).toBe("on_track");
+  });
+
+  test("ratio 0.5〜1.0 → adjust", () => {
+    // actual = -0.6, required = -1.0 → ratio = 0.6
+    expect(calcGoalStatus(-0.6, -1.0, 2.0, 30)).toBe("adjust");
+  });
+
+  test("ratio < 0.5 → behind", () => {
+    // actual = -0.3, required = -1.0 → ratio = 0.3
+    expect(calcGoalStatus(-0.3, -1.0, 2.0, 30)).toBe("behind");
+  });
+
+  test("required = null かつ days >= PACE_CALC_MIN_DAYS → unknown", () => {
+    expect(calcGoalStatus(-1.0, null, 2.0, 30)).toBe("unknown");
   });
 });
 

--- a/src/lib/utils/calcReadiness.ts
+++ b/src/lib/utils/calcReadiness.ts
@@ -150,11 +150,13 @@ export function calcReadiness(
       : null;
 
   // --- 必要週次変化率: (goal - current) / weeks_left ---
+  // days_to_contest < PACE_CALC_MIN_DAYS のとき weeksLeft が極小になり
+  // 非現実的な kg/週 値になるため null を返す (大会直前は週次ペース算出不可)
   let required_rate_kg_per_week: number | null = null;
   if (
     remaining_to_goal_kg !== null &&
     days_to_contest !== null &&
-    days_to_contest > 0
+    days_to_contest >= PACE_CALC_MIN_DAYS
   ) {
     const weeksLeft = days_to_contest / 7;
     // (goal - current) = -remaining, 負なら減量が必要
@@ -238,13 +240,23 @@ export function calcActualPacePerTwoWeeks(
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
+ * 必要ペース算出の最小残り日数。
+ *
+ * days_to_contest がこの値未満のとき、weeksLeft が極小になり
+ * 非現実的な kg/週 値になるため required_rate を null にする。
+ * 大会まで 1 週間未満では週次ペース指標は実用的でない。
+ */
+export const PACE_CALC_MIN_DAYS = 7;
+
+/**
  * 目標達成ステータス。
- * - achieved   : 残り ≤ 0.2 kg
- * - on_track   : 実績ペース ≥ 必要ペース (比率 ≥ 1.0)
- * - adjust     : 比率 0.5〜1.0 未満
- * - behind     : 比率 0.5 未満 または逆方向
- * - no_contest : contest_date 未設定または過去
- * - unknown    : データ不足
+ * - achieved          : 残り ≤ 0.2 kg
+ * - on_track          : 実績ペース ≥ 必要ペース (比率 ≥ 1.0)
+ * - adjust            : 比率 0.5〜1.0 未満
+ * - behind            : 比率 0.5 未満 または逆方向
+ * - no_contest        : contest_date 未設定または過去
+ * - contest_imminent  : days_to_contest < PACE_CALC_MIN_DAYS (週次ペース算出不可)
+ * - unknown           : データ不足
  */
 export type GoalStatus =
   | "achieved"
@@ -252,6 +264,7 @@ export type GoalStatus =
   | "adjust"
   | "behind"
   | "no_contest"
+  | "contest_imminent"
   | "unknown";
 
 /**
@@ -274,6 +287,9 @@ export function calcGoalStatus(
 ): GoalStatus {
   if (daysToContest === null || daysToContest < 0) return "no_contest";
   if (remainingToGoalKg !== null && Math.abs(remainingToGoalKg) < 0.2) return "achieved";
+  // 大会直前 (days < PACE_CALC_MIN_DAYS): 週次ペース算出不可のため専用状態を返す
+  // required_rate は null になるため "unknown" と区別することで UI が明示的な fallback を出せる
+  if (daysToContest < PACE_CALC_MIN_DAYS) return "contest_imminent";
   if (actualRateKgPerWeek === null || requiredRateKgPerWeek === null) return "unknown";
   if (requiredRateKgPerWeek === 0) return "on_track";
 


### PR DESCRIPTION
## Summary

Issue #277 対応。大会直前など `days_to_contest` が極小のとき非現実的な `kg/週` が算出されるバグを修正する。

## 問題

```
残り 3 日、残り 5 kg → weeksLeft = 3/7 ≈ 0.43 → required = 5/0.43 ≈ 11.7 kg/週
```

このような非現実的な値が GoalNavigator の「必要ペース」に表示されていた。

## 変更概要

### `calcReadiness.ts`
- **`PACE_CALC_MIN_DAYS = 7` 定数を追加 (export)**  
  大会まで 1 週間未満では週次ペース指標は実用的でないという根拠で 7 日に設定。
- **`required_rate_kg_per_week` のガードを `days > 0` → `days >= PACE_CALC_MIN_DAYS` に変更**  
  1〜6 日では `null` を返す。通常ケース (7 日以上) の計算式は変更なし。
- **`GoalStatus` に `"contest_imminent"` を追加**
- **`calcGoalStatus` で `daysToContest < PACE_CALC_MIN_DAYS` → `"contest_imminent"` を返す**  
  優先順位: `no_contest` → `achieved` → **`contest_imminent`** → `unknown` → pace ratio

### `GoalNavigator.tsx`
- `requiredRateKg2W` の計算ガードを `PACE_CALC_MIN_DAYS` に統一
- `STATUS_CONFIG` に `contest_imminent` (ラベル: "大会直前") を追加
- ペース分析セクションに fallback メッセージを追加:  
  `大会まで N 日のためペース算出なし`

## 状態遷移（`days_to_contest` 別）

| days | 変更前 | 変更後 |
|---|---|---|
| null / 負 | `no_contest` | `no_contest`（変更なし）|
| 0〜6 | `required=算出` + `"unknown"` | `required=null` + `"contest_imminent"` |
| 7+ | `required=算出` + pace ratio | 同じ（変更なし）|
| 0〜6 かつ 目標達成済み | — | `"achieved"` を優先（変更なし）|

## 追加テスト (calcReadiness.test.ts)

- **大会直前ガード** 5件: days=1/3/6 → required=null、days=7/14 → 非 null
- **calcGoalStatus** 13件: contest_imminent/no_contest/achieved 優先順位/通常ケース全網羅

Closes #277