### PR TITLE
fix: guard ew linear forecast against non-finite slope/intercept

### DIFF
--- a/src/lib/utils/forecastUtils.test.ts
+++ b/src/lib/utils/forecastUtils.test.ts
@@ -85,6 +85,35 @@ describe("calcEwLinearForecast", () => {
     // 下降トレンドなので予測値が下がっていること
     expect(result[13].value).toBeLessThan(70.0);
   });
+
+  // ── 非有限値ガード ────────────────────────────────────────────────────────────
+
+  it("value に NaN を含む場合は空配列を返す", () => {
+    const sma7 = makeSma7(20, latestLogDate, 70.0, 0.0);
+    sma7[10].value = NaN;
+    expect(calcEwLinearForecast(sma7, latestLogDate)).toEqual([]);
+  });
+
+  it("value に Infinity を含む場合は空配列を返す", () => {
+    const sma7 = makeSma7(20, latestLogDate, 70.0, 0.0);
+    sma7[5].value = Infinity;
+    expect(calcEwLinearForecast(sma7, latestLogDate)).toEqual([]);
+  });
+
+  it("value に -Infinity を含む場合は空配列を返す", () => {
+    const sma7 = makeSma7(20, latestLogDate, 70.0, 0.0);
+    sma7[5].value = -Infinity;
+    expect(calcEwLinearForecast(sma7, latestLogDate)).toEqual([]);
+  });
+
+  it("正常系: 返り値の全 value が有限値である", () => {
+    const sma7 = makeSma7(20, latestLogDate, 70.0, -0.05);
+    const result = calcEwLinearForecast(sma7, latestLogDate);
+    expect(result.length).toBeGreaterThan(0);
+    for (const p of result) {
+      expect(Number.isFinite(p.value)).toBe(true);
+    }
+  });
 });
 
 describe("buildForecastMap", () => {

--- a/src/lib/utils/forecastUtils.ts
+++ b/src/lib/utils/forecastUtils.ts
@@ -74,6 +74,7 @@ export function calcEwLinearForecast(
 
   const slope     = (sw * swxy - swx * swy) / denom;
   const intercept = (swy - slope * swx) / sw;
+  if (!Number.isFinite(slope) || !Number.isFinite(intercept)) return [];
 
   // latestLogDate 翌日から horizonDays 日先まで外挿
   // x = n-1 が直近 SMA7 点に対応するため、h 日後は x = n-1+h


### PR DESCRIPTION
## Summary
- Issue #280 対応: `calcEwLinearForecast` の `slope` / `intercept` に `Number.isFinite` ガードを追加
- `slope` または `intercept` が NaN / Infinity の場合は空配列 `[]` を返す
- 正常系の計算ロジック・`denom === 0` ガードはそのまま維持

## 変更内容

**`src/lib/utils/forecastUtils.ts`**
```ts
// slope/intercept 算出直後に追加
if (!Number.isFinite(slope) || !Number.isFinite(intercept)) return [];
```

**`src/lib/utils/forecastUtils.test.ts`** — 追加テスト 4 件:
- `value` に `NaN` を含む → `[]`
- `value` に `Infinity` を含む → `[]`
- `value` に `-Infinity` を含む → `[]`
- 正常系: 返り値の全 `value` が有限値であること

## 影響範囲
- 正常な SMA7 入力に対する forecast 件数・値は変わらない
- ForecastChart 側の変更なし

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)