### PR TITLE
fix: change goal reach date display format from MM-DD to YYYY-MM-DD

### DIFF
--- a/src/lib/utils/calcReadiness.test.ts
+++ b/src/lib/utils/calcReadiness.test.ts
@@ -309,7 +309,7 @@ describe("calcGoalReachDate", () => {
     const r = calcGoalReachDate(70.0, slope, 68.0, today);
     expect(r.status).toBe("projected");
     expect(r.date).toBe("2026-03-29"); // today + 14日
-    expect(r.label).toBe("03-29");
+    expect(r.label).toBe("2026-03-29");
   });
 
   test("Cut: 7日後に到達するペース → status=projected", () => {
@@ -317,7 +317,7 @@ describe("calcGoalReachDate", () => {
     const r = calcGoalReachDate(69.0, -1 / 7, 68.0, today);
     expect(r.status).toBe("projected");
     expect(r.date).toBe("2026-03-22"); // today + 7日
-    expect(r.label).toBe("03-22");
+    expect(r.label).toBe("2026-03-22");
   });
 
   test("Bulk: 目標より低く増量中 → status=projected", () => {

--- a/src/lib/utils/calcReadiness.ts
+++ b/src/lib/utils/calcReadiness.ts
@@ -315,7 +315,7 @@ export interface GoalReachResult {
   status: "achieved" | "stalled" | "projected" | "no_data";
   /** 到達予定日 (YYYY-MM-DD)。status="projected" 時のみ非 null */
   date: string | null;
-  /** 表示ラベル ("MM-DD" / "達成済み ✓" / "停滞中" / "—") */
+  /** 表示ラベル ("YYYY-MM-DD" / "達成済み ✓" / "停滞中" / "—") */
   label: string;
 }
 
@@ -370,7 +370,7 @@ export function calcGoalReachDate(
   const date = addDaysStr(today, Math.round(daysNeeded));
   if (!date) return { status: "stalled", date: null, label: "停滞中" };
 
-  return { status: "projected", date, label: date.slice(5) }; // MM-DD
+  return { status: "projected", date, label: date }; // YYYY-MM-DD
 }
 
 /**


### PR DESCRIPTION
## Summary
- ダッシュボードの「目標到達予定」表示を `MM-DD` から `YYYY-MM-DD` に変更
- 年をまたぐ場合でも日付解釈が曖昧にならない表示形式に統一

## 変更内容

**`src/lib/utils/calcReadiness.ts`**
- `calcGoalReachDate()` の `label` を `date.slice(5)` → `date` に変更（1行）
- `GoalReachResult.label` の JSDoc コメントを `"MM-DD"` → `"YYYY-MM-DD"` に更新

**`src/lib/utils/calcReadiness.test.ts`**
- `label` の期待値を `"03-29"` → `"2026-03-29"`、`"03-22"` → `"2026-03-22"` に更新（2行）

## 対象箇所以外の変更
- **対象箇所以外は触っていません**
- 変更は目標到達予定日表示に関係する箇所のみに限定しています
- `KpiCards.tsx` は `goalReachLabel` をそのまま表示しているため変更不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)