### PR TITLE
feat: replace MealLogger alerts with toast feedback (#293)

### DIFF
--- a/src/components/meal/MealLogger.tsx
+++ b/src/components/meal/MealLogger.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState } from "react";
-import { CheckCircle2, AlertCircle, Loader2, PenLine, X, Undo2 } from "lucide-react";
+import { Loader2, PenLine, X, Undo2 } from "lucide-react";
+import { Toast } from "@/components/ui/Toast";
 import { saveDailyLog } from "@/app/actions/saveDailyLog";
 import { FoodPicker } from "./FoodPicker";
 import { Cart, calcCartTotals } from "./Cart";
@@ -592,18 +593,7 @@ export function MealLogger({ sidebar = false, showHeader = true }: MealLoggerPro
       </div>
 
       {/* 保存ボタン */}
-      <div className="flex items-center justify-end gap-3">
-        {status === "error" && (
-          <span className="flex items-center gap-1.5 text-xs font-medium text-rose-500 max-w-xs text-right">
-            <AlertCircle size={14} className="shrink-0" />
-            {errorMessage || "保存に失敗しました"}
-          </span>
-        )}
-        {status === "saved" && (
-          <span className="flex items-center gap-1.5 text-xs font-medium text-emerald-600">
-            <CheckCircle2 size={14} /> 保存しました
-          </span>
-        )}
+      <div className="flex items-center justify-end">
         <button
           onClick={handleSave}
           disabled={status === "saving" || !hasContent}
@@ -614,6 +604,13 @@ export function MealLogger({ sidebar = false, showHeader = true }: MealLoggerPro
             : <>保存</>}
         </button>
       </div>
+
+      {/* Toast 通知（fixed 配置・保存成功/失敗） */}
+      <Toast
+        type={status === "error" ? "error" : "success"}
+        message={status === "error" ? (errorMessage || "保存に失敗しました") : "保存しました"}
+        visible={status === "saved" || status === "error"}
+      />
     </div>
   );
 

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { CheckCircle2, AlertCircle } from "lucide-react";
+
+interface ToastProps {
+  type: "success" | "error";
+  message: string;
+  visible: boolean;
+}
+
+/**
+ * Toast — 非モーダルの一時通知コンポーネント
+ *
+ * fixed 配置で画面右上に表示する。z-[60] で MobileMealLoggerSheet (z-50) より上に重なる。
+ * 表示タイミング・自動消去は呼び元の state 管理に委ねる（visible prop で制御）。
+ * スクリーンリーダー向け: 成功は aria-live="polite"、エラーは aria-live="assertive"。
+ */
+export function Toast({ type, message, visible }: ToastProps) {
+  if (!visible) return null;
+
+  const isSuccess = type === "success";
+  return (
+    <div
+      role="status"
+      aria-live={isSuccess ? "polite" : "assertive"}
+      className={`fixed top-4 inset-x-4 sm:inset-x-auto sm:right-4 sm:w-80 z-[60] flex items-center gap-2.5 rounded-2xl border px-4 py-3 shadow-lg text-sm font-medium ${
+        isSuccess
+          ? "border-emerald-200 bg-emerald-50 text-emerald-700"
+          : "border-rose-200 bg-rose-50 text-rose-700"
+      }`}
+    >
+      {isSuccess ? (
+        <CheckCircle2 size={16} className="shrink-0" />
+      ) : (
+        <AlertCircle size={16} className="shrink-0" />
+      )}
+      <span>{message}</span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Issue #293 対応: MealLogger の保存成功/失敗フィードバックをインラインスパンから Toast 通知に置き換え

## 変更内容

### 新規: `src/components/ui/Toast.tsx`
既存 Toast 基盤がないため最小限の共有 Toast コンポーネントを新規作成。

- `fixed top-4 inset-x-4 sm:right-4 sm:w-80` — モバイルで全幅、デスクトップで右上固定
- `z-[60]` — MobileMealLoggerSheet (z-50) / MobileBottomNav (z-30) より上に重なる
- 成功: emerald 配色 + `aria-live="polite"`
- エラー: rose 配色 + `aria-live="assertive"`
- 表示/非表示は `visible` prop で呼び元が制御（独自タイマー不要）

### 変更: `src/components/meal/MealLogger.tsx`
- 保存ボタン左のインライン status スパン（成功/エラー）を除去
- `<Toast>` を `content` 末尾に追加（fixed 配置のためレイアウトへの影響なし）
- `CheckCircle2` / `AlertCircle` の import を削除
- **保存ロジック・`status` state・自動リセットタイマーは変更なし**

## 表示仕様
| 状態 | メッセージ | 配色 | 消去タイミング |
|---|---|---|---|
| 成功 | 保存しました | emerald | 2秒後（既存 setTimeout と同じ） |
| エラー | errorMessage または "保存に失敗しました" | rose | 5秒後（既存 setTimeout と同じ） |

Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)