### PR TITLE
fix: use JST year for history current season fallback

### DIFF
--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -38,7 +38,7 @@ export default async function HistoryPage() {
 
   const currentSeasonLabel = settings.currentSeason
     ? settings.currentSeason
-    : `${currentLogs.at(-1)?.log_date.slice(0, 4) ?? new Date().getFullYear()}_Current`;
+    : `${currentLogs.at(-1)?.log_date.slice(0, 4) ?? toJstDateStr().slice(0, 4)}_Current`;
 
   const seasonMeta = calcSeasonMeta(careerLogs);
 


### PR DESCRIPTION
## 概要

`history/page.tsx` の現在シーズン名 fallback で使っていた `new Date().getFullYear()` を `toJstDateStr().slice(0, 4)` に置き換えます。

## 変更内容

```diff
- : `${currentLogs.at(-1)?.log_date.slice(0, 4) ?? new Date().getFullYear()}_Current`;
+ : `${currentLogs.at(-1)?.log_date.slice(0, 4) ?? toJstDateStr().slice(0, 4)}_Current`;
```

`toJstDateStr` は同ファイルの14行目ですでにインポート済みのため、import 変更は不要です。

## 影響範囲

- この fallback が踏まれる条件: `settings.currentSeason` が未設定 かつ `currentLogs`（体重ログ）が 0 件
- 実行環境が UTC の Vercel 上で JST 1月1日 00:00〜08:59 にアクセスした場合、`new Date().getFullYear()` は前年を返していたが、`toJstDateStr()` は正しく JST 年を返す

シーズン名の決定優先順位は変えていない:
1. `settings.currentSeason`（設定済みなら最優先）
2. `currentLogs.at(-1)?.log_date.slice(0, 4)`（最終ログの年）
3. `toJstDateStr().slice(0, 4)`（今回の修正箇所）

## 確認内容

- 型チェック: エラーなし
- 全テスト 1129件: 通過

## 補足

`toJstDateStr()` は `src/lib/utils/date.ts` の JST 固定実装で、UTC オフセット +9 を明示的に加算するため、Vercel（UTC）環境でも正しい JST 年を返します。

Closes #355