### PR TITLE
feat: add runtime validation for analytics cache payload

### DIFF
--- a/src/lib/queries/analytics.test.ts
+++ b/src/lib/queries/analytics.test.ts
@@ -141,6 +141,54 @@ describe("fetchEnrichedLogs", () => {
     expect(result.rows).toEqual([]);
   });
 
+  it("payload 要素が number の場合（不正 shape）: status = unavailable / rows = []", async () => {
+    setupChain({
+      data: { payload: [1, 2, 3], updated_at: "2026-03-14T03:00:00Z" },
+      error: null,
+    });
+    const result = await fetchEnrichedLogs("2026-03-14T03:00:00Z");
+    expect(result.availability.status).toBe("unavailable");
+    expect(result.rows).toEqual([]);
+  });
+
+  it("payload 要素が object だが必須 key が欠けている場合: status = unavailable", async () => {
+    // { foo: "bar" } は log_date / weight_sma7 / tdee_estimated を持たない
+    setupChain({
+      data: { payload: [{ foo: "bar" }], updated_at: "2026-03-14T03:00:00Z" },
+      error: null,
+    });
+    const result = await fetchEnrichedLogs("2026-03-14T03:00:00Z");
+    expect(result.availability.status).toBe("unavailable");
+    expect(result.rows).toEqual([]);
+    expect(result.updatedAt).toBeNull();
+  });
+
+  it("log_date が number の場合（string でない）: status = unavailable", async () => {
+    setupChain({
+      data: {
+        payload: [{ log_date: 20260314, weight_sma7: 70.0, tdee_estimated: 2400 }],
+        updated_at: "2026-03-14T03:00:00Z",
+      },
+      error: null,
+    });
+    const result = await fetchEnrichedLogs("2026-03-14T03:00:00Z");
+    expect(result.availability.status).toBe("unavailable");
+    expect(result.rows).toEqual([]);
+  });
+
+  it("weight_sma7 が null の正常行: status = fresh（null は有効値）", async () => {
+    setupChain({
+      data: {
+        payload: [{ log_date: "2026-03-14", weight_sma7: null, tdee_estimated: null }],
+        updated_at: "2026-03-14T03:00:00Z",
+      },
+      error: null,
+    });
+    const result = await fetchEnrichedLogs("2026-03-14T03:00:00Z");
+    expect(result.availability.status).toBe("fresh");
+    expect(result.rows).toHaveLength(1);
+  });
+
   it("payload validation 失敗時は console.error が呼ばれる", async () => {
     const spy = jest.spyOn(console, "error").mockImplementation(() => {});
     setupChain({
@@ -151,6 +199,19 @@ describe("fetchEnrichedLogs", () => {
     expect(spy).toHaveBeenCalledWith(
       expect.stringContaining("enriched_logs: payload validation failed"),
       expect.anything()
+    );
+    spy.mockRestore();
+  });
+
+  it("要素 shape validation 失敗時は console.error にインデックスが含まれる", async () => {
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    setupChain({
+      data: { payload: [{ foo: "bar" }], updated_at: "2026-03-14T03:00:00Z" },
+      error: null,
+    });
+    await fetchEnrichedLogs("2026-03-14T03:00:00Z");
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining("row[0]")
     );
     spy.mockRestore();
   });

--- a/src/lib/queries/analytics.ts
+++ b/src/lib/queries/analytics.ts
@@ -59,6 +59,23 @@ export interface FactorAnalysisResult {
 // ── payload バリデーション ─────────────────────────────────────────────────────
 
 /**
+ * enriched_logs の各行が最低限の shape を満たすか検証する。
+ * UI が参照する必須フィールドの存在を確認する:
+ *   - log_date: string（主キー、日付表示に使用）
+ *   - weight_sma7: キーが存在する（値は number | null）
+ *   - tdee_estimated: キーが存在する（値は number | null）
+ */
+function isValidEnrichedLogRow(val: unknown): boolean {
+  if (typeof val !== "object" || val === null) return false;
+  const v = val as Record<string, unknown>;
+  return (
+    typeof v.log_date === "string" &&
+    "weight_sma7" in v &&
+    "tdee_estimated" in v
+  );
+}
+
+/**
  * xgboost_importance の各 feature エントリが最低限の shape を満たすか検証する。
  * UI が必ず参照する `importance: number` / `pct: number` の存在を確認する。
  */
@@ -121,6 +138,15 @@ export async function fetchEnrichedLogs(
     console.error(
       "[analytics] enriched_logs: payload validation failed — expected array, got",
       typeof row.payload
+    );
+    return { availability: unavailableAvailability(), rows: [], updatedAt: null };
+  }
+
+  // runtime validation: 各行が最低限の shape を満たすか検証する
+  const invalidIndex = row.payload.findIndex((el) => !isValidEnrichedLogRow(el));
+  if (invalidIndex !== -1) {
+    console.error(
+      `[analytics] enriched_logs: payload validation failed — row[${invalidIndex}] is missing required fields (log_date: string, weight_sma7, tdee_estimated)`
     );
     return { availability: unavailableAvailability(), rows: [], updatedAt: null };
   }


### PR DESCRIPTION
## Summary
- Issue #284 対応: `analytics_cache.payload` にランタイムバリデーションを追加
- バリデーション失敗時は `unavailableAvailability()` に落とし、`FactorAnalysisPlaceholder` の graceful degradation フローを維持
- バリデーション失敗は `console.error` でログ記録（key 名・理由を含む、raw payload 全体は出さない）

## 採用方針
手書きバリデーション（zod 不使用）。追加フィールドを拒否しない前方互換設計。

## 変更内容

**`src/lib/queries/analytics.ts`**

`fetchEnrichedLogs`:
- `!Array.isArray(row.payload)` → `unavailableAvailability()` + `console.error`

`fetchFactorAnalysis`:
- payload が plain object でない（配列・null 等）→ `unavailableAvailability()` + `console.error`
- 各 feature エントリに `importance: number` / `pct: number` がない → `unavailableAvailability()` + `console.error`
- `_meta` / `_stability` は検証対象外（除外後の entries のみ検証）
- `isValidFactorEntryShape()` ヘルパーを query 層に追加

## 追加テスト (10件)

**fetchEnrichedLogs**:
- payload が object（非配列）→ unavailable
- payload が null → unavailable
- validation 失敗時に `console.error` が呼ばれる

**fetchFactorAnalysis**:
- payload が配列 → unavailable
- payload が文字列 → unavailable
- entry に `importance` なし → unavailable
- entry に `pct` なし → unavailable
- entry 値が null → unavailable
- validation 失敗時に `console.error` で key 名が含まれる
- `_meta` / `_stability` のみ（feature エントリなし）→ 正常に空 payload を返す

Closes #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)