### PR TITLE
feat: log feature-drop rate around dropna in analyze.py (#302)

### DIFF
--- a/ml-pipeline/analyze.py
+++ b/ml-pipeline/analyze.py
@@ -142,8 +142,16 @@ def run_importance(df: pd.DataFrame) -> dict[str, dict[str, float | str]]:
             "xgboost が未導入です。pip install xgboost でインストールしてください。"
         ) from e
 
+    before_rows = len(df)
     df = apply_feature_engineering(df)
     df = df.dropna(subset=FEATURE_COLS + ["target"])
+    after_rows = len(df)
+    dropped_rows = before_rows - after_rows
+    drop_rate = dropped_rows / before_rows if before_rows > 0 else 0.0
+    logger.info(
+        "Feature drop by null filtering: before=%d, after=%d, dropped=%d, drop_rate=%.1f%%",
+        before_rows, after_rows, dropped_rows, drop_rate * 100,
+    )
 
     if len(df) < MIN_ROWS:
         raise ValueError(f"有効行数が不足 ({len(df)} < {MIN_ROWS})")


### PR DESCRIPTION
## Summary
- Issue #302 対応
- `run_importance()` の `dropna()` 前後で行数を比較し、削除行数とドロップ率を `logging.info` で出力する
- 分析ロジック自体は変更していない

## 追加したログ
```
Feature drop by null filtering: before=120, after=96, dropped=24, drop_rate=20.0%
```
- `before_rows`: `apply_feature_engineering()` 呼び出し前の入力行数
- `after_rows`: 特徴量エンジニアリング + `dropna(FEATURE_COLS + ["target"])` 後の有効行数
- `dropped_rows` / `drop_rate`: 入力から分析可能行数への全体ドロップ量

## ドロップ率計算
```python
drop_rate = dropped_rows / before_rows if before_rows > 0 else 0.0
```
- `before_rows = 0` 時の ZeroDivisionError をガード済み

## ログ追加箇所の選定理由
- `run_importance()` のみに追加（`compute_stability()` / `compute_meta()` は同じフィルタを内部で再実行するため、重複ログを避けた）
- `apply_feature_engineering()` は pure logic 層のため logging を持たせず、呼び出し元で計測

## 影響範囲
- 分析ロジック・`dropna()` 条件・出力 payload いずれも変更なし
- Python コードの動作は変わらず、ログ行が 1 行追加されるのみ

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)