### PR TITLE
feat: show empty-state message when forecast predictions are missing (#297)

### DIFF
--- a/src/components/charts/ForecastChart.integration.test.tsx
+++ b/src/components/charts/ForecastChart.integration.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * ForecastChart 結合テスト
+ *
+ * 検証内容:
+ * 1. predictions = [] のとき empty state メッセージが表示される
+ * 2. predictions = [] のとき ResponsiveContainer（チャート）が描画されない
+ * 3. predictions が 1 件以上あるとき ResponsiveContainer が描画される
+ * 4. predictions が 1 件以上あるとき empty state メッセージが表示されない
+ */
+
+// @jest-environment jest-environment-jsdom
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+// recharts をモック
+jest.mock("recharts", () => ({
+  ComposedChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="recharts-composed-chart">{children}</div>
+  ),
+  Line:               () => <div data-testid="recharts-line" />,
+  XAxis:              () => <div data-testid="recharts-xaxis" />,
+  YAxis:              () => <div data-testid="recharts-yaxis" />,
+  CartesianGrid:      () => <div data-testid="recharts-grid" />,
+  Tooltip:            () => <div data-testid="recharts-tooltip" />,
+  Legend:             () => <div data-testid="recharts-legend" />,
+  ReferenceLine:      () => <div data-testid="recharts-ref-line" />,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="recharts-container">{children}</div>
+  ),
+}));
+
+import { ForecastChart } from "@/components/charts/ForecastChart";
+import type { Prediction } from "@/lib/supabase/types";
+
+// ─── テストフィクスチャ ──────────────────────────────────────────────────────
+
+const basePrediction: Prediction = {
+  id: 1,
+  ds: "2025-06-01",
+  yhat: 68.5,
+  model_version: "neuralprophet-v1",
+  created_at: "2025-05-01T00:00:00Z",
+};
+
+const baseProps = {
+  logs: [],
+  sma7: [],
+  predictions: [] as Prediction[],
+};
+
+// ─── テスト ─────────────────────────────────────────────────────────────────
+
+describe("ForecastChart empty state", () => {
+  it("predictions が空のとき empty state メッセージを表示する", () => {
+    render(<ForecastChart {...baseProps} predictions={[]} />);
+    expect(screen.getByText("予測データがありません")).toBeInTheDocument();
+    expect(screen.getByText("ML バッチ（predict.py）実行後に表示されます")).toBeInTheDocument();
+  });
+
+  it("predictions が空のとき ResponsiveContainer を描画しない", () => {
+    render(<ForecastChart {...baseProps} predictions={[]} />);
+    expect(screen.queryByTestId("recharts-container")).not.toBeInTheDocument();
+  });
+
+  it("predictions が 1 件以上あるとき ResponsiveContainer を描画する", () => {
+    render(<ForecastChart {...baseProps} predictions={[basePrediction]} />);
+    expect(screen.getByTestId("recharts-container")).toBeInTheDocument();
+  });
+
+  it("predictions が 1 件以上あるとき empty state メッセージを表示しない", () => {
+    render(<ForecastChart {...baseProps} predictions={[basePrediction]} />);
+    expect(screen.queryByText("予測データがありません")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/charts/ForecastChart.tsx
+++ b/src/components/charts/ForecastChart.tsx
@@ -177,7 +177,14 @@ export function ForecastChart({
         </div>
       </div>
 
-      <ResponsiveContainer width="100%" height={380}>
+      {predictions.length === 0 ? (
+        <div className="flex h-[380px] flex-col items-center justify-center gap-2 text-center">
+          <p className="text-sm font-medium text-slate-500">予測データがありません</p>
+          <p className="text-xs text-slate-400">ML バッチ（predict.py）実行後に表示されます</p>
+        </div>
+      ) : null}
+
+      {predictions.length > 0 && <ResponsiveContainer width="100%" height={380}>
         <ComposedChart data={data} margin={{ top: 4, right: 8, bottom: 4, left: 0 }}>
           <CartesianGrid strokeDasharray="3 3" stroke="#f1f5f9" />
           <XAxis
@@ -306,7 +313,7 @@ export function ForecastChart({
             />
           )}
         </ComposedChart>
-      </ResponsiveContainer>
+      </ResponsiveContainer>}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Issue #297 対応: `ForecastChart` で `predictions` が空のとき、空グラフの代わりに意味のある empty state メッセージを表示

## 変更内容

### `ForecastChart.tsx`
`predictions.length === 0` のとき `ResponsiveContainer`（グラフ領域）を empty state div に差し替える。

- カードヘッダー（タイトル・期間タブ）は維持
- h-[380px] の領域を確保しレイアウト高さが変わらない
- 表示メッセージ:
  - `予測データがありません`
  - `ML バッチ（predict.py）実行後に表示されます`
- `predictions.length > 0` のときは従来どおりグラフを描画

### `ForecastChart.integration.test.tsx` (新規)
4 件のテストを追加:
- `predictions = []` → empty state メッセージが表示される ✅
- `predictions = []` → ResponsiveContainer が描画されない ✅
- `predictions` が 1 件以上 → ResponsiveContainer が描画される ✅
- `predictions` が 1 件以上 → empty state メッセージが表示されない ✅

## 正常系への影響
なし。既存グラフ描画・データ変換ロジックは変更なし。

Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)