### PR TITLE
fix: モバイルダッシュボードの記録 CTA をページ上部に移動 (#325)

### DIFF
--- a/src/components/dashboard/DashboardLayout.tsx
+++ b/src/components/dashboard/DashboardLayout.tsx
@@ -75,12 +75,12 @@ export function DashboardLayout({ children, header }: DashboardLayoutProps) {
 
       {/* メインコンテンツ */}
       <main className="min-w-0 flex-1 flex flex-col gap-6">
-        {children}
-
-        {/* モバイル用 MealLogger: 閲覧コンテンツの後に trigger を配置し、
+        {/* モバイル用 MealLogger: ページ最上部に trigger を配置し、
             bottom sheet で入力フォームを開く（lg+ では描画なし）。
-            閲覧導線（KPI → GoalNavigator → WeeklyReview → Tabs）を先に確保する。 */}
+            記録 CTA をスクロール前に見えるようにする。 */}
         <MobileMealLoggerSheet />
+
+        {children}
       </main>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- `DashboardLayout.tsx` で `<MobileMealLoggerSheet />` を `{children}` の前に移動
- モバイルでスクロールなしに「食事・体重を記録する」ボタンが表示される
- デスクトップ (lg+) は `lg:hidden` のため影響なし

## Test plan
- [ ] モバイル幅でダッシュボードを開き、ページ上部に「食事・体重を記録する」ボタンが表示されることを確認
- [ ] ボタンをタップして bottom sheet が開くことを確認
- [ ] デスクトップ (lg+) でボタンが表示されないことを確認

Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)