### PR TITLE
feat: add timeout and failure alerts to ml daily workflow

### DIFF
--- a/.github/workflows/ml-daily.yml
+++ b/.github/workflows/ml-daily.yml
@@ -8,10 +8,12 @@ on:
 
 permissions:
   contents: read
+  issues: write # 失敗通知用 Issue 作成に必要
 
 jobs:
   predict:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     # 環境変数を job-level に集約（各 step での重複定義を解消）
     env:
       SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
@@ -36,3 +38,24 @@ jobs:
 
       - name: Run analyze
         run: python ml-pipeline/analyze.py
+
+      - name: Notify failure via GitHub Issue
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `⚠️ ML Daily Batch failed (Run #${context.runNumber})`,
+              body: [
+                '## ML Daily Batch が失敗しました',
+                '',
+                `- **Workflow**: ${context.workflow}`,
+                `- **Job**: predict`,
+                `- **Run**: [#${context.runNumber}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
+                `- **Trigger**: ${context.eventName}`,
+                '',
+                '上記リンクからログを確認し、原因を調査してください。',
+              ].join('\n'),
+            });


### PR DESCRIPTION
## Summary
- Issue #292 対応: `ml-daily.yml` にタイムアウトと失敗通知を追加

## 変更内容

**timeout**
- `predict` job に `timeout-minutes: 30` を追加
- NeuralProphet 学習（predict.py）が最重量ステップで通常 15-20 分。30 分でバッファ確保しつつハングを早期検知

**失敗通知**
- 採用方式: `actions/github-script@v7` による **GitHub Issue 自動作成**
  - 外部 secret 不要（`GITHUB_TOKEN` で完結）
  - 既存の Slack 等通知インフラなし → GitHub 内完結方式を優先
- `if: failure()` で失敗時のみ発火（成功時ノイズなし）
- Issue 本文に含まれる情報:
  - Workflow 名
  - Job 名（predict）
  - Run URL（クリックでログに直行）
  - Trigger（schedule / workflow_dispatch）
- `permissions: issues: write` を追加（Issue 作成に必要）
- 重複 issue: run number をタイトルに含め実行ごとに識別可能。日次バッチの失敗頻度は低いため単純作成方式で十分

**リトライロジック**: 追加なし（scope 外）

## 正常系への影響
- 通常実行のステップ構成・順序は変更なし
- タイムアウト内に完了する正常実行には影響なし

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)