### PR TITLE
feat: add loading.tsx skeleton UIs to all app pages (#281)

### DIFF
--- a/src/app/history/loading.tsx
+++ b/src/app/history/loading.tsx
@@ -1,0 +1,23 @@
+/**
+ * History page loading skeleton — mirrors PageShell + charts + comparison table layout.
+ */
+import { SkeletonBlock, SkeletonCardRow } from "@/components/ui/Skeleton";
+
+export default function HistoryLoading() {
+  return (
+    <main className="py-4 md:py-6">
+      <div className="mx-auto max-w-screen-xl px-4 flex flex-col gap-6">
+        {/* Page title */}
+        <SkeletonBlock className="h-8 w-24" />
+        {/* Today window comparison cards */}
+        <SkeletonCardRow count={3} height="h-24" cols="grid-cols-1 sm:grid-cols-3" />
+        {/* Days-out chart */}
+        <SkeletonBlock className="h-64" />
+        {/* Season low chart */}
+        <SkeletonBlock className="h-48" />
+        {/* Season comparison table */}
+        <SkeletonBlock className="h-56" />
+      </div>
+    </main>
+  );
+}

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,30 @@
+/**
+ * Dashboard loading skeleton — approximate DashboardLayout structure.
+ * Sidebar (lg: visible) + main content area with KpiCards, chart, review sections.
+ */
+import { SkeletonBlock, SkeletonCardRow } from "@/components/ui/Skeleton";
+
+export default function DashboardLoading() {
+  return (
+    <div className="flex flex-col min-h-screen bg-slate-50 py-6 gap-2 lg:flex-row lg:items-start lg:px-4">
+      {/* Main content */}
+      <div className="min-w-0 flex-1 flex flex-col gap-6 px-4 lg:px-0">
+        {/* KpiCards */}
+        <SkeletonCardRow count={3} height="h-24" cols="grid-cols-1 sm:grid-cols-3" />
+        {/* GoalNavigator */}
+        <SkeletonBlock className="h-48" />
+        {/* ForecastChart */}
+        <SkeletonBlock className="h-64" />
+        {/* WeeklyReview */}
+        <SkeletonBlock className="h-40" />
+        {/* LogsAndSummaryTabs */}
+        <SkeletonBlock className="h-56" />
+      </div>
+
+      {/* Sidebar (MealLogger) — visible on lg+ */}
+      <div className="hidden lg:flex w-80 shrink-0">
+        <SkeletonBlock className="w-full h-[600px]" />
+      </div>
+    </div>
+  );
+}

--- a/src/app/macro/loading.tsx
+++ b/src/app/macro/loading.tsx
@@ -1,0 +1,23 @@
+/**
+ * Macro page loading skeleton — mirrors PageShell + MacroKpiCards + chart + table layout.
+ */
+import { SkeletonBlock, SkeletonCardRow } from "@/components/ui/Skeleton";
+
+export default function MacroLoading() {
+  return (
+    <main className="py-4 md:py-6">
+      <div className="mx-auto max-w-screen-xl px-4 flex flex-col gap-6">
+        {/* Page title */}
+        <SkeletonBlock className="h-8 w-32" />
+        {/* KPI cards */}
+        <SkeletonCardRow count={4} height="h-24" cols="grid-cols-2 sm:grid-cols-4" />
+        {/* PFC summary */}
+        <SkeletonBlock className="h-32" />
+        {/* Stacked chart */}
+        <SkeletonBlock className="h-64" />
+        {/* Daily table */}
+        <SkeletonBlock className="h-56" />
+      </div>
+    </main>
+  );
+}

--- a/src/app/settings/loading.tsx
+++ b/src/app/settings/loading.tsx
@@ -1,0 +1,22 @@
+/**
+ * Settings page loading skeleton — mirrors PageShell + SettingsForm + data panels layout.
+ */
+import { SkeletonBlock } from "@/components/ui/Skeleton";
+
+export default function SettingsLoading() {
+  return (
+    <main className="py-4 md:py-6">
+      <div className="mx-auto max-w-screen-xl px-4 flex flex-col gap-6">
+        {/* Page title */}
+        <SkeletonBlock className="h-8 w-16" />
+        {/* Settings form */}
+        <SkeletonBlock className="h-96" />
+        {/* Data quality panel */}
+        <SkeletonBlock className="h-48" />
+        {/* Export / import sections */}
+        <SkeletonBlock className="h-32" />
+        <SkeletonBlock className="h-32" />
+      </div>
+    </main>
+  );
+}

--- a/src/app/tdee/loading.tsx
+++ b/src/app/tdee/loading.tsx
@@ -1,0 +1,21 @@
+/**
+ * TDEE page loading skeleton — mirrors PageShell + TdeeKpiCard + chart + table layout.
+ */
+import { SkeletonBlock, SkeletonCardRow } from "@/components/ui/Skeleton";
+
+export default function TdeeLoading() {
+  return (
+    <main className="py-4 md:py-6">
+      <div className="mx-auto max-w-screen-xl px-4 flex flex-col gap-6">
+        {/* Page title */}
+        <SkeletonBlock className="h-8 w-32" />
+        {/* KPI cards */}
+        <SkeletonCardRow count={3} height="h-24" cols="grid-cols-1 sm:grid-cols-3" />
+        {/* Detail chart */}
+        <SkeletonBlock className="h-64" />
+        {/* Daily table */}
+        <SkeletonBlock className="h-56" />
+      </div>
+    </main>
+  );
+}

--- a/src/components/ui/Skeleton.tsx
+++ b/src/components/ui/Skeleton.tsx
@@ -1,0 +1,39 @@
+/**
+ * Skeleton — ローディング用スケルトン UI のビルディングブロック
+ *
+ * loading.tsx 内で使用する最小限のプレースホルダー。
+ * animate-pulse で脈動アニメーションを付与する。
+ */
+
+interface SkeletonBlockProps {
+  className?: string;
+}
+
+/** 汎用スケルトンブロック。className で高さ・幅・角丸を調整する。 */
+export function SkeletonBlock({ className }: SkeletonBlockProps) {
+  return (
+    <div
+      aria-hidden="true"
+      className={`animate-pulse rounded-2xl bg-slate-200 ${className ?? ""}`}
+    />
+  );
+}
+
+/** スケルトンカード行: 横並びの複数カードを生成するユーティリティ */
+export function SkeletonCardRow({
+  count,
+  height = "h-24",
+  cols = "grid-cols-1 sm:grid-cols-3",
+}: {
+  count: number;
+  height?: string;
+  cols?: string;
+}) {
+  return (
+    <div className={`grid gap-3 ${cols}`}>
+      {Array.from({ length: count }).map((_, i) => (
+        <SkeletonBlock key={i} className={height} />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Add `SkeletonBlock` / `SkeletonCardRow` shared primitives (`src/components/ui/Skeleton.tsx`)
- Add `loading.tsx` for Dashboard, TDEE, Macro, History, Settings pages
- Dashboard skeleton approximates `DashboardLayout` (sidebar + main) structure
- Other pages mirror `PageShell` + page-specific block layout
- Eliminates white-screen flash during SSR data fetching; no logic changes

## Test plan

- [ ] Build passes (`npm run build`) — confirmed
- [ ] Type check passes (`npx tsc --noEmit`) — confirmed
- [ ] No new lint errors — confirmed
- [ ] Verify skeleton appears briefly during page load on each route

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)