### PR TITLE
feat: enable noUncheckedIndexedAccess and fix resulting type errors (#299)

### DIFF
--- a/src/app/api/export/route.ts
+++ b/src/app/api/export/route.ts
@@ -27,7 +27,7 @@ const ALLOWED_TABLES = ["daily_logs", "food_master", "predictions"] as const;
  */
 export function isValidDateParam(s: string): boolean {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(s)) return false;
-  const [y, m, d] = s.split("-").map(Number);
+  const [y, m, d] = s.split("-").map(Number) as [number, number, number];
   const date = new Date(y, m - 1, d);
   return (
     date.getFullYear() === y &&

--- a/src/components/charts/ForecastChart.tsx
+++ b/src/components/charts/ForecastChart.tsx
@@ -76,7 +76,7 @@ export function ForecastChart({
 
   // タブごとの表示範囲
   const lastForecastDate = predictions.length > 0
-    ? [...predictions].sort((a, b) => b.ds.localeCompare(a.ds))[0].ds
+    ? [...predictions].sort((a, b) => b.ds.localeCompare(a.ds))[0]!.ds
     : today;
   // EW 補助線の最終日 (latestLogDate + 14 日、点がなければ今日)
   const lastEwDate = ewForecastPoints.at(-1)?.date ?? today;

--- a/src/components/dashboard/MonthlyCalendar.tsx
+++ b/src/components/dashboard/MonthlyCalendar.tsx
@@ -235,7 +235,7 @@ interface MonthlyCalendarProps {
 export function MonthlyCalendar({ logs }: MonthlyCalendarProps) {
   // 当月（JST 基準）でデフォルト初期化
   const todayKey          = toJstDateStr();
-  const [y, m]            = todayKey.split("-").map(Number);
+  const [y, m]            = todayKey.split("-").map(Number) as [number, number, number];
   const [month, setMonth] = useState<Date>(new Date(y, m - 1, 1));
 
   const dayMap = useMemo(() => buildCalendarDayMap(logs), [logs]);

--- a/src/components/dashboard/RecentLogsTable.tsx
+++ b/src/components/dashboard/RecentLogsTable.tsx
@@ -21,7 +21,7 @@ export function RecentLogsTable({ logs, embedded = false, seasonMap, currentSeas
     if (log.calories === null) return null;
     const idx = ascending.findIndex((d) => d.log_date === log.log_date);
     if (idx <= 0) return null;
-    const prev = ascending[idx - 1];
+    const prev = ascending[idx - 1]!;
     if (prev.calories === null) return null;
     return log.calories - prev.calories;
   }

--- a/src/components/foods/FoodTable.integration.test.tsx
+++ b/src/components/foods/FoodTable.integration.test.tsx
@@ -106,7 +106,7 @@ describe("FoodTable — バリデーション", () => {
   it("kcal が空のとき「kcal は必須です」を表示", async () => {
     // textbox[0]=検索ボックス, textbox[1]=食品名入力
     const inputs = screen.getAllByRole("textbox");
-    fireEvent.change(inputs[1], { target: { value: "テスト食品" } });
+    fireEvent.change(inputs[1]!, { target: { value: "テスト食品" } });
     // kcal は空のまま保存
     fireEvent.click(screen.getByText("保存"));
     await waitFor(() => {
@@ -135,11 +135,11 @@ describe("FoodTable — 保存成功", () => {
     const textInputs = screen.getAllByRole("textbox");
     const numberInputs = screen.getAllByRole("spinbutton");
 
-    fireEvent.change(textInputs[1], { target: { value: "テスト食品" } });
-    fireEvent.change(numberInputs[0], { target: { value: "200" } }); // calories
-    fireEvent.change(numberInputs[1], { target: { value: "10" } });  // protein
-    fireEvent.change(numberInputs[2], { target: { value: "5" } });   // fat
-    fireEvent.change(numberInputs[3], { target: { value: "30" } });  // carbs
+    fireEvent.change(textInputs[1]!, { target: { value: "テスト食品" } });
+    fireEvent.change(numberInputs[0]!, { target: { value: "200" } }); // calories
+    fireEvent.change(numberInputs[1]!, { target: { value: "10" } });  // protein
+    fireEvent.change(numberInputs[2]!, { target: { value: "5" } });   // fat
+    fireEvent.change(numberInputs[3]!, { target: { value: "30" } });  // carbs
 
     fireEvent.click(screen.getByText("保存"));
 
@@ -171,11 +171,11 @@ describe("FoodTable — 保存失敗", () => {
     const textInputs = screen.getAllByRole("textbox");
     const numberInputs = screen.getAllByRole("spinbutton");
 
-    fireEvent.change(textInputs[1], { target: { value: "重複食品" } });
-    fireEvent.change(numberInputs[0], { target: { value: "100" } });
-    fireEvent.change(numberInputs[1], { target: { value: "10" } });
-    fireEvent.change(numberInputs[2], { target: { value: "5" } });
-    fireEvent.change(numberInputs[3], { target: { value: "10" } });
+    fireEvent.change(textInputs[1]!, { target: { value: "重複食品" } });
+    fireEvent.change(numberInputs[0]!, { target: { value: "100" } });
+    fireEvent.change(numberInputs[1]!, { target: { value: "10" } });
+    fireEvent.change(numberInputs[2]!, { target: { value: "5" } });
+    fireEvent.change(numberInputs[3]!, { target: { value: "10" } });
 
     fireEvent.click(screen.getByText("保存"));
 
@@ -200,7 +200,7 @@ describe("FoodTable — 削除", () => {
     render(<FoodTable initialFoods={[makeFoodMaster({ name: "削除対象" })]} />);
 
     // mobile/desktop 両方にボタンがあるので最初のものを使用
-    const [deleteButton] = screen.getAllByLabelText("削除対象を削除");
+    const deleteButton = screen.getAllByLabelText("削除対象を削除")[0]!;
     await act(async () => {
       fireEvent.click(deleteButton);
     });

--- a/src/components/foods/MenuTable.integration.test.tsx
+++ b/src/components/foods/MenuTable.integration.test.tsx
@@ -140,7 +140,7 @@ describe("MenuTable — 保存成功（新規）", () => {
     const plusButtons = screen.getAllByRole("button").filter(
       (b) => b.querySelector("[data-testid='icon-plus']")
     );
-    fireEvent.click(plusButtons[plusButtons.length - 1]);
+    fireEvent.click(plusButtons[plusButtons.length - 1]!);
 
     fireEvent.click(screen.getByText("保存"));
 
@@ -173,7 +173,7 @@ describe("MenuTable — 保存成功（更新）", () => {
   it("編集ボタンでフォームが開き updateMenu が呼ばれる", async () => {
     // 編集ボタンは複数ある（モバイル/デスクトップ）ので最初の1つを使う
     const editButtons = screen.getAllByText("編集");
-    fireEvent.click(editButtons[0]);
+    fireEvent.click(editButtons[0]!);
 
     // 名前を変更
     const nameInput = screen.getByPlaceholderText("セット名（例: 鶏飯セット）");
@@ -206,7 +206,7 @@ describe("MenuTable — 削除", () => {
 
     const deleteButtons = screen.getAllByLabelText("鶏飯セットを削除");
     await act(async () => {
-      fireEvent.click(deleteButtons[0]);
+      fireEvent.click(deleteButtons[0]!);
     });
 
     await waitFor(() => {

--- a/src/components/history/SeasonComparisonTable.tsx
+++ b/src/components/history/SeasonComparisonTable.tsx
@@ -107,7 +107,7 @@ export function SeasonComparisonTable({
   }
 
   // 最新の過去シーズン (差分比較用)
-  const prevSeason = pastSeasons[pastSeasons.length - 1];
+  const prevSeason = pastSeasons[pastSeasons.length - 1]!;
 
   // 仕上がり体重 Map (season → peakWeight)
   const peakBySeasons: Record<string, number | null> = {};

--- a/src/components/history/SeasonLowChart.tsx
+++ b/src/components/history/SeasonLowChart.tsx
@@ -85,7 +85,7 @@ export function SeasonLowChart({ seasons, currentSeason }: SeasonLowChartProps) 
               if (entry.isCurrent) {
                 color = CURRENT_COLOR;
               } else {
-                color = PAST_COLORS[pastIdx % PAST_COLORS.length];
+                color = PAST_COLORS[pastIdx % PAST_COLORS.length]!;
                 pastIdx++;
               }
               return <Cell key={i} fill={color} />;

--- a/src/components/history/TodayWindowComparison.tsx
+++ b/src/components/history/TodayWindowComparison.tsx
@@ -91,7 +91,7 @@ function generateFinding(
 
   if (pastWithData.length === 0) return null;
 
-  const prev = pastWithData[0];
+  const prev = pastWithData[0]!;
   const diff = current.avgWeight - prev.avgWeight!;
   const direction = isCut
     ? diff < -0.05 ? "先行" : diff > 0.05 ? "遅れ" : "同ペース"

--- a/src/components/meal/Cart.tsx
+++ b/src/components/meal/Cart.tsx
@@ -98,7 +98,7 @@ export function Cart({ items, onChange }: CartProps) {
     if (raw === undefined) return; // 未編集ならスキップ
 
     const item = items[index];
-    if (item.kind !== "regular") return; // 一時食品は grams 編集なし
+    if (!item || item.kind !== "regular") return; // 一時食品は grams 編集なし
 
     const grams = normalizeGrams(raw, item.grams);
     const next = items.map((it, i) => (i === index ? { ...it, grams } : it));
@@ -113,6 +113,7 @@ export function Cart({ items, onChange }: CartProps) {
 
   function remove(index: number) {
     const item = items[index];
+    if (!item) return;
     if (item.kind === "regular") {
       setEditingGrams((prev) => {
         const updated = { ...prev };

--- a/src/components/meal/MealLogger.tsx
+++ b/src/components/meal/MealLogger.tsx
@@ -209,7 +209,7 @@ export function MealLogger({ sidebar = false, showHeader = true }: MealLoggerPro
           (c) => c.kind === "regular" && c.food.name === item.food.name
         );
         if (existing >= 0) {
-          const existingItem = next[existing];
+          const existingItem = next[existing]!;
           if (existingItem.kind === "regular") {
             next[existing] = { ...existingItem, grams: existingItem.grams + item.grams };
           }

--- a/src/components/settings/SettingsForm.integration.test.tsx
+++ b/src/components/settings/SettingsForm.integration.test.tsx
@@ -89,7 +89,7 @@ describe("SettingsForm — 保存成功", () => {
     });
 
     // 渡された引数に必須フィールドが含まれることを確認する
-    const callArg = mockSaveSettings.mock.calls[0][0];
+    const callArg = mockSaveSettings.mock.calls[0]![0];
     expect(callArg).toHaveProperty("contest_date");
     expect(callArg).toHaveProperty("goal_weight");
     expect(callArg).toHaveProperty("activity_factor");

--- a/src/components/settings/SettingsForm.tsx
+++ b/src/components/settings/SettingsForm.tsx
@@ -315,7 +315,7 @@ export function SettingsForm({ initialSettings, currentWeight = null }: Settings
               <FieldItem
                 key={key}
                 fieldKey={key}
-                meta={FIELDS[key]}
+                meta={FIELDS[key]!}
                 value={values[key] ?? ""}
                 error={fieldErrors[key]}
                 onChange={(val) => set(key, val)}
@@ -338,7 +338,7 @@ export function SettingsForm({ initialSettings, currentWeight = null }: Settings
             <FieldItem
               key={key}
               fieldKey={key}
-              meta={FIELDS[key]}
+              meta={FIELDS[key]!}
               value={values[key] ?? ""}
               error={fieldErrors[key]}
               onChange={(val) => set(key, val)}
@@ -360,7 +360,7 @@ export function SettingsForm({ initialSettings, currentWeight = null }: Settings
             <FieldItem
               key={key}
               fieldKey={key}
-              meta={MACRO_TARGET_FIELDS[key]}
+              meta={MACRO_TARGET_FIELDS[key]!}
               value={values[key] ?? ""}
               error={fieldErrors[key]}
               onChange={(val) => set(key, val)}

--- a/src/components/ui/MobileBottomNav.tsx
+++ b/src/components/ui/MobileBottomNav.tsx
@@ -80,8 +80,8 @@ export function MobileBottomNav() {
         sheet.querySelectorAll<HTMLElement>("a[href], button:not([disabled])")
       );
       if (focusable.length === 0) return;
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
+      const first = focusable[0]!;
+      const last = focusable[focusable.length - 1]!;
       if (e.shiftKey) {
         if (document.activeElement === first) {
           e.preventDefault();

--- a/src/lib/queries/analytics.test.ts
+++ b/src/lib/queries/analytics.test.ts
@@ -286,8 +286,8 @@ describe("fetchFactorAnalysis", () => {
       error: null,
     });
     const result = await fetchFactorAnalysis("2026-03-14T03:00:00Z");
-    expect(result.payload!["cal_lag1"].stability).toBe("high");
-    expect(result.payload!["cal_lag1"].cv).toBe(0.1);
+    expect(result.payload!["cal_lag1"]!.stability).toBe("high");
+    expect(result.payload!["cal_lag1"]!.cv).toBe(0.1);
     // _stability はエントリから除外されている
     expect(result.payload!["_stability"]).toBeUndefined();
   });
@@ -301,8 +301,8 @@ describe("fetchFactorAnalysis", () => {
       error: null,
     });
     const result = await fetchFactorAnalysis("2026-03-14T03:00:00Z");
-    expect(result.payload!["cal_lag1"].stability).toBe("unavailable");
-    expect(result.payload!["cal_lag1"].cv).toBeNull();
+    expect(result.payload!["cal_lag1"]!.stability).toBe("unavailable");
+    expect(result.payload!["cal_lag1"]!.cv).toBeNull();
   });
 
   it("行なし (PGRST116): status = unavailable / payload = null", async () => {

--- a/src/lib/queries/backtest.test.ts
+++ b/src/lib/queries/backtest.test.ts
@@ -112,7 +112,7 @@ describe("fetchMetrics", () => {
     expect(result.kind).toBe("ok");
     if (result.kind === "ok") {
       expect(result.data).toHaveLength(2);
-      expect(result.data[0].horizon_days).toBe(7);
+      expect(result.data[0]!.horizon_days).toBe(7);
     }
   });
 

--- a/src/lib/queries/dailyLogs.test.ts
+++ b/src/lib/queries/dailyLogs.test.ts
@@ -77,7 +77,7 @@ describe("fetchMacroDailyLogs", () => {
     expect(result.kind).toBe("ok");
     if (result.kind === "ok") {
       expect(result.data).toHaveLength(2);
-      expect(result.data[0].log_date).toBe("2026-03-01"); // reverse 後は昇順
+      expect(result.data[0]!.log_date).toBe("2026-03-01"); // reverse 後は昇順
     }
   });
 
@@ -115,7 +115,7 @@ describe("fetchTdeeDailyLogs", () => {
     expect(result.kind).toBe("ok");
     if (result.kind === "ok") {
       expect(result.data).toHaveLength(2);
-      expect(result.data[0].log_date).toBe("2026-03-01");
+      expect(result.data[0]!.log_date).toBe("2026-03-01");
     }
   });
 
@@ -237,7 +237,7 @@ describe("fetchCareerLogs", () => {
     expect(result.kind).toBe("ok");
     if (result.kind === "ok") {
       expect(result.data).toHaveLength(1);
-      expect(result.data[0].season).toBe("2025_Spring");
+      expect(result.data[0]!.season).toBe("2025_Spring");
     }
   });
 
@@ -275,7 +275,7 @@ describe("fetchCareerLogsForDashboard", () => {
     mockFrom.mockReturnValue({ select: selectFn });
     const result = await fetchCareerLogsForDashboard();
     expect(result).toHaveLength(1);
-    expect(result[0].season).toBe("2025_Spring");
+    expect(result[0]!.season).toBe("2025_Spring");
   });
 
   it("異常系: DB エラーのとき空配列を返す", async () => {
@@ -299,7 +299,7 @@ describe("fetchPredictions", () => {
     setupChain({ data: rows, error: null });
     const result = await fetchPredictions();
     expect(result).toHaveLength(1);
-    expect(result[0].ds).toBe("2026-03-15");
+    expect(result[0]!.ds).toBe("2026-03-15");
   });
 
   it("正常系: データが空のとき空配列を返す", async () => {

--- a/src/lib/queries/foods.test.ts
+++ b/src/lib/queries/foods.test.ts
@@ -41,7 +41,7 @@ describe("fetchFoods", () => {
     expect(result.kind).toBe("ok");
     if (result.kind === "ok") {
       expect(result.data).toHaveLength(2);
-      expect(result.data[0].name).toBe("鶏むね肉");
+      expect(result.data[0]!.name).toBe("鶏むね肉");
     }
   });
 
@@ -87,8 +87,8 @@ describe("fetchMenus", () => {
     expect(result.kind).toBe("ok");
     if (result.kind === "ok") {
       expect(result.data).toHaveLength(1);
-      expect(result.data[0].name).toBe("鶏むね肉定食");
-      expect(result.data[0].recipe).toHaveLength(1);
+      expect(result.data[0]!.name).toBe("鶏むね肉定食");
+      expect(result.data[0]!.recipe).toHaveLength(1);
     }
   });
 
@@ -98,7 +98,7 @@ describe("fetchMenus", () => {
     const result = await fetchMenus();
     expect(result.kind).toBe("ok");
     if (result.kind === "ok") {
-      expect(result.data[0].recipe).toEqual([]);
+      expect(result.data[0]!.recipe).toEqual([]);
     }
   });
 

--- a/src/lib/queries/settings.test.ts
+++ b/src/lib/queries/settings.test.ts
@@ -112,7 +112,7 @@ describe("fetchSettingsRows", () => {
     expect(result.kind).toBe("ok");
     if (result.kind === "ok") {
       expect(result.data).toHaveLength(2);
-      expect(result.data[0].key).toBe("goal_weight");
+      expect(result.data[0]!.key).toBe("goal_weight");
     }
   });
 

--- a/src/lib/schemas/settingsSchema.ts
+++ b/src/lib/schemas/settingsSchema.ts
@@ -162,7 +162,7 @@ function isNumericKey(key: string): key is NumericSettingKey {
  */
 function isValidDate(s: string): boolean {
   if (!DATE_PATTERN.test(s)) return false;
-  const [year, month, day] = s.split("-").map(Number);
+  const [year, month, day] = s.split("-").map(Number) as [number, number, number];
   // 月: 1-12, 日: 1-31 の基本チェック
   if (month < 1 || month > 12) return false;
   if (day < 1 || day > 31) return false;

--- a/src/lib/utils/__tests__/calcMonthlyBehaviorStats.test.ts
+++ b/src/lib/utils/__tests__/calcMonthlyBehaviorStats.test.ts
@@ -43,7 +43,7 @@ describe("calcMonthlyBehaviorStats", () => {
         makeLog("2026-03-04", { had_bowel_movement: true }),
       ];
       const result = calcMonthlyBehaviorStats(logs);
-      expect(result[0].bowelDays).toBe(2);
+      expect(result[0]!.bowelDays).toBe(2);
     });
 
     test("had_bowel_movement が全て null の月は bowelDays = 0", () => {
@@ -52,7 +52,7 @@ describe("calcMonthlyBehaviorStats", () => {
         makeLog("2026-03-02", { had_bowel_movement: null }),
       ];
       const result = calcMonthlyBehaviorStats(logs);
-      expect(result[0].bowelDays).toBe(0);
+      expect(result[0]!.bowelDays).toBe(0);
     });
 
     test("had_bowel_movement === false は集計対象外", () => {
@@ -61,7 +61,7 @@ describe("calcMonthlyBehaviorStats", () => {
         makeLog("2026-03-02", { had_bowel_movement: false }),
       ];
       const result = calcMonthlyBehaviorStats(logs);
-      expect(result[0].bowelDays).toBe(0);
+      expect(result[0]!.bowelDays).toBe(0);
     });
   });
 
@@ -74,7 +74,7 @@ describe("calcMonthlyBehaviorStats", () => {
         makeLog("2026-03-04", { training_type: "off" }),
       ];
       const result = calcMonthlyBehaviorStats(logs);
-      expect(result[0].trainingCounts).toEqual({
+      expect(result[0]!.trainingCounts).toEqual({
         chest: 2,
         back: 1,
         off: 1,
@@ -87,7 +87,7 @@ describe("calcMonthlyBehaviorStats", () => {
         makeLog("2026-03-02", { training_type: "chest" }),
       ];
       const result = calcMonthlyBehaviorStats(logs);
-      expect(result[0].trainingCounts).toEqual({ chest: 1 });
+      expect(result[0]!.trainingCounts).toEqual({ chest: 1 });
     });
 
     test("無効な training_type 文字列は集計対象外", () => {
@@ -96,7 +96,7 @@ describe("calcMonthlyBehaviorStats", () => {
         makeLog("2026-03-02", { training_type: "chest" }),
       ];
       const result = calcMonthlyBehaviorStats(logs);
-      expect(result[0].trainingCounts).toEqual({ chest: 1 });
+      expect(result[0]!.trainingCounts).toEqual({ chest: 1 });
     });
 
     test("off は有効値として集計される", () => {
@@ -105,13 +105,13 @@ describe("calcMonthlyBehaviorStats", () => {
         makeLog("2026-03-02", { training_type: "off" }),
       ];
       const result = calcMonthlyBehaviorStats(logs);
-      expect(result[0].trainingCounts).toEqual({ off: 2 });
+      expect(result[0]!.trainingCounts).toEqual({ off: 2 });
     });
 
     test("記録がない月は trainingCounts が空オブジェクト", () => {
       const logs = [makeLog("2026-03-01", { training_type: null })];
       const result = calcMonthlyBehaviorStats(logs);
-      expect(result[0].trainingCounts).toEqual({});
+      expect(result[0]!.trainingCounts).toEqual({});
     });
   });
 
@@ -124,7 +124,7 @@ describe("calcMonthlyBehaviorStats", () => {
         makeLog("2026-03-04", { work_mode: "off" }),
       ];
       const result = calcMonthlyBehaviorStats(logs);
-      expect(result[0].workModeCounts).toEqual({
+      expect(result[0]!.workModeCounts).toEqual({
         remote: 2,
         office: 1,
         off: 1,
@@ -137,7 +137,7 @@ describe("calcMonthlyBehaviorStats", () => {
         makeLog("2026-03-02", { work_mode: "remote" }),
       ];
       const result = calcMonthlyBehaviorStats(logs);
-      expect(result[0].workModeCounts).toEqual({ remote: 1 });
+      expect(result[0]!.workModeCounts).toEqual({ remote: 1 });
     });
 
     test("off (休日) は有効値として集計される", () => {
@@ -146,7 +146,7 @@ describe("calcMonthlyBehaviorStats", () => {
         makeLog("2026-03-02", { work_mode: "off" }),
       ];
       const result = calcMonthlyBehaviorStats(logs);
-      expect(result[0].workModeCounts).toEqual({ off: 2 });
+      expect(result[0]!.workModeCounts).toEqual({ off: 2 });
     });
   });
 
@@ -163,7 +163,7 @@ describe("calcMonthlyBehaviorStats", () => {
         makeLog("2026-03-08", { is_poor_sleep: true }),
       ];
       const result = calcMonthlyBehaviorStats(logs);
-      expect(result[0].flagCounts).toEqual({
+      expect(result[0]!.flagCounts).toEqual({
         is_cheat_day:  1,
         is_refeed_day: 2,
         is_eating_out: 3,
@@ -179,7 +179,7 @@ describe("calcMonthlyBehaviorStats", () => {
         makeLog("2026-03-03", { is_refeed_day: false }),
       ];
       const result = calcMonthlyBehaviorStats(logs);
-      expect(result[0].flagCounts).toEqual({
+      expect(result[0]!.flagCounts).toEqual({
         is_cheat_day:  0,
         is_refeed_day: 0,
         is_eating_out: 0,
@@ -198,10 +198,10 @@ describe("calcMonthlyBehaviorStats", () => {
       ];
       const result = calcMonthlyBehaviorStats(logs);
       // 2026-03 が先 (降順)
-      expect(result[0].month).toBe("2026-03");
-      expect(result[0].bowelDays).toBe(2);
-      expect(result[1].month).toBe("2026-02");
-      expect(result[1].bowelDays).toBe(1);
+      expect(result[0]!.month).toBe("2026-03");
+      expect(result[0]!.bowelDays).toBe(2);
+      expect(result[1]!.month).toBe("2026-02");
+      expect(result[1]!.bowelDays).toBe(1);
     });
 
     test("months パラメータで返す月数を制限できる", () => {
@@ -212,8 +212,8 @@ describe("calcMonthlyBehaviorStats", () => {
       ];
       const result = calcMonthlyBehaviorStats(logs, 2);
       expect(result).toHaveLength(2);
-      expect(result[0].month).toBe("2026-03");
-      expect(result[1].month).toBe("2026-02");
+      expect(result[0]!.month).toBe("2026-03");
+      expect(result[1]!.month).toBe("2026-02");
     });
 
     test("months = 0 (デフォルト) で全月を返す", () => {
@@ -237,10 +237,10 @@ describe("calcMonthlyBehaviorStats", () => {
       const logs = [makeLog("2026-03-01")];
       const result = calcMonthlyBehaviorStats(logs);
       expect(result).toHaveLength(1);
-      expect(result[0].bowelDays).toBe(0);
-      expect(result[0].trainingCounts).toEqual({});
-      expect(result[0].workModeCounts).toEqual({});
-      expect(result[0].flagCounts).toEqual({
+      expect(result[0]!.bowelDays).toBe(0);
+      expect(result[0]!.trainingCounts).toEqual({});
+      expect(result[0]!.workModeCounts).toEqual({});
+      expect(result[0]!.flagCounts).toEqual({
         is_cheat_day: 0,
         is_refeed_day: 0,
         is_eating_out: 0,
@@ -270,10 +270,10 @@ describe("calcMonthlyBehaviorStats", () => {
         }),
       ];
       const result = calcMonthlyBehaviorStats(logs);
-      expect(result[0].bowelDays).toBe(1);
-      expect(result[0].trainingCounts).toEqual({ chest: 1, back: 1 });
-      expect(result[0].workModeCounts).toEqual({ remote: 1, office: 1 });
-      expect(result[0].flagCounts.is_cheat_day).toBe(1);
+      expect(result[0]!.bowelDays).toBe(1);
+      expect(result[0]!.trainingCounts).toEqual({ chest: 1, back: 1 });
+      expect(result[0]!.workModeCounts).toEqual({ remote: 1, office: 1 });
+      expect(result[0]!.flagCounts.is_cheat_day).toBe(1);
     });
   });
 });
@@ -291,7 +291,7 @@ describe("sortedTrainingEntries", () => {
     const counts = { chest: 0, back: 2 };
     const result = sortedTrainingEntries(counts);
     expect(result).toHaveLength(1);
-    expect(result[0].type).toBe("back");
+    expect(result[0]!.type).toBe("back");
   });
 
   test("空オブジェクトは空配列を返す", () => {
@@ -311,6 +311,6 @@ describe("sortedWorkModeEntries", () => {
     const counts = { off: 0, office: 3 };
     const result = sortedWorkModeEntries(counts);
     expect(result).toHaveLength(1);
-    expect(result[0].mode).toBe("office");
+    expect(result[0]!.mode).toBe("office");
   });
 });

--- a/src/lib/utils/calcDataQuality.ts
+++ b/src/lib/utils/calcDataQuality.ts
@@ -119,8 +119,8 @@ function buildWindow(
   // sortedWithWeight は全期間のデータ (ウィンドウより広い範囲が渡されることを想定)
   const datesSet = new Set(dates);
   for (let i = 1; i < sortedWithWeight.length; i++) {
-    const cur = sortedWithWeight[i];
-    const prev = sortedWithWeight[i - 1];
+    const cur = sortedWithWeight[i]!;
+    const prev = sortedWithWeight[i - 1]!;
     // 両日がウィンドウ内でなくても、ウィンドウ内の日が cur なら検出する
     if (!datesSet.has(cur.date)) continue;
     const delta = Math.abs(cur.weight - prev.weight);

--- a/src/lib/utils/calcMacro.test.ts
+++ b/src/lib/utils/calcMacro.test.ts
@@ -135,8 +135,8 @@ describe("calcDailyMacro", () => {
   it("null の栄養素は 0 に変換される", () => {
     const logs = [makeLog("2026-03-08", { calories: null, protein: null, fat: null, carbs: null })];
     const result = calcDailyMacro(logs);
-    expect(result[0].calories).toBe(0);
-    expect(result[0].protein).toBe(0);
+    expect(result[0]!.calories).toBe(0);
+    expect(result[0]!.protein).toBe(0);
   });
 });
 

--- a/src/lib/utils/calcReadiness.test.ts
+++ b/src/lib/utils/calcReadiness.test.ts
@@ -54,7 +54,7 @@ function makeDailyLog(
 
 /** today から n 日前の日付 (YYYY-MM-DD) を返すシンプルなヘルパー */
 function daysAgo(today: string, n: number): string {
-  const [y, m, d] = today.split("-").map(Number);
+  const [y, m, d] = today.split("-").map(Number) as [number, number, number];
   const date = new Date(y, m - 1, d - n);
   const yy = date.getFullYear();
   const mm = String(date.getMonth() + 1).padStart(2, "0");

--- a/src/lib/utils/calcSeason.test.ts
+++ b/src/lib/utils/calcSeason.test.ts
@@ -22,8 +22,8 @@ describe("calcSeasonMeta", () => {
       makeLog("2025-11-01", 62.0), // 最小
     ];
     const [meta] = calcSeasonMeta(logs);
-    expect(meta.peakWeight).toBe(62.0);
-    expect(meta.peakDate).toBe("2025-11-01");
+    expect(meta!.peakWeight).toBe(62.0);
+    expect(meta!.peakDate).toBe("2025-11-01");
   });
 
   it("日付範囲（startDate / endDate）が正しい", () => {
@@ -33,8 +33,8 @@ describe("calcSeasonMeta", () => {
       makeLog("2025-11-01", 62.0),
     ];
     const [meta] = calcSeasonMeta(logs);
-    expect(meta.startDate).toBe("2025-09-01");
-    expect(meta.endDate).toBe("2025-11-01");
+    expect(meta!.startDate).toBe("2025-09-01");
+    expect(meta!.endDate).toBe("2025-11-01");
   });
 
   it("件数（count）が正しい", () => {
@@ -43,7 +43,7 @@ describe("calcSeasonMeta", () => {
       makeLog("2025-10-01", 65.0),
     ];
     const [meta] = calcSeasonMeta(logs);
-    expect(meta.count).toBe(2);
+    expect(meta!.count).toBe(2);
   });
 
   it("複数シーズンが独立して集計される", () => {
@@ -71,8 +71,8 @@ describe("buildDaysOutSeries", () => {
     const seriesMap = buildDaysOutSeries(logs);
     const points = seriesMap.get("S1")!;
 
-    expect(points[0].daysOut).toBe(-30);
-    expect(points[1].daysOut).toBe(0);
+    expect(points[0]!.daysOut).toBe(-30);
+    expect(points[1]!.daysOut).toBe(0);
   });
 
   it("seasonFilter を指定すると対象シーズンのみが含まれる", () => {
@@ -90,7 +90,7 @@ describe("buildDaysOutSeries", () => {
     const seriesMap = buildDaysOutSeries(logs);
     const [point] = seriesMap.get("S1")!;
     // 1点だけの場合は sma7 = weight
-    expect(point.sma7).toBeCloseTo(62.5, 5);
+    expect(point!.sma7).toBeCloseTo(62.5, 5);
   });
 
   it("7日移動平均が正しく計算される", () => {
@@ -105,7 +105,7 @@ describe("buildDaysOutSeries", () => {
     );
     const seriesMap = buildDaysOutSeries(logs);
     const points = seriesMap.get("S1")!;
-    const lastSma7 = points[6].sma7!;
+    const lastSma7 = points[6]!.sma7!;
     // 全7点の平均 = (70+69+68+67+66+65+64)/7 = 67
     expect(lastSma7).toBeCloseTo(67, 5);
   });

--- a/src/lib/utils/calcSeason.ts
+++ b/src/lib/utils/calcSeason.ts
@@ -36,11 +36,11 @@ export function calcSeasonMeta(logs: CareerLog[]): SeasonMeta[] {
 
       return {
         season,
-        targetDate: sorted[0].target_date,
-        startDate: sorted[0].log_date,
-        endDate: sorted[sorted.length - 1].log_date,
+        targetDate: sorted[0]!.target_date,
+        startDate: sorted[0]!.log_date,
+        endDate: sorted[sorted.length - 1]!.log_date,
         peakWeight: minWeight,
-        peakDate: sorted[minIdx].log_date,
+        peakDate: sorted[minIdx]!.log_date,
         count: sorted.length,
       };
     })
@@ -197,8 +197,8 @@ export function buildTodayWindowEntries(
 
     // inWindow は buildDaysOutSeries で log_date 昇順にソート済みのため、
     // 先頭が最古・末尾が最新の日付になる
-    const dateFrom = inWindow[0].log_date;
-    const dateTo = inWindow[inWindow.length - 1].log_date;
+    const dateFrom = inWindow[0]!.log_date;
+    const dateTo = inWindow[inWindow.length - 1]!.log_date;
 
     return { season, count: inWindow.length, avgWeight, centerDaysOut, dateFrom, dateTo };
   });

--- a/src/lib/utils/calcTdee.test.ts
+++ b/src/lib/utils/calcTdee.test.ts
@@ -68,14 +68,14 @@ describe("calcMetabolicSim", () => {
   it("カロリー制限中は体重が減少する", () => {
     // 摂取 1800 < TDEE 2200 → 減量
     const result = calcMetabolicSim(65.0, 2200, 1800, "2026-03-15", "2026-03-08");
-    const lastWeight = result[result.length - 1].weight;
+    const lastWeight = result[result.length - 1]!.weight;
     expect(lastWeight).toBeLessThan(65.0);
   });
 
   it("カロリー過剰時は体重が増加する", () => {
     // 摂取 2600 > TDEE 2200 → 増量
     const result = calcMetabolicSim(65.0, 2200, 2600, "2026-03-15", "2026-03-08");
-    const lastWeight = result[result.length - 1].weight;
+    const lastWeight = result[result.length - 1]!.weight;
     expect(lastWeight).toBeGreaterThan(65.0);
   });
 
@@ -169,7 +169,7 @@ describe("calcTheoreticalWeightChangePerWeek", () => {
     const result = calcTheoreticalWeightChangePerWeek(300);
     expect(result).not.toBeNull();
     const str = result!.toString();
-    const decimals = str.includes(".") ? str.split(".")[1].length : 0;
+    const decimals = str.includes(".") ? str.split(".")[1]!.length : 0;
     expect(decimals).toBeLessThanOrEqual(2);
   });
 });

--- a/src/lib/utils/calcTdee.ts
+++ b/src/lib/utils/calcTdee.ts
@@ -169,8 +169,8 @@ export function smoothTdeeSeries(
     const sorted = [...win].sort((a, b) => a - b);
     const mid = Math.floor(sorted.length / 2);
     return sorted.length % 2 === 0
-      ? (sorted[mid - 1] + sorted[mid]) / 2
-      : sorted[mid];
+      ? (sorted[mid - 1]! + sorted[mid]!) / 2
+      : sorted[mid]!;
   });
 }
 

--- a/src/lib/utils/calcTrend.ts
+++ b/src/lib/utils/calcTrend.ts
@@ -36,7 +36,7 @@ export function calcWeightTrend(
     return ms;
   };
 
-  const firstMs = parseDateMs(data[0].date);
+  const firstMs = parseDateMs(data[0]!.date);
   const xs = data.map((d) => (parseDateMs(d.date) - firstMs) / 86_400_000);
   const ys = data.map((d) => d.weight);
 
@@ -44,7 +44,7 @@ export function calcWeightTrend(
   const meanY = ys.reduce((a, b) => a + b, 0) / n;
 
   const ssXX = xs.reduce((acc, x) => acc + (x - meanX) ** 2, 0);
-  const ssXY = xs.reduce((acc, x, i) => acc + (x - meanX) * (ys[i] - meanY), 0);
+  const ssXY = xs.reduce((acc, x, i) => acc + (x - meanX) * (ys[i]! - meanY), 0);
   const ssYY = ys.reduce((acc, y) => acc + (y - meanY) ** 2, 0);
 
   const slope = ssXX === 0 ? 0 : ssXY / ssXX;

--- a/src/lib/utils/calendarUtils.test.ts
+++ b/src/lib/utils/calendarUtils.test.ts
@@ -287,7 +287,7 @@ describe("buildConditionTags", () => {
 
   it("work_mode=remote → cyan color", () => {
     const tags = buildConditionTags({ had_bowel_movement: null, training_type: null, work_mode: "remote" });
-    expect(tags[0].colorClass).toContain("cyan");
+    expect(tags[0]!.colorClass).toContain("cyan");
   });
 });
 

--- a/src/lib/utils/calendarUtils.ts
+++ b/src/lib/utils/calendarUtils.ts
@@ -147,7 +147,7 @@ export function buildCalendarDayMap(logs: DashboardDailyLog[]): Map<string, Cale
     if (log.weight !== null) {
       const idx = withWeight.findIndex((d) => d.log_date === log.log_date);
       if (idx > 0) {
-        weightDelta = Math.round((log.weight - withWeight[idx - 1].weight!) * 100) / 100;
+        weightDelta = Math.round((log.weight - withWeight[idx - 1]!.weight!) * 100) / 100;
       }
     }
 
@@ -156,7 +156,7 @@ export function buildCalendarDayMap(logs: DashboardDailyLog[]): Map<string, Cale
     if (log.calories !== null) {
       const idx = withCals.findIndex((d) => d.log_date === log.log_date);
       if (idx > 0) {
-        calDelta = Math.round(log.calories - withCals[idx - 1].calories!);
+        calDelta = Math.round(log.calories - withCals[idx - 1]!.calories!);
       }
     }
 

--- a/src/lib/utils/csvParser.test.ts
+++ b/src/lib/utils/csvParser.test.ts
@@ -92,7 +92,7 @@ describe("parseCSV", () => {
     const result = parseCSV(csv);
     expect(result.errors).toHaveLength(0);
     expect(result.rows).toHaveLength(1);
-    expect(result.rows[0].note).toBe("chicken, rice");
+    expect(result.rows[0]!.note).toBe("chicken, rice");
   });
 
   it("note にダブルクォートを含む CSV を正しくパースする", () => {
@@ -103,7 +103,7 @@ describe("parseCSV", () => {
 
     const result = parseCSV(csv);
     expect(result.errors).toHaveLength(0);
-    expect(result.rows[0].note).toBe('say "hello" today');
+    expect(result.rows[0]!.note).toBe('say "hello" today');
   });
 
   it("note にセル内改行を含む CSV を正しくパースする (multiline)", () => {
@@ -116,8 +116,8 @@ describe("parseCSV", () => {
     const result = parseCSV(csv);
     expect(result.errors).toHaveLength(0);
     expect(result.rows).toHaveLength(2);
-    expect(result.rows[0].note).toBe("line1\nline2");
-    expect(result.rows[1].log_date).toBe("2026-03-05");
+    expect(result.rows[0]!.note).toBe("line1\nline2");
+    expect(result.rows[1]!.log_date).toBe("2026-03-05");
   });
 
   it("列数不一致: 列が少ない行はスキップしエラーに記録する", () => {
@@ -131,7 +131,7 @@ describe("parseCSV", () => {
     expect(result.errors.length).toBeGreaterThanOrEqual(1);
     // 不足行はスキップ、正常行のみ取り込み
     expect(result.rows).toHaveLength(1);
-    expect(result.rows[0].log_date).toBe("2026-03-04");
+    expect(result.rows[0]!.log_date).toBe("2026-03-04");
   });
 
   it("必須列欠損: log_date がない場合はエラーを返す", () => {
@@ -155,7 +155,7 @@ describe("parseCSV", () => {
     const result = parseCSV(csv);
     expect(result.errors.length).toBeGreaterThanOrEqual(1);
     expect(result.rows).toHaveLength(1);
-    expect(result.rows[0].log_date).toBe("2026-03-05");
+    expect(result.rows[0]!.log_date).toBe("2026-03-05");
   });
 
   it("存在しない日付（2026-02-30）はエラーに記録してスキップする", () => {
@@ -169,7 +169,7 @@ describe("parseCSV", () => {
     expect(result.errors.length).toBeGreaterThanOrEqual(1);
     expect(result.errors[0]).toContain("2026-02-30");
     expect(result.rows).toHaveLength(1);
-    expect(result.rows[0].log_date).toBe("2026-03-01");
+    expect(result.rows[0]!.log_date).toBe("2026-03-01");
   });
 
   it("不正な training_type はエラーに記録して行をスキップする", () => {
@@ -183,7 +183,7 @@ describe("parseCSV", () => {
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0]).toContain("invalid_type");
     expect(result.rows).toHaveLength(1);
-    expect(result.rows[0].log_date).toBe("2026-03-02");
+    expect(result.rows[0]!.log_date).toBe("2026-03-02");
   });
 
   it("有効な training_type はそのまま保持する", () => {
@@ -195,8 +195,8 @@ describe("parseCSV", () => {
 
     const result = parseCSV(csv);
     expect(result.errors).toHaveLength(0);
-    expect(result.rows[0].training_type).toBe("quads");
-    expect(result.rows[1].training_type).toBe("off");
+    expect(result.rows[0]!.training_type).toBe("quads");
+    expect(result.rows[1]!.training_type).toBe("off");
   });
 
   it("不正な work_mode はエラーに記録して行をスキップする", () => {
@@ -210,7 +210,7 @@ describe("parseCSV", () => {
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0]).toContain("invalid_mode");
     expect(result.rows).toHaveLength(1);
-    expect(result.rows[0].log_date).toBe("2026-03-02");
+    expect(result.rows[0]!.log_date).toBe("2026-03-02");
   });
 
   it("有効な work_mode はそのまま保持する", () => {
@@ -222,8 +222,8 @@ describe("parseCSV", () => {
 
     const result = parseCSV(csv);
     expect(result.errors).toHaveLength(0);
-    expect(result.rows[0].work_mode).toBe("office");
-    expect(result.rows[1].work_mode).toBe("remote");
+    expect(result.rows[0]!.work_mode).toBe("office");
+    expect(result.rows[1]!.work_mode).toBe("remote");
   });
 
   it("YYYY/MM/DD 形式を受け入れる", () => {
@@ -234,7 +234,7 @@ describe("parseCSV", () => {
 
     const result = parseCSV(csv);
     expect(result.errors).toHaveLength(0);
-    expect(result.rows[0].log_date).toBe("2026-03-06");
+    expect(result.rows[0]!.log_date).toBe("2026-03-06");
   });
 
   it("列エイリアス: 'date' 列を log_date として扱う", () => {
@@ -245,7 +245,7 @@ describe("parseCSV", () => {
 
     const result = parseCSV(csv);
     expect(result.errors).toHaveLength(0);
-    expect(result.rows[0].log_date).toBe("2026-03-07");
+    expect(result.rows[0]!.log_date).toBe("2026-03-07");
   });
 
   it("空データの場合はエラーメッセージを返す", () => {
@@ -281,7 +281,7 @@ describe("parseCSV", () => {
     const csv = "log_date,weight\r\n2026-03-08,65.0\r\n";
     const result = parseCSV(csv);
     expect(result.rows).toHaveLength(1);
-    expect(result.rows[0].log_date).toBe("2026-03-08");
+    expect(result.rows[0]!.log_date).toBe("2026-03-08");
   });
 
   // ---- 新カラム ----
@@ -309,7 +309,7 @@ describe("parseCSV", () => {
     ].join("\n");
 
     const result = parseCSV(csv);
-    expect(result.rows[0].had_bowel_movement).toBeNull();
+    expect(result.rows[0]!.had_bowel_movement).toBeNull();
   });
 
   it("新カラム: had_bowel_movement は true/false を正しくパースする", () => {
@@ -320,8 +320,8 @@ describe("parseCSV", () => {
     ].join("\n");
 
     const result = parseCSV(csv);
-    expect(result.rows[0].had_bowel_movement).toBe(true);
-    expect(result.rows[1].had_bowel_movement).toBe(false);
+    expect(result.rows[0]!.had_bowel_movement).toBe(true);
+    expect(result.rows[1]!.had_bowel_movement).toBe(false);
   });
 
   it("新カラム: leg_flag は空文字で null になる", () => {
@@ -331,7 +331,7 @@ describe("parseCSV", () => {
     ].join("\n");
 
     const result = parseCSV(csv);
-    expect(result.rows[0].leg_flag).toBeNull();
+    expect(result.rows[0]!.leg_flag).toBeNull();
   });
 
   it("新カラム: leg_flag は true/false を正しくパースする", () => {
@@ -342,8 +342,8 @@ describe("parseCSV", () => {
     ].join("\n");
 
     const result = parseCSV(csv);
-    expect(result.rows[0].leg_flag).toBe(true);
-    expect(result.rows[1].leg_flag).toBe(false);
+    expect(result.rows[0]!.leg_flag).toBe(true);
+    expect(result.rows[1]!.leg_flag).toBe(false);
   });
 
   it("新カラム: training_type / work_mode / sleep_hours を正しくパースする", () => {
@@ -367,8 +367,8 @@ describe("parseCSV", () => {
     ].join("\n");
 
     const result = parseCSV(csv);
-    expect(result.rows[0].training_type).toBeNull();
-    expect(result.rows[0].work_mode).toBeNull();
+    expect(result.rows[0]!.training_type).toBeNull();
+    expect(result.rows[0]!.work_mode).toBeNull();
   });
 
   it("旧 CSV（新カラムなし）をインポートしても新フィールドはデフォルト値になる", () => {
@@ -404,8 +404,8 @@ describe("round-trip: export → import", () => {
 
     expect(result.errors).toHaveLength(0);
     expect(result.rows).toHaveLength(1);
-    expect(result.rows[0].note).toBe("chicken, rice");
-    expect(result.rows[0].log_date).toBe("2026-03-20");
+    expect(result.rows[0]!.note).toBe("chicken, rice");
+    expect(result.rows[0]!.log_date).toBe("2026-03-20");
   });
 
   it("note にダブルクォートを含むレコードが往復できる", () => {
@@ -422,7 +422,7 @@ describe("round-trip: export → import", () => {
     const result = parseCSV(csv);
 
     expect(result.errors).toHaveLength(0);
-    expect(result.rows[0].note).toBe('say "hello" today');
+    expect(result.rows[0]!.note).toBe('say "hello" today');
   });
 
   it("note に改行を含むレコードが往復できる", () => {
@@ -440,8 +440,8 @@ describe("round-trip: export → import", () => {
 
     expect(result.errors).toHaveLength(0);
     expect(result.rows).toHaveLength(1);
-    expect(result.rows[0].note).toBe("朝: オートミール\n昼: チキン\n夜: サラダ");
-    expect(result.rows[0].log_date).toBe("2026-03-22");
+    expect(result.rows[0]!.note).toBe("朝: オートミール\n昼: チキン\n夜: サラダ");
+    expect(result.rows[0]!.log_date).toBe("2026-03-22");
   });
 
   it("複数レコードの note に改行が含まれていても行数が保たれる", () => {
@@ -469,11 +469,11 @@ describe("round-trip: export → import", () => {
 
     expect(result.errors).toHaveLength(0);
     expect(result.rows).toHaveLength(2);
-    expect(result.rows[0].note).toBe("line1\nline2");
-    expect(result.rows[1].log_date).toBe("2026-03-24");
-    expect(result.rows[1].is_cheat_day).toBe(true);
-    expect(result.rows[1].sleep_hours).toBe(6.5);
-    expect(result.rows[1].training_type).toBe("back");
+    expect(result.rows[0]!.note).toBe("line1\nline2");
+    expect(result.rows[1]!.log_date).toBe("2026-03-24");
+    expect(result.rows[1]!.is_cheat_day).toBe(true);
+    expect(result.rows[1]!.sleep_hours).toBe(6.5);
+    expect(result.rows[1]!.training_type).toBe("back");
   });
 
   it("全新カラムを含むレコードが往復できる", () => {
@@ -490,7 +490,7 @@ describe("round-trip: export → import", () => {
     const result = parseCSV(csv);
 
     expect(result.errors).toHaveLength(0);
-    const row = result.rows[0];
+    const row = result.rows[0]!;
     expect(row.is_cheat_day).toBe(true);
     expect(row.is_refeed_day).toBe(true);
     expect(row.is_eating_out).toBe(true);

--- a/src/lib/utils/csvParser.ts
+++ b/src/lib/utils/csvParser.ts
@@ -187,7 +187,7 @@ export function parseCSV(text: string): ParseResult {
 
   if (nonEmpty.length < 2) return { rows: [], errors: ["データ行がありません"] };
 
-  const headerCells = nonEmpty[0];
+  const headerCells = nonEmpty[0]!;
   const headers = headerCells.map((h) => h.trim());
   const keyMap = headers.map(normalizeKey);
 
@@ -202,7 +202,7 @@ export function parseCSV(text: string): ParseResult {
   const errors: string[] = [];
 
   for (let i = 1; i < nonEmpty.length; i++) {
-    const cells = nonEmpty[i];
+    const cells = nonEmpty[i]!;
 
     // 列数不足の行はスキップして errors に記録する。
     // 余剰列（cells.length > headers.length）は keyMap の範囲外として自然に無視される。

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -70,7 +70,7 @@ export function toLocalDateStr(date?: Date): string {
  */
 export function parseLocalDateStr(s: string): Date | null {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(s)) return null;
-  const [y, m, d] = s.split("-").map(Number);
+  const [y, m, d] = s.split("-").map(Number) as [number, number, number];
   if (m < 1 || m > 12) return null;
   const date = new Date(y, m - 1, d);
   if (date.getFullYear() !== y || date.getMonth() + 1 !== m || date.getDate() !== d) {

--- a/src/lib/utils/factorAnalysisUtils.test.ts
+++ b/src/lib/utils/factorAnalysisUtils.test.ts
@@ -60,22 +60,22 @@ describe("prepareFactorRows", () => {
 
   it("重要度の高い順にソートされる", () => {
     const { rows } = prepareFactorRows(data);
-    expect(rows[0].key).toBe("cal_lag1");
-    expect(rows[1].key).toBe("p_lag1");
-    expect(rows[2].key).toBe("c_lag1");
+    expect(rows[0]!.key).toBe("cal_lag1");
+    expect(rows[1]!.key).toBe("p_lag1");
+    expect(rows[2]!.key).toBe("c_lag1");
   });
 
   it("rank が 1 始まりで付与される", () => {
     const { rows } = prepareFactorRows(data);
-    expect(rows[0].rank).toBe(1);
-    expect(rows[1].rank).toBe(2);
-    expect(rows[2].rank).toBe(3);
+    expect(rows[0]!.rank).toBe(1);
+    expect(rows[1]!.rank).toBe(2);
+    expect(rows[2]!.rank).toBe(3);
   });
 
   it("ラベルが featureLabels の FEATURE_LABEL_MAP で解決される", () => {
     const { rows } = prepareFactorRows(data);
     // FEATURE_LABEL_MAP に cal_lag1 → "摂取 kcal（当日）" が登録されている
-    expect(rows[0].label).toBe("摂取 kcal（当日）");
+    expect(rows[0]!.label).toBe("摂取 kcal（当日）");
   });
 
   it("FEATURE_LABEL_MAP に未登録のキーは payload の label にフォールバックする", () => {
@@ -83,7 +83,7 @@ describe("prepareFactorRows", () => {
       unknown_feature: { label: "バックエンドラベル", importance: 1.0, pct: 100 },
     };
     const { rows } = prepareFactorRows(custom);
-    expect(rows[0].label).toBe("バックエンドラベル");
+    expect(rows[0]!.label).toBe("バックエンドラベル");
   });
 
   it("NaN を含む無効エントリは除外される", () => {
@@ -202,11 +202,11 @@ describe("mergeStability", () => {
 
   it("_stability がある場合、各エントリに stability / cv がマージされる", () => {
     const result = mergeStability(entries, stabilityMap);
-    expect(result["cal_lag1"].stability).toBe("high");
-    expect(result["cal_lag1"].cv).toBe(0.1);
-    expect(result["p_lag1"].stability).toBe("medium");
-    expect(result["c_lag1"].stability).toBe("low");
-    expect(result["c_lag1"].cv).toBe(0.8);
+    expect(result["cal_lag1"]!.stability).toBe("high");
+    expect(result["cal_lag1"]!.cv).toBe(0.1);
+    expect(result["p_lag1"]!.stability).toBe("medium");
+    expect(result["c_lag1"]!.stability).toBe("low");
+    expect(result["c_lag1"]!.cv).toBe(0.8);
   });
 
   it("_stability が null の場合、全エントリの stability が unavailable になる", () => {
@@ -230,21 +230,21 @@ describe("mergeStability", () => {
       // p_lag1 と c_lag1 は省略
     };
     const result = mergeStability(entries, partialStability);
-    expect(result["cal_lag1"].stability).toBe("high");
-    expect(result["p_lag1"].stability).toBe("unavailable");
-    expect(result["c_lag1"].stability).toBe("unavailable");
+    expect(result["cal_lag1"]!.stability).toBe("high");
+    expect(result["p_lag1"]!.stability).toBe("unavailable");
+    expect(result["c_lag1"]!.stability).toBe("unavailable");
   });
 
   it("元の entries の importance / pct / label を変更しない", () => {
     const result = mergeStability(entries, stabilityMap);
-    expect(result["cal_lag1"].importance).toBe(0.5);
-    expect(result["cal_lag1"].pct).toBe(50);
-    expect(result["cal_lag1"].label).toBe("カロリー");
+    expect(result["cal_lag1"]!.importance).toBe(0.5);
+    expect(result["cal_lag1"]!.pct).toBe(50);
+    expect(result["cal_lag1"]!.label).toBe("カロリー");
   });
 
   it("入力 entries を変更しない（immutable）", () => {
     mergeStability(entries, stabilityMap);
-    expect(entries["cal_lag1"].stability).toBeUndefined();
+    expect(entries["cal_lag1"]!.stability).toBeUndefined();
   });
 
   it("空の entries を渡すと空オブジェクトが返る", () => {
@@ -262,8 +262,8 @@ describe("prepareFactorRows stability fields", () => {
       p_lag1:   { label: "タンパク質", importance: 0.3, pct: 30, stability: "low", cv: 0.9 },
     };
     const { rows } = prepareFactorRows(data);
-    expect(rows[0].stability).toBe("high");
-    expect(rows[1].stability).toBe("low");
+    expect(rows[0]!.stability).toBe("high");
+    expect(rows[1]!.stability).toBe("low");
   });
 
   it("stability が付いていないエントリは unavailable として扱われる", () => {
@@ -271,8 +271,8 @@ describe("prepareFactorRows stability fields", () => {
       cal_lag1: { label: "カロリー", importance: 0.5, pct: 100 },
     };
     const { rows } = prepareFactorRows(data);
-    expect(rows[0].stability).toBe("unavailable");
-    expect(rows[0].cv).toBeNull();
+    expect(rows[0]!.stability).toBe("unavailable");
+    expect(rows[0]!.cv).toBeNull();
   });
 
   it("stability=unavailable のエントリも正常に表示できる（フィルタされない）", () => {

--- a/src/lib/utils/forecastUtils.test.ts
+++ b/src/lib/utils/forecastUtils.test.ts
@@ -10,7 +10,7 @@ function makeSma7(n: number, latestDate: string, valueAtLatest: number, slope: n
   for (let i = 0; i < n; i++) {
     // latestDate - (n-1-i) 日
     const daysBack = n - 1 - i;
-    const [y, m, d] = latestDate.split("-").map(Number);
+    const [y, m, d] = latestDate.split("-").map(Number) as [number, number, number];
     const dt = new Date(y, m - 1, d - daysBack);
     const date = `${dt.getFullYear()}-${String(dt.getMonth() + 1).padStart(2, "0")}-${String(dt.getDate()).padStart(2, "0")}`;
     result.push({ date, value: valueAtLatest + slope * (i - (n - 1)) });
@@ -42,19 +42,19 @@ describe("calcEwLinearForecast", () => {
     const sma7 = makeSma7(20, latestLogDate, 70.0, 0.0);
     const result = calcEwLinearForecast(sma7, latestLogDate, 30);
     expect(result).toHaveLength(30);
-    expect(result[29].date).toBe("2026-04-14");
+    expect(result[29]!.date).toBe("2026-04-14");
   });
 
   it("latestLogDate の翌日から始まる", () => {
     const sma7 = makeSma7(20, latestLogDate, 70.0, 0.0);
     const result = calcEwLinearForecast(sma7, latestLogDate);
-    expect(result[0].date).toBe("2026-03-16");
+    expect(result[0]!.date).toBe("2026-03-16");
   });
 
   it("14 件目が latestLogDate + 14 日の日付になる", () => {
     const sma7 = makeSma7(20, latestLogDate, 70.0, 0.0);
     const result = calcEwLinearForecast(sma7, latestLogDate);
-    expect(result[13].date).toBe("2026-03-29");
+    expect(result[13]!.date).toBe("2026-03-29");
   });
 
   it("一定 SMA7 では一定値を予測する", () => {
@@ -69,13 +69,13 @@ describe("calcEwLinearForecast", () => {
     // slope = -0.05 kg/日 の下降トレンド
     const sma7 = makeSma7(20, latestLogDate, 70.0, -0.05);
     const result = calcEwLinearForecast(sma7, latestLogDate, 7);
-    expect(result[6].value).toBeLessThan(70.0);
+    expect(result[6]!.value).toBeLessThan(70.0);
   });
 
   it("上昇トレンドでは予測値が latestLogDate 時点の SMA7 より高くなる", () => {
     const sma7 = makeSma7(20, latestLogDate, 70.0, 0.05);
     const result = calcEwLinearForecast(sma7, latestLogDate, 7);
-    expect(result[6].value).toBeGreaterThan(70.0);
+    expect(result[6]!.value).toBeGreaterThan(70.0);
   });
 
   it("SMA7 が 30 件を超える場合でも直近 30 件を使って予測できる", () => {
@@ -83,26 +83,26 @@ describe("calcEwLinearForecast", () => {
     const result = calcEwLinearForecast(sma7, latestLogDate);
     expect(result).toHaveLength(14);
     // 下降トレンドなので予測値が下がっていること
-    expect(result[13].value).toBeLessThan(70.0);
+    expect(result[13]!.value).toBeLessThan(70.0);
   });
 
   // ── 非有限値ガード ────────────────────────────────────────────────────────────
 
   it("value に NaN を含む場合は空配列を返す", () => {
     const sma7 = makeSma7(20, latestLogDate, 70.0, 0.0);
-    sma7[10].value = NaN;
+    sma7[10]!.value = NaN;
     expect(calcEwLinearForecast(sma7, latestLogDate)).toEqual([]);
   });
 
   it("value に Infinity を含む場合は空配列を返す", () => {
     const sma7 = makeSma7(20, latestLogDate, 70.0, 0.0);
-    sma7[5].value = Infinity;
+    sma7[5]!.value = Infinity;
     expect(calcEwLinearForecast(sma7, latestLogDate)).toEqual([]);
   });
 
   it("value に -Infinity を含む場合は空配列を返す", () => {
     const sma7 = makeSma7(20, latestLogDate, 70.0, 0.0);
-    sma7[5].value = -Infinity;
+    sma7[5]!.value = -Infinity;
     expect(calcEwLinearForecast(sma7, latestLogDate)).toEqual([]);
   });
 
@@ -166,7 +166,7 @@ describe("buildForecastMap", () => {
 /** tick 配列の隣接差がすべて step に等しいことを検証するヘルパー */
 function assertUniformStep(ticks: number[], step: number) {
   for (let i = 1; i < ticks.length; i++) {
-    expect(ticks[i] - ticks[i - 1]).toBeCloseTo(step);
+    expect(ticks[i]! - ticks[i - 1]!).toBeCloseTo(step);
   }
 }
 

--- a/src/lib/utils/forecastUtils.ts
+++ b/src/lib/utils/forecastUtils.ts
@@ -64,9 +64,9 @@ export function calcEwLinearForecast(
     const w = Math.pow(alpha, n - 1 - i);
     sw   += w;
     swx  += w * i;
-    swy  += w * ys[i];
+    swy  += w * ys[i]!;
     swxx += w * i * i;
-    swxy += w * i * ys[i];
+    swxy += w * i * ys[i]!;
   }
 
   const denom = sw * swxx - swx * swx;

--- a/src/lib/utils/importPreflight.ts
+++ b/src/lib/utils/importPreflight.ts
@@ -50,7 +50,7 @@ export function computeImportPreflight(
     parsedRows.length > 0
       ? (() => {
           const sorted = parsedRows.map((r) => r.log_date).sort();
-          return { from: sorted[0], to: sorted[sorted.length - 1] };
+          return { from: sorted[0]!, to: sorted[sorted.length - 1]! };
         })()
       : null;
 

--- a/src/lib/utils/recentLogsUtils.ts
+++ b/src/lib/utils/recentLogsUtils.ts
@@ -15,7 +15,7 @@ export function computeWeightDelta(
 ): number | null {
   const idx = ascending.findIndex((d) => d.log_date === log.log_date);
   if (idx <= 0) return null;
-  const prev = ascending[idx - 1];
+  const prev = ascending[idx - 1]!;
   if (prev.weight === null || log.weight === null) return null;
   return log.weight - prev.weight;
 }

--- a/src/lib/utils/timeWindow.test.ts
+++ b/src/lib/utils/timeWindow.test.ts
@@ -28,7 +28,7 @@ function makeLog(date: string) {
 /** 連続した日付のログを生成 (欠損なし) */
 function makeConsecutiveLogs(startDate: string, count: number) {
   const logs = [];
-  const [y, m, d] = startDate.split("-").map(Number);
+  const [y, m, d] = startDate.split("-").map(Number) as [number, number, number];
   const base = new Date(y, m - 1, d);
   for (let i = 0; i < count; i++) {
     const cur = new Date(base);
@@ -122,7 +122,7 @@ describe("filterLastNCalendarDays", () => {
   it("ログが1件のみ: today と一致すれば返す", () => {
     const logs = [makeLog("2026-03-14")];
     expect(filterLastNCalendarDays(logs, "2026-03-14", 7).length).toBe(1);
-    expect(filterLastNCalendarDays(logs, "2026-03-14", 7)[0].log_date).toBe("2026-03-14");
+    expect(filterLastNCalendarDays(logs, "2026-03-14", 7)[0]!.log_date).toBe("2026-03-14");
   });
 
   it("ログが1件のみ: ウィンドウ外なら空を返す", () => {
@@ -206,16 +206,16 @@ describe("暦日ベース vs 記録日ベースの挙動の違い", () => {
     // 暦日ベース: 3/8〜3/14 に含まれる4件のみ
     const calResult = filterLastNCalendarDays(logs, "2026-03-14", 7);
     expect(calResult.length).toBe(4);
-    expect(calResult[0].log_date).toBe("2026-03-08");
+    expect(calResult[0]!.log_date).toBe("2026-03-08");
 
     // 記録日ベース: 末尾から7件 → 3/3, 3/8, 3/10, 3/12, 3/14 + 3/1, 3/2 = 7件
     // つまり 3/1〜3/3 の古いデータも含まれる（欠損分だけ過去にずれる）
     const entryResult = lastNEntries(logs, 7);
     expect(entryResult.length).toBe(7);
-    expect(entryResult[0].log_date).toBe("2026-03-01"); // 記録日ベースは2週間前まで遡る
+    expect(entryResult[0]!.log_date).toBe("2026-03-01"); // 記録日ベースは2週間前まで遡る
 
     // 両者で先頭の日付が異なることを確認（定義が異なることの明示）
-    expect(calResult[0].log_date).not.toBe(entryResult[0].log_date);
+    expect(calResult[0]!.log_date).not.toBe(entryResult[0]!.log_date);
   });
 });
 
@@ -226,8 +226,8 @@ describe("lastNEntries", () => {
     const logs = makeConsecutiveLogs("2026-03-01", 14);
     const result = lastNEntries(logs, 7);
     expect(result.length).toBe(7);
-    expect(result[0].log_date).toBe("2026-03-08");
-    expect(result[6].log_date).toBe("2026-03-14");
+    expect(result[0]!.log_date).toBe("2026-03-08");
+    expect(result[6]!.log_date).toBe("2026-03-14");
   });
 
   it("ログが n 未満の場合は全件返す", () => {
@@ -254,8 +254,8 @@ describe("prevNEntries", () => {
     const result = prevNEntries(logs, 7);
     // 末尾7件 = 3/8〜3/14, その前7件 = 3/1〜3/7
     expect(result.length).toBe(7);
-    expect(result[0].log_date).toBe("2026-03-01");
-    expect(result[6].log_date).toBe("2026-03-07");
+    expect(result[0]!.log_date).toBe("2026-03-01");
+    expect(result[6]!.log_date).toBe("2026-03-07");
   });
 
   it("lastNEntries と prevNEntries は重ならない", () => {
@@ -278,8 +278,8 @@ describe("prevNEntries", () => {
     // n=7: 末尾7件=3/4〜3/10, 前7件を取ろうとしても3件しかない
     const result = prevNEntries(logs, 7);
     expect(result.length).toBe(3);
-    expect(result[0].log_date).toBe("2026-03-01");
-    expect(result[2].log_date).toBe("2026-03-03");
+    expect(result[0]!.log_date).toBe("2026-03-01");
+    expect(result[2]!.log_date).toBe("2026-03-03");
   });
 
   it("空配列は空を返す", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
+    "noUncheckedIndexedAccess": true,
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",


### PR DESCRIPTION
## Summary
- Issue #299 対応: `tsconfig.json` に `noUncheckedIndexedAccess: true` を追加
- 有効化で発生した 241 件の型エラーを全て修正 (本番コード 68件 + テストコード 173件)
- `tsc --noEmit` / 全テスト (1113件) が通ることを確認済み

## 発生した型エラーの傾向
| エラーコード | 件数 | 内容 |
|---|---|---|
| TS2532 | 149 | Object is possibly 'undefined' |
| TS18048 | 61 | variable is possibly 'undefined' |
| TS2345 | 21 | undefined は引数型に不一致 |
| TS2322 | 7 | undefined は代入型に不一致 |
| TS2339 | 2 | プロパティが union 型に存在しない |
| TS2538 | 1 | undefined はインデックス型に使用不可 |

## 修正方針
### 本番コード: ケースごとに適切な修正を適用
- `s.split("-").map(Number)` の destructuring → `as [number, number, number]` (regex ガードで保証)
- `for`ループ内 `arr[i]` → `!` (ループ条件で範囲内を保証)
- 非空配列の先頭/末尾 → `!` (length > 0 guard 後)
- `Cart.tsx`: 実装上安全だが `if (!item) return` ガードを追加
- `SettingsForm.tsx FIELDS[key]` → `!` (キー配列とオブジェクトが対応)

### テストコード: `result[n]!` / `arr[n]!` 非null アサーション
- テストデータが制御されているため、非null アサーションは文書的に適切
- `!` の乱用ではなく、データの存在が論理的に保証されている箇所のみに適用

## tsc --noEmit 結果
- **0 errors** (修正前: 241 errors)

## テスト結果
- **46 suites / 1113 tests passed** (修正前後で変化なし)

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)