### PR TITLE
fix: validate monthlyGoalPlan goalDeadlineDate as a real date

### DIFF
--- a/src/lib/utils/monthlyGoalPlan.test.ts
+++ b/src/lib/utils/monthlyGoalPlan.test.ts
@@ -206,6 +206,44 @@ describe("buildMonthlyGoalPlan", () => {
       expect(plan.errors[0]!.code).toBe("INVALID_DEADLINE");
     });
 
+    describe("goalDeadlineDate が実在しない日付 → INVALID_DEADLINE", () => {
+      test.each([
+        ["2月30日", "2026-02-30"],
+        ["4月31日", "2026-04-31"],
+        ["13月1日", "2026-13-01"],
+        ["0月1日",  "2026-00-01"],
+      ])("%s (%s) は弾かれる", (_label, date) => {
+        const plan = buildMonthlyGoalPlan(makeInput({ goalDeadlineDate: date }));
+        expect(plan.isValid).toBe(false);
+        expect(plan.errors[0]!.code).toBe("INVALID_DEADLINE");
+        expect(plan.entries).toHaveLength(0);
+      });
+
+      test("うるう年の 2026-02-29 は弾かれる（2026 は平年）", () => {
+        const plan = buildMonthlyGoalPlan(
+          makeInput({ goalDeadlineDate: "2026-02-29" })
+        );
+        expect(plan.isValid).toBe(false);
+        expect(plan.errors[0]!.code).toBe("INVALID_DEADLINE");
+      });
+
+      test("うるう年の 2024-02-29 は通る", () => {
+        const plan = buildMonthlyGoalPlan(
+          makeInput({ today: "2024-02-01", goalDeadlineDate: "2024-02-29" })
+        );
+        expect(plan.isValid).toBe(true);
+        expect(plan.errors).toHaveLength(0);
+      });
+
+      test("2026-02-28 は通る", () => {
+        const plan = buildMonthlyGoalPlan(
+          makeInput({ today: "2026-02-01", goalDeadlineDate: "2026-02-28" })
+        );
+        expect(plan.isValid).toBe(true);
+        expect(plan.errors).toHaveLength(0);
+      });
+    });
+
     test("goalDeadlineDate が期限月 < currentMonth → DEADLINE_IN_PAST", () => {
       const plan = buildMonthlyGoalPlan(
         makeInput({

--- a/src/lib/utils/monthlyGoalPlan.ts
+++ b/src/lib/utils/monthlyGoalPlan.ts
@@ -27,6 +27,8 @@
  *   既存アプリに明示的な月間閾値がないため本ファイルで定数化する。
  */
 
+import { parseLocalDateStr } from "./date";
+
 // ─── 警告閾値定数 ────────────────────────────────────────────────────────────
 
 /**
@@ -194,7 +196,7 @@ function validateInput(input: MonthlyGoalPlanInput): MonthlyGoalError[] {
 
   if (
     !input.goalDeadlineDate ||
-    !/^\d{4}-\d{2}-\d{2}$/.test(input.goalDeadlineDate)
+    parseLocalDateStr(input.goalDeadlineDate) === null
   ) {
     errors.push({ code: "INVALID_DEADLINE" });
     return errors; // 日付依存の検証はスキップ


### PR DESCRIPTION
## Summary

Issue #288 対応 — `goalDeadlineDate` の実在日付チェックを追加。

- `validateInput` の `goalDeadlineDate` チェックを regex のみ → `parseLocalDateStr()` に置き換え
- `parseLocalDateStr()` は regex + 実在日付チェックを両方担うため、1行の差分で修正完了
- `2026-02-30` / `2026-04-31` などの書式は正しいが存在しない日付を `INVALID_DEADLINE` で弾く

## 変更内容

**`monthlyGoalPlan.ts`**
- `import { parseLocalDateStr } from "./date"` を追加
- `!/^\d{4}-\d{2}-\d{2}$/.test(...)` → `parseLocalDateStr(...) === null` に置き換え

**`monthlyGoalPlan.test.ts`**
- 実在しない日付 5 ケース（弾かれることを確認）: `2026-02-30`, `2026-04-31`, `2026-13-01`, `2026-00-01`, `2026-02-29`（平年）
- 正常な日付 2 ケース（通ることを確認）: `2024-02-29`（うるう年）, `2026-02-28`

## 既存正常系への影響

なし。`parseLocalDateStr` は既存の regex チェックと実在日付チェックを統合したものであり、正常な日付に対する挙動は変わらない。既存テスト 66 件 + 新規 7 件 = 73 件全通過。

Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)