### PR TITLE
feat: add inputMode="decimal" to numeric inputs for mobile keyboard (#282)

### DIFF
--- a/src/components/foods/MenuTable.tsx
+++ b/src/components/foods/MenuTable.tsx
@@ -191,6 +191,7 @@ export function MenuTable({ initialMenus, foods }: MenuTableProps) {
             </select>
             <input
               type="number"
+              inputMode="decimal"
               min={1}
               max={9999}
               value={addAmount}

--- a/src/components/meal/Cart.tsx
+++ b/src/components/meal/Cart.tsx
@@ -150,6 +150,7 @@ export function Cart({ items, onChange }: CartProps) {
                 <div className="flex items-center gap-1">
                   <input
                     type="number"
+                    inputMode="decimal"
                     min={0}
                     max={9999}
                     value={item.food.name in editingGrams ? editingGrams[item.food.name] : item.grams}

--- a/src/components/meal/MealLogger.tsx
+++ b/src/components/meal/MealLogger.tsx
@@ -349,7 +349,7 @@ export function MealLogger({ sidebar = false, showHeader = true }: MealLoggerPro
             {weight === null ? (
               <input type="number" disabled placeholder="削除予定" className={inputClearedCls} />
             ) : (
-              <input type="number" step="0.1" min="0" placeholder="70.5" value={weight}
+              <input type="number" inputMode="decimal" step="0.1" min="0" placeholder="70.5" value={weight}
                 onChange={(e) => { setWeight(e.target.value); setWeightTouched(true); }}
                 className={`${inputCls} ${weight !== "" ? "pr-8" : ""}`} />
             )}
@@ -474,7 +474,7 @@ export function MealLogger({ sidebar = false, showHeader = true }: MealLoggerPro
               {sleepHours === null ? (
                 <input type="number" disabled placeholder="削除予定" className={inputClearedCls} />
               ) : (
-                <input type="number" step="0.5" min="0" max="24" placeholder="7.5"
+                <input type="number" inputMode="decimal" step="0.5" min="0" max="24" placeholder="7.5"
                   value={sleepHours}
                   onChange={(e) => { setSleepHours(e.target.value); setSleepHoursTouched(true); }}
                   className={`${inputCls} ${sleepHours !== "" ? "pr-8" : ""}`} />

--- a/src/components/meal/TempFoodForm.tsx
+++ b/src/components/meal/TempFoodForm.tsx
@@ -127,6 +127,7 @@ export function TempFoodForm({ onAdd }: TempFoodFormProps) {
         <input
           id="temp-food-grams"
           type="number"
+          inputMode="decimal"
           min={0}
           placeholder="200"
           value={form.grams}
@@ -144,6 +145,7 @@ export function TempFoodForm({ onAdd }: TempFoodFormProps) {
             <input
               id="temp-food-calories"
               type="number"
+              inputMode="decimal"
               min={0}
               placeholder="350"
               value={form.calories}
@@ -157,6 +159,7 @@ export function TempFoodForm({ onAdd }: TempFoodFormProps) {
             <input
               id="temp-food-protein"
               type="number"
+              inputMode="decimal"
               min={0}
               placeholder="25"
               value={form.protein}
@@ -170,6 +173,7 @@ export function TempFoodForm({ onAdd }: TempFoodFormProps) {
             <input
               id="temp-food-fat"
               type="number"
+              inputMode="decimal"
               min={0}
               placeholder="12"
               value={form.fat}
@@ -183,6 +187,7 @@ export function TempFoodForm({ onAdd }: TempFoodFormProps) {
             <input
               id="temp-food-carbs"
               type="number"
+              inputMode="decimal"
               min={0}
               placeholder="30"
               value={form.carbs}

--- a/src/components/settings/MonthlyGoalPlanSection.tsx
+++ b/src/components/settings/MonthlyGoalPlanSection.tsx
@@ -331,6 +331,7 @@ function PlanContent({
                       <div className="flex items-center justify-end gap-1">
                         <input
                           type="number"
+                          inputMode="decimal"
                           step="0.1"
                           min="20"
                           max="200"


### PR DESCRIPTION
## Summary
- Issue #282 対応: モバイルで数値入力時に小数対応テンキーが表示されるよう `inputMode="decimal"` を追加

## 変更箇所

| ファイル | 入力欄 | 小数? | 追加 |
|---|---|---|---|
| `MealLogger.tsx` | 体重 (`step="0.1"`) | ✅ | `inputMode="decimal"` |
| `MealLogger.tsx` | 睡眠時間 (`step="0.5"`) | ✅ | `inputMode="decimal"` |
| `Cart.tsx` | グラム数 | ✅ | `inputMode="decimal"` |
| `TempFoodForm.tsx` | グラム数・kcal・たんぱく質・脂質・炭水化物 | ✅ | `inputMode="decimal"` |
| `MonthlyGoalPlanSection.tsx` | 目標体重 (`step="0.1"`) | ✅ | `inputMode="decimal"` |
| `MenuTable.tsx` | グラム数 | ✅ | `inputMode="decimal"` |

## 入力ロジックへの影響
- `inputMode` は HTML 属性の追加のみ。`step` / `min` / `max` / `value` / `onChange` の挙動は変更なし
- バリデーション・スキーマ・保存処理に影響なし
- 既存の空文字保持・touched 管理に影響なし

## Test plan
- [ ] モバイルで MealLogger の体重欄をタップし、小数点付きテンキーが表示されることを確認
- [ ] Cart のグラム数欄で同様に確認
- [ ] デスクトップでは通常どおり入力できることを確認

Closes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)