### PR TITLE
feat: add Jest coverage thresholds and enforce them in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: npx tsc --noEmit
 
       - name: Test
-        run: npm test -- --runInBand --no-coverage
+        run: npm test -- --runInBand --coverage --coverageReporters=text-summary
 
       - name: Build
         env:

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -6,6 +6,25 @@ const config = {
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/src/$1",
   },
+  // カバレッジ対象: src/lib/ 配下のビジネスロジック・クエリ・ユーティリティに限定。
+  // src/app/ や src/components/ の Server Component / Next.js ルートは
+  // Jest での単体テストが難しいため除外し、測定対象を絞ることで閾値を意味のある値に保つ。
+  collectCoverageFrom: [
+    "src/lib/**/*.{ts,tsx}",
+    "!src/lib/supabase/types.ts",
+    "!src/lib/**/*.test.{ts,tsx}",
+    "!src/lib/**/*.d.ts",
+  ],
+  // 初期閾値: 現状 coverage を踏まえた現実的な下限（2026-03 計測値ベース）
+  // statements 80.1% / branches 77.96% / functions 79.93% / lines 80.33%
+  coverageThreshold: {
+    global: {
+      statements: 78,
+      branches: 75,
+      functions: 77,
+      lines: 78,
+    },
+  },
   transform: {
     "^.+\\.tsx?$": [
       "ts-jest",


### PR DESCRIPTION
## Summary

Issue #300 対応。

- `jest.config.cjs` に `collectCoverageFrom` と `coverageThreshold` を追加
- CI の Jest 実行を `--no-coverage` から `--coverage --coverageReporters=text-summary` に変更

## 計測範囲

`src/lib/**/*.{ts,tsx}` のみを対象とする（`src/app/` / `src/components/` の Server Component・Next.js ルートは Jest での単体テストが難しいため除外）。

## 現状 coverage（2026-03 計測値）

| 指標 | 現状 | 閾値 | バッファ |
|---|---|---|---|
| statements | 80.1% | 78% | 2.1pt |
| branches | 77.96% | 75% | 2.9pt |
| functions | 79.93% | 77% | 2.9pt |
| lines | 80.33% | 78% | 2.3pt |

## 閾値設定の理由

- 現状 coverage の 2〜3pt 下に設定し、テスト削除・カバレッジ劣化を CI で検知できるようにした
- branches のみ他指標より若干低めにせず、全指標で同程度のバッファを確保した
- `src/app/` / `src/components/` を除外したことで閾値が実態を正確に反映する

## 動作確認

- `npx jest --runInBand --coverage` → 全閾値クリア、1113 テスト全通過
- 閾値未満になると `Jest: "global" coverage threshold for XXX not met` が出て終了コード 1 になる

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)