### PR TITLE
fix: align target intake with current intake basis in dashboard nav

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -234,7 +234,7 @@ export default async function DashboardPage() {
             phase={phase}
             goalWeight={goalWeight ?? null}
             contestDate={contestDate ?? null}
-            avgTdee={latestTdee}
+            avgCalories={weeklyReview.nutrition.avgCalories}
             monthlyGoalProgress={monthlyGoalProgress}
             currentMonthMinWeight={currentMonthMinWeight}
           />

--- a/src/components/dashboard/GoalNavigator.tsx
+++ b/src/components/dashboard/GoalNavigator.tsx
@@ -36,8 +36,8 @@ interface GoalNavigatorProps {
   phase: string;
   goalWeight: number | null;
   contestDate: string | null;
-  /** 直近の推定 TDEE (kcal). 表示参考値として利用 */
-  avgTdee: number | null;
+  /** 直近 7 暦日の平均摂取カロリー (kcal/日). 目標摂取の算出基準 */
+  avgCalories: number | null;
   /** 今月目標に対する進捗 (calcMonthlyGoalProgress の結果) */
   monthlyGoalProgress: MonthlyGoalProgress;
   /** 当月内の最小実測体重 (kg) */
@@ -194,7 +194,7 @@ export function GoalNavigator({
   metrics,
   phase,
   goalWeight,
-  avgTdee,
+  avgCalories,
   monthlyGoalProgress,
   currentMonthMinWeight,
 }: GoalNavigatorProps) {
@@ -252,10 +252,10 @@ export function GoalNavigator({
   const missingGoal = goalWeight === null;
 
   // ── kcal 表示の補足 ──
-  // avgTdee があれば推奨摂取量も計算
+  // 現在の平均摂取カロリー + 推奨調整 で目標摂取を算出
   const recommendedIntake =
-    avgTdee !== null && kcalCorrection !== null
-      ? Math.round(avgTdee + kcalCorrection)
+    avgCalories !== null && kcalCorrection !== null
+      ? Math.round(avgCalories + kcalCorrection)
       : null;
 
   return (
@@ -407,7 +407,7 @@ export function GoalNavigator({
               {recommendedIntake !== null && (
                 <MetricRow
                   label="目標摂取"
-                  value={`${recommendedIntake.toLocaleString()} kcal`}
+                  value={`${recommendedIntake.toLocaleString()} kcal/日`}
                   valueColor="text-slate-700"
                 />
               )}
@@ -423,7 +423,7 @@ export function GoalNavigator({
               {recommendedIntake !== null && (
                 <MetricRow
                   label="目標摂取"
-                  value={`${recommendedIntake.toLocaleString()} kcal`}
+                  value={`${recommendedIntake.toLocaleString()} kcal/日`}
                   valueColor="text-slate-700"
                 />
               )}


### PR DESCRIPTION
## 概要

目標達成ナビ「調整提案」の `目標摂取` 算出基準を修正し、表示単位を `kcal/日` に統一する。

## 原因

修正前の実装:
```ts
// GoalNavigator.tsx
const recommendedIntake =
  avgTdee !== null && kcalCorrection !== null
    ? Math.round(avgTdee + kcalCorrection)
    : null;
```

`avgTdee` は **推定 TDEE（推定消費カロリー）** であり、実際にユーザーが摂取しているカロリーとは異なる値。
たとえば 300 kcal の赤字を維持している場合:
- 推定 TDEE: ~2,300 kcal/日
- 実際の平均摂取: ~2,000 kcal/日
- 旧表示: `目標摂取 = 2,300 + 補正`（ユーザーの体感と乖離）
- 期待表示: `目標摂取 = 2,000 + 補正`（現在の摂取カロリーに対する調整として自然）

## 変更内容

### `src/components/dashboard/GoalNavigator.tsx`
- `avgTdee` prop を `avgCalories`（直近 7 暦日の平均摂取カロリー）に変更
- `recommendedIntake` 算出を `avgCalories + kcalCorrection` に変更
- `目標摂取` の表示単位を `kcal` → `kcal/日` に統一（2 箇所）

### `src/app/page.tsx`
- `GoalNavigator` への渡し値を `avgTdee={latestTdee}` → `avgCalories={weeklyReview.nutrition.avgCalories}` に変更
- `weeklyReview.nutrition.avgCalories` は `calcWeeklyReview` が計算する直近 7 暦日の平均摂取カロリー

## 判断理由

- `目標摂取 = 現在の摂取カロリー + 推奨調整` がユーザーの直感と一致する（「今より XX kcal 増やす/減らす」）
- `weeklyReview.nutrition.avgCalories` は `calcWeeklyReview` 内で既に計算済みのため、新規計算ロジック追加なし
- `latestTdee`（推定 TDEE）は GoalNavigator では目標摂取の算出に使うべき値ではないため、参照を削除

## 影響範囲

- `GoalNavigator` コンポーネントのみ（他画面・他カードへの影響なし）
- `latestTdee` は `KpiCards` には引き続き渡っているため、TDEE 表示は変更なし
- GoalNavigator にテストファイルなし。型チェック・全テスト (1113 件) で回帰なし確認済み

## テスト

- `npx tsc --noEmit` → エラー 0 件
- `npx jest --no-coverage` → 1113 tests passed (46 suites)

## 補足

`kcal/日` の単位表記は既存の `fmtKcal()` 関数（`推奨調整` の表示）と統一。

Closes #343