### PR TITLE
refactor: clarify query cast boundaries for projection and JSON payloads

### DIFF
--- a/src/lib/queries/analytics.ts
+++ b/src/lib/queries/analytics.ts
@@ -130,6 +130,8 @@ export async function fetchEnrichedLogs(
     };
   }
 
+  // 列を明示指定すると supabase-js が戻り値型を絞り込むため単純キャストで対応する。
+  // AnalyticsCache["payload"] (Json) は後続の runtime validation で具体型に絞る。
   const row = data as Pick<AnalyticsCache, "payload" | "updated_at">;
   const updatedAt = row.updated_at;
 
@@ -153,6 +155,7 @@ export async function fetchEnrichedLogs(
 
   return {
     availability: getEnrichedLogsAvailability(updatedAt, latestRawLogUpdatedAt),
+    // runtime validation 通過後: supabase JSONB の Json 型から具体的な行型へキャスト。
     rows: row.payload as unknown as EnrichedLogPayloadRow[],
     updatedAt,
   };
@@ -203,8 +206,11 @@ export async function fetchFactorAnalysis(
     };
   }
 
+  // 列を明示指定すると supabase-js が戻り値型を絞り込むため単純キャストで対応する。
+  // AnalyticsCache["payload"] (Json) は後続の runtime validation で具体型に絞る。
   const row = data as Pick<AnalyticsCache, "payload" | "updated_at">;
   const updatedAt = row.updated_at;
+  // JSONB payload を中間型で受け取り、runtime validation で shape を確認する。
   const rawPayload = row.payload as Record<string, unknown>;
 
   // runtime validation: payload は plain object でなければならない

--- a/src/lib/queries/dailyLogs.ts
+++ b/src/lib/queries/dailyLogs.ts
@@ -117,6 +117,8 @@ export async function fetchMacroDailyLogs(days = 60): Promise<QueryResult<MacroD
     console.error("[fetchMacroDailyLogs] daily_logs fetch error:", error.message, { code: error.code });
     return { kind: "error", message: error.message };
   }
+  // 列を明示指定すると supabase-js が戻り値型を絞り込むため unknown 経由でキャストする。
+  // MacroDailyLog は取得列と 1:1 対応しており、未取得列は含まない。
   const sorted = ((data as unknown as MacroDailyLog[]) ?? []).reverse();
   return { kind: "ok", data: sorted };
 }
@@ -157,6 +159,8 @@ export async function fetchTdeeDailyLogs(limit = 180): Promise<QueryResult<TdeeD
     console.error("[fetchTdeeDailyLogs] daily_logs fetch error:", error.message, { code: error.code });
     return { kind: "error", message: error.message };
   }
+  // 列を明示指定すると supabase-js が戻り値型を絞り込むため unknown 経由でキャストする。
+  // TdeeDailyLog は取得列と 1:1 対応しており、未取得列は含まない。
   const sorted = ((data as unknown as TdeeDailyLog[]) ?? []).reverse();
   return { kind: "ok", data: sorted };
 }


### PR DESCRIPTION
## Summary

- `fetchMacroDailyLogs` / `fetchTdeeDailyLogs` に projection query cast コメントを追加（`fetchDashboardDailyLogs` の既存パターンと統一）
- `analytics.ts` の 2 種類のキャストをそれぞれ意図別に明記:
  - `as Pick<AnalyticsCache, ...>`: 列指定クエリで supabase-js の型推論が絞り込まれるため単純キャストで対応
  - `as unknown as EnrichedLogPayloadRow[]`: runtime validation 通過後、JSONB の `Json` 型から具体的な行型へキャスト
  - `as Record<string, unknown>`: JSONB payload の中間型受け取り（後続 validation で shape 確認）

## Motivation

`as unknown as T` は projection query cast と JSONB payload cast の 2 種類が混在しており、理由がコメントなしでは判断しにくかった。コメントを統一し、キャストを削除できない理由を明示する。

## cast 削減の検討結果

今回は **安全に削減できる cast はなかった** と判断した。

**Projection query cast（`as unknown as`）が残る理由:**
`createClient<Database>()` を使っていても supabase-js v2 の `.select("col1, col2")` は文字列クエリのため、戻り値型が `Database["public"]["Tables"]["daily_logs"]["Row"]`（フル行型）として推論される。対して `MacroDailyLog` / `TdeeDailyLog` は `Pick<DailyLog, ...>` で定義された **より狭い型** であり、フル行型 → 狭い型への代入は TypeScript が直接受け付けない。`as T` だと型エラー、`as unknown as T` が必要。

**JSONB payload cast（`as unknown as`）が残る理由:**
supabase-js の JSONB カラムは型レベルで `Json`（= `string | number | boolean | null | Json[] | { [key: string]: Json }`）として扱われる。`EnrichedLogPayloadRow[]` は `Json` の部分型ではないため、runtime validation を通過した後でも `as unknown as` を経由するしかない。

## `supabase gen types` 再生成の確認結果

再生成しても今回のキャストは **削減されない**。

理由は 2 点:
1. `DashboardDailyLog` / `MacroDailyLog` / `TdeeDailyLog` は `types.ts` の **手書き `Pick`/`Omit` 型**。`supabase gen types` が生成するのはフル行型のみであり、これらの narrower 型は生成対象外。再生成しても projection cast の必要性は変わらない。
2. JSONB カラムの型は再生成後も `Json` のまま。payload cast も同様に残る。

なお `supabase gen types` 自体は「スキーマが変更された際に `types.ts` のフル行型定義を最新化するため」実行する価値はある（MEMORY.md の積残しタスク）。ただしキャスト削減を目的とした再生成ではないため、今回のスコープには含めていない。

Closes #356

## Test plan

- [x] `npx tsc --noEmit` — 型エラーなし
- [ ] 動作変更なし（コメント追加のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)