### PR TITLE
feat: expand CI coverage for torch-free Python tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,4 +56,4 @@ jobs:
 
       - name: Test
         working-directory: ml-pipeline
-        run: pytest test_analyze.py test_enrich.py test_feature_registry.py test_backtest.py -v
+        run: pytest test_predict.py test_analyze.py test_enrich.py test_feature_registry.py test_backtest.py -v


### PR DESCRIPTION
## Summary

Issue #286 対応。

CI で実行可能な Python テストを棚卸しし、未追加だった `test_predict.py` を CI に追加する。

## 現状 CI 対象テスト（変更前）

```
pytest test_analyze.py test_enrich.py test_feature_registry.py test_backtest.py -v
```

## Python テスト一覧と torch 依存分類

| ファイル | torch 依存 | 説明 | CI 対象 |
|---|---|---|---|
| `test_analyze.py` | なし | XGBoost 因子分析ロジック | ✅ 既存 |
| `test_enrich.py` | なし | TDEE 計算・データ加工 | ✅ 既存 |
| `test_feature_registry.py` | なし | feature_registry 定義 + TS 同期 | ✅ 既存 |
| `test_backtest.py` | なし（mock 利用） | バックテスト純粋ロジック | ✅ 既存 |
| `test_predict.py` | なし | predict.py の変換ロジック + import 境界 | ✅ **今回追加** |

## `test_predict.py` について

- ファイルヘッダーに「torch / neuralprophet / supabase は不要、pandas のみで完結」と明記
- import 境界テスト・DataFrame 変換テスト・record 組み立てテストで構成
- `requirements-ci.txt` の依存（pandas, pytest）だけで動作する
- ローカル検証: 168 tests passed（全 5 ファイル合計）

## `test_feature_registry.py` の扱い

TS 同期テスト（`TestActiveFeatureNamesSync`）を含むこのファイルはすでに CI に含まれていた。変更なし。

## CI への影響

- 依存追加なし（`requirements-ci.txt` は変更なし）
- torch 依存テストは引き続き除外
- 実行テスト数が増加（+25 テスト程度）するが実行時間への影響は軽微

## 変更ファイル

- `.github/workflows/ci.yml`: pytest コマンドに `test_predict.py` を追加

Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)