### PR TITLE
feat: Bulk フェーズ時の履歴ページを参照モードに切り替え (#323)

### DIFF
--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -42,6 +42,9 @@ export default async function HistoryPage() {
 
   const seasonMeta = calcSeasonMeta(careerLogs);
 
+  const isCut = settings.currentPhase !== "Bulk";
+  const deadlineLabel = isCut ? "大会日" : "目標日";
+
   // 現在シーズンのログを career_logs 形式に変換して比較に追加
   const currentAsCareer: CareerLog[] = currentLogs
     .filter((d) => d.weight !== null)
@@ -54,7 +57,10 @@ export default async function HistoryPage() {
       note: null,
     }));
 
-  const allCareerLogs = [...careerLogs, ...currentAsCareer];
+  // Bulk フェーズ時は現在シーズンを比較系列に含めない（参照モード）
+  const allCareerLogs = isCut
+    ? [...careerLogs, ...currentAsCareer]
+    : [...careerLogs];
   const allSeasonMeta = calcSeasonMeta(allCareerLogs);
   const seriesMap = buildDaysOutSeries(allCareerLogs);
   const daysOutData = buildDaysOutChartData(seriesMap, -300, 0);
@@ -72,9 +78,6 @@ export default async function HistoryPage() {
       ? buildTodayWindowEntries(seriesMap, todayDaysOut, 7)
       : [];
 
-  const isCut = settings.currentPhase !== "Bulk";
-  const deadlineLabel = isCut ? "大会日" : "目標日";
-
   return (
     <PageShell title="履歴">
 
@@ -87,6 +90,13 @@ export default async function HistoryPage() {
       {settingsResult.kind === "error" && (
         <div className="mb-4 rounded-2xl border border-rose-100 bg-rose-50 px-5 py-3 text-sm text-rose-700">
           {`設定データの取得中にエラーが発生しました。${deadlineLabel}・シーズン名がデフォルト値になります。`}
+        </div>
+      )}
+
+      {/* Bulk 参照モード注記 */}
+      {!isCut && (
+        <div className="mb-4 rounded-xl border border-amber-100 bg-amber-50 px-4 py-2.5 text-xs text-amber-700">
+          Bulk フェーズ中は参照モードで表示しています。現在シーズンの比較は非表示です。
         </div>
       )}
 
@@ -108,8 +118,8 @@ export default async function HistoryPage() {
       <div className="space-y-6">
         {allCareerLogs.length > 0 ? (
           <>
-            {/* 今日基準近傍比較 (メイン判断用) */}
-            {todayDaysOut !== null && (
+            {/* 今日基準近傍比較 (メイン判断用) — Bulk 時は非表示 */}
+            {isCut && todayDaysOut !== null && (
               <TodayWindowComparison
                 entries={todayWindowEntries}
                 currentSeason={currentSeasonLabel}
@@ -135,6 +145,7 @@ export default async function HistoryPage() {
                 seasons={allSeasons}
                 currentSeason={currentSeasonLabel}
                 isCut={isCut}
+                showCurrentSeason={isCut}
               />
             </div>
             <div className="hidden md:block">
@@ -144,6 +155,7 @@ export default async function HistoryPage() {
                 seasons={allSeasons}
                 currentSeason={currentSeasonLabel}
                 isCut={isCut}
+                showCurrentSeason={isCut}
               />
             </div>
 

--- a/src/components/history/SeasonComparisonAccordion.tsx
+++ b/src/components/history/SeasonComparisonAccordion.tsx
@@ -22,6 +22,11 @@ interface SeasonComparisonAccordionProps {
   seasons: string[];
   currentSeason: string;
   isCut?: boolean;
+  /**
+   * true (default / Cut)  : 今季列・差列を表示
+   * false (Bulk)           : 今季列・差列を非表示（過去シーズン参照モード）
+   */
+  showCurrentSeason?: boolean;
 }
 
 // ─── ヘルパー ────────────────────────────────────────────────────────────────
@@ -72,6 +77,7 @@ export function SeasonComparisonAccordion({
   seasons,
   currentSeason,
   isCut = true,
+  showCurrentSeason = true,
 }: SeasonComparisonAccordionProps) {
   const [openSeason, setOpenSeason] = useState<string | null>(null);
 
@@ -108,9 +114,11 @@ export function SeasonComparisonAccordion({
       {/* ── ヘッダー ── */}
       <div className="flex flex-wrap items-center justify-between gap-2 border-b border-slate-100 bg-slate-50 px-5 py-3">
         <p className="text-sm font-bold text-slate-700">シーズン比較</p>
-        <span className="rounded-full bg-red-50 px-2.5 py-1 text-xs font-semibold text-red-500">
-          {currentSeason}
-        </span>
+        {showCurrentSeason && (
+          <span className="rounded-full bg-red-50 px-2.5 py-1 text-xs font-semibold text-red-500">
+            {currentSeason}
+          </span>
+        )}
       </div>
 
       {/* ── アコーディオン行 (新しい順に表示) ── */}
@@ -150,7 +158,7 @@ export function SeasonComparisonAccordion({
                   )}
                 </div>
                 <div className="flex items-center gap-2">
-                  {finisherDiff !== null && (
+                  {showCurrentSeason && finisherDiff !== null && (
                     <span
                       className={`text-xs tabular-nums ${
                         finisherAhead === null
@@ -185,8 +193,12 @@ export function SeasonComparisonAccordion({
                       <tr className="border-b border-slate-100 text-[10px] font-semibold uppercase tracking-wide text-slate-400">
                         <th className="px-4 py-2 text-left">基準点</th>
                         <th className="px-3 py-2 text-right">{season}</th>
-                        <th className="px-3 py-2 text-right text-red-400">{currentSeason}</th>
-                        <th className="px-4 py-2 text-right">差</th>
+                        {showCurrentSeason && (
+                          <th className="px-3 py-2 text-right text-red-400">{currentSeason}</th>
+                        )}
+                        {showCurrentSeason && (
+                          <th className="px-4 py-2 text-right">差</th>
+                        )}
                       </tr>
                     </thead>
                     <tbody className="divide-y divide-slate-50">
@@ -214,18 +226,22 @@ export function SeasonComparisonAccordion({
                                 <span className="text-slate-300">—</span>
                               )}
                             </td>
-                            <td className="px-3 py-2 text-right tabular-nums">
-                              {curVal !== null ? (
-                                <span className="font-semibold text-red-500">
-                                  {curVal.toFixed(1)}<span className="ml-0.5 text-[9px] font-normal text-slate-300">kg</span>
-                                </span>
-                              ) : (
-                                <span className="text-slate-300">—</span>
-                              )}
-                            </td>
-                            <td className="px-4 py-2 text-right tabular-nums">
-                              <DiffCell current={curVal} past={pastVal} isCut={isCut} />
-                            </td>
+                            {showCurrentSeason && (
+                              <td className="px-3 py-2 text-right tabular-nums">
+                                {curVal !== null ? (
+                                  <span className="font-semibold text-red-500">
+                                    {curVal.toFixed(1)}<span className="ml-0.5 text-[9px] font-normal text-slate-300">kg</span>
+                                  </span>
+                                ) : (
+                                  <span className="text-slate-300">—</span>
+                                )}
+                              </td>
+                            )}
+                            {showCurrentSeason && (
+                              <td className="px-4 py-2 text-right tabular-nums">
+                                <DiffCell current={curVal} past={pastVal} isCut={isCut} />
+                              </td>
+                            )}
                           </tr>
                         );
                       })}
@@ -238,17 +254,19 @@ export function SeasonComparisonAccordion({
         })}
       </div>
 
-      {/* ── 凡例 ── */}
-      <div className="flex flex-wrap items-center gap-4 border-t border-slate-50 bg-slate-50 px-5 py-2 text-[11px] text-slate-400">
-        <span className="flex items-center gap-1">
-          <TrendingDown size={11} className="text-emerald-600" />
-          {isCut ? "今季が前回より軽い（先行）" : "今季が前回より重い（先行）"}
-        </span>
-        <span className="flex items-center gap-1">
-          <TrendingUp size={11} className="text-amber-600" />
-          {isCut ? "今季が前回より重い（遅れ）" : "今季が前回より軽い（遅れ）"}
-        </span>
-      </div>
+      {/* ── 凡例 — Bulk 時非表示 ── */}
+      {showCurrentSeason && (
+        <div className="flex flex-wrap items-center gap-4 border-t border-slate-50 bg-slate-50 px-5 py-2 text-[11px] text-slate-400">
+          <span className="flex items-center gap-1">
+            <TrendingDown size={11} className="text-emerald-600" />
+            {isCut ? "今季が前回より軽い（先行）" : "今季が前回より重い（先行）"}
+          </span>
+          <span className="flex items-center gap-1">
+            <TrendingUp size={11} className="text-amber-600" />
+            {isCut ? "今季が前回より重い（遅れ）" : "今季が前回より軽い（遅れ）"}
+          </span>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/history/SeasonComparisonTable.tsx
+++ b/src/components/history/SeasonComparisonTable.tsx
@@ -23,6 +23,11 @@ interface SeasonComparisonTableProps {
   seasons: string[];
   currentSeason: string;
   isCut?: boolean;
+  /**
+   * true (default / Cut)  : 今季列・差列を表示
+   * false (Bulk)           : 今季列・差列を非表示（過去シーズン参照モード）
+   */
+  showCurrentSeason?: boolean;
 }
 
 // ─── ヘルパー ────────────────────────────────────────────────────────────────
@@ -91,6 +96,7 @@ export function SeasonComparisonTable({
   seasons,
   currentSeason,
   isCut = true,
+  showCurrentSeason = true,
 }: SeasonComparisonTableProps) {
   const pastSeasons = seasons.filter((s) => s !== currentSeason);
 
@@ -128,7 +134,9 @@ export function SeasonComparisonTable({
       <div className="flex flex-wrap items-center justify-between gap-2 border-b border-slate-100 bg-slate-50 px-5 py-3">
         <p className="text-sm font-bold text-slate-700">シーズン比較テーブル</p>
         <p className="text-xs text-slate-400">
-          体重は 7日移動平均 / 大会 ±3日以内の最近接値 / 差は今季 − {prevSeason}
+          {showCurrentSeason
+            ? `体重は 7日移動平均 / 大会 ±3日以内の最近接値 / 差は今季 − ${prevSeason}`
+            : "体重は 7日移動平均 / 大会 ±3日以内の最近接値（参照用）"}
         </p>
       </div>
 
@@ -152,15 +160,19 @@ export function SeasonComparisonTable({
                   {s}
                 </th>
               ))}
-              {/* 今季 (赤でハイライト) */}
-              <th className="px-3 py-2.5 text-right text-red-500">
-                {currentSeason}
-                <span className="ml-1 rounded bg-red-50 px-1 text-[9px] font-bold">今季</span>
-              </th>
-              {/* 差分列 */}
-              <th className="px-4 py-2.5 text-right text-slate-500">
-                差 (vs {prevSeason})
-              </th>
+              {/* 今季 (赤でハイライト) — Bulk 時非表示 */}
+              {showCurrentSeason && (
+                <th className="px-3 py-2.5 text-right text-red-500">
+                  {currentSeason}
+                  <span className="ml-1 rounded bg-red-50 px-1 text-[9px] font-bold">今季</span>
+                </th>
+              )}
+              {/* 差分列 — Bulk 時非表示 */}
+              {showCurrentSeason && (
+                <th className="px-4 py-2.5 text-right text-slate-500">
+                  差 (vs {prevSeason})
+                </th>
+              )}
             </tr>
           </thead>
           <tbody className="divide-y divide-slate-50">
@@ -212,27 +224,31 @@ export function SeasonComparisonTable({
                     );
                   })}
 
-                  {/* 今季の体重 */}
-                  <td className="px-3 py-2.5 text-right tabular-nums">
-                    {curVal !== null ? (
-                      <span className="font-semibold text-red-500">
-                        {curVal.toFixed(1)}
-                        <span className="ml-0.5 text-xs font-normal text-slate-300">kg</span>
-                      </span>
-                    ) : (
-                      <span className="text-slate-300">
-                        —
-                        <span className="ml-0.5 text-[10px]">
-                          {isFinisher ? "中" : "未達"}
+                  {/* 今季の体重 — Bulk 時非表示 */}
+                  {showCurrentSeason && (
+                    <td className="px-3 py-2.5 text-right tabular-nums">
+                      {curVal !== null ? (
+                        <span className="font-semibold text-red-500">
+                          {curVal.toFixed(1)}
+                          <span className="ml-0.5 text-xs font-normal text-slate-300">kg</span>
                         </span>
-                      </span>
-                    )}
-                  </td>
+                      ) : (
+                        <span className="text-slate-300">
+                          —
+                          <span className="ml-0.5 text-[10px]">
+                            {isFinisher ? "中" : "未達"}
+                          </span>
+                        </span>
+                      )}
+                    </td>
+                  )}
 
-                  {/* 差分 */}
-                  <td className="px-4 py-2.5 text-right tabular-nums">
-                    <DiffCell current={curVal} prev={prvVal} isCut={isCut} />
-                  </td>
+                  {/* 差分 — Bulk 時非表示 */}
+                  {showCurrentSeason && (
+                    <td className="px-4 py-2.5 text-right tabular-nums">
+                      <DiffCell current={curVal} prev={prvVal} isCut={isCut} />
+                    </td>
+                  )}
                 </tr>
               );
             })}
@@ -242,14 +258,18 @@ export function SeasonComparisonTable({
 
       {/* ── 凡例 ── */}
       <div className="flex flex-wrap items-center gap-4 border-t border-slate-50 bg-slate-50 px-5 py-2 text-[11px] text-slate-400">
-        <span className="flex items-center gap-1">
-          <TrendingDown size={11} className="text-emerald-600" />
-          {isCut ? "今季が前回より軽い (先行)" : "今季が前回より重い (先行)"}
-        </span>
-        <span className="flex items-center gap-1">
-          <TrendingUp size={11} className="text-amber-600" />
-          {isCut ? "今季が前回より重い (遅れ)" : "今季が前回より軽い (遅れ)"}
-        </span>
+        {showCurrentSeason && (
+          <span className="flex items-center gap-1">
+            <TrendingDown size={11} className="text-emerald-600" />
+            {isCut ? "今季が前回より軽い (先行)" : "今季が前回より重い (先行)"}
+          </span>
+        )}
+        {showCurrentSeason && (
+          <span className="flex items-center gap-1">
+            <TrendingUp size={11} className="text-amber-600" />
+            {isCut ? "今季が前回より重い (遅れ)" : "今季が前回より軽い (遅れ)"}
+          </span>
+        )}
         <span className="ml-auto">
           過去シーズン数: {pastSeasons.length} / 全 {seasons.length} シーズン
         </span>


### PR DESCRIPTION
## Summary

- Bulk フェーズ時は `currentAsCareer` を `allCareerLogs` から除外し、今季系列をグラフ・テーブルに混在させない
- `TodayWindowComparison` を `isCut` 時のみ表示（Bulk 時は大会日基準の比較が無意味なため）
- `SeasonComparisonTable` / `SeasonComparisonAccordion` に `showCurrentSeason` prop を追加し、Bulk 時は今季列・差列・凡例を非表示
- 参照モード中であることを示す amber バナーを履歴ページ上部に表示
- `isCut` 宣言を使用箇所より前に移動（TypeScript TS2448 エラー修正）

## Test plan

- [ ] `npx tsc --noEmit` がエラーなし
- [ ] `npx jest --no-coverage` が 1113 件全パス
- [ ] Cut フェーズ時: 今季列・差列・凡例・TodayWindowComparison が通常通り表示される
- [ ] Bulk フェーズ時: amber バナーが表示され、今季列・差列・凡例・TodayWindowComparison が非表示になる

Closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)