### PR TITLE
feat: clarify backtest result meanings on forecast accuracy page

### DIFF
--- a/src/components/charts/BacktestPolicyComparison.tsx
+++ b/src/components/charts/BacktestPolicyComparison.tsx
@@ -121,15 +121,21 @@ export function BacktestPolicyComparison({ metrics }: Props) {
           </div>
         </div>
         <p className="mt-1 text-xs text-slate-500">
-          チートデイ・旅行日と回復期間（2日）を除いた通常日の予測精度と、全日評価を比較します。
+          <span className="font-medium text-slate-600">全日</span>はイベント日を含む全サンプルで評価、
+          <span className="font-medium text-violet-600">通常日</span>はチートデイ・旅行日と回復期間（2日）を除外したサンプルで評価します。
           <strong className="text-slate-600">
-            {" "}除外件数が少ない場合は精度差を過大評価しないでください。
+            {" "}除外サンプルが少ない場合は精度差を過大評価しないでください。
           </strong>
         </p>
         {summaryRow && summaryRow.n_total > 0 && (
           <p className="mt-1 text-[11px] text-slate-400">
-            除外状況（h=7 代表）: 全 {summaryRow.n_total} 件中{" "}
-            {summaryRow.n_excluded} 件除外 → 使用 {summaryRow.n_predictions} 件
+            除外状況（h=7, NP 代表）: 評価サンプル計 {summaryRow.n_total} 件中{" "}
+            {summaryRow.n_excluded} 件除外 → 評価使用 {summaryRow.n_predictions} 件
+            {summaryRow.n_excluded === 0 && (
+              <span className="ml-1 text-slate-400">
+                ※ 手動イベント期間未設定。自動タグ (cheat/travel) のみが除外対象です。
+              </span>
+            )}
           </p>
         )}
       </div>
@@ -167,7 +173,7 @@ export function BacktestPolicyComparison({ metrics }: Props) {
                 <div>
                   <p className="mb-0.5 font-medium text-violet-600">通常日 ★</p>
                   {allExcluded ? (
-                    <p className="text-slate-400">全件除外</p>
+                    <p className="text-slate-400">全件除外（除外条件により評価対象なし）</p>
                   ) : exBest ? (
                     <>
                       <p className="font-semibold text-slate-700">
@@ -187,7 +193,8 @@ export function BacktestPolicyComparison({ metrics }: Props) {
           );
         })}
         <p className="text-[10px] text-slate-400">
-          ★ = ホライズン別最良モデル / 除外 = イベント除外評価で使われなかった予測点数
+          ★ = ホライズン別最良モデル / 件数はホライズンごとの評価サンプル数（予測点数）。実日数ではない。
+          全件除外 = 除外条件により評価対象サンプルがゼロになった状態（データ欠損ではない）。
         </p>
       </div>
 
@@ -215,7 +222,7 @@ export function BacktestPolicyComparison({ metrics }: Props) {
                     全日
                   </th>
                   <th className="px-3 py-1.5 text-center text-violet-500">通常日</th>
-                  <th className="px-2 py-1.5 text-center text-slate-400">除外数</th>
+                  <th className="px-2 py-1.5 text-center text-slate-400">除外†</th>
                 </Fragment>
               ))}
             </tr>
@@ -239,7 +246,10 @@ export function BacktestPolicyComparison({ metrics }: Props) {
                         {/* 通常日 MAE / 全件除外バッジ */}
                         <td className="px-3 py-2.5 text-center font-mono tabular-nums">
                           {allExcluded ? (
-                            <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-medium text-slate-400">
+                            <span
+                              className="rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-medium text-slate-400"
+                              title="除外条件により評価対象サンプルがゼロになった状態。データ欠損ではありません。"
+                            >
                               全件除外
                             </span>
                           ) : (
@@ -262,9 +272,9 @@ export function BacktestPolicyComparison({ metrics }: Props) {
 
       {/* ── フッター注記 ── */}
       <div className="border-t border-slate-50 bg-slate-50 px-5 py-2.5 text-[11px] text-slate-400">
-        通常日 = チートデイ (is_cheat_day) · 旅行日 (is_travel_day) と回復 2 日を除外した日。
-        全件除外 = イベント除外後に評価可能な予測点がなかった条件。
-        除外数が少ないほど比較は参考程度。
+        全日 = イベントを含む全評価サンプルで評価 / 通常日 = cheat_day · travel_day と回復 2 日を除外して評価。
+        全件除外 = 除外条件により評価対象サンプルがゼロになった状態（データ欠損ではない）。
+        † 除外数は実日数ではなくホライズンごとの評価サンプル数（予測点数）。除外数が少ないほど精度差は参考程度。
       </div>
     </div>
   );

--- a/src/components/charts/BacktestResults.tsx
+++ b/src/components/charts/BacktestResults.tsx
@@ -105,7 +105,7 @@ export function BacktestResults({ run, metrics }: Props) {
         <div className="grid grid-cols-2 gap-x-8 gap-y-1 text-xs text-slate-500 sm:grid-cols-4">
           <div><span className="font-medium text-slate-600">実行日時:</span> {fmtDate(run.created_at)}</div>
           <div><span className="font-medium text-slate-600">データ期間:</span> {run.train_min_date ?? "—"} → {run.train_max_date ?? "—"}</div>
-          <div><span className="font-medium text-slate-600">データ点数:</span> {run.n_source_rows} 件</div>
+          <div><span className="font-medium text-slate-600">ログ日数:</span> {run.n_source_rows} 日（訓練データの実日数）</div>
           <div><span className="font-medium text-slate-600">メモ:</span> {run.notes ?? "—"}</div>
         </div>
       </div>
@@ -248,7 +248,7 @@ export function BacktestResults({ run, metrics }: Props) {
                   <th className="py-1 px-2 text-right font-normal">RMSE↓</th>
                   <th className="py-1 px-2 text-right font-normal">MAPE↓</th>
                   <th className="py-1 px-2 text-right font-normal">Bias</th>
-                  <th className="py-1 px-2 text-right font-normal">n</th>
+                  <th className="py-1 px-2 text-right font-normal" title="評価サンプル数（予測点数、実日数ではない）">n†</th>
                 </React.Fragment>
               ))}
             </tr>
@@ -307,6 +307,7 @@ export function BacktestResults({ run, metrics }: Props) {
         <p className="mt-2 text-xs text-slate-400">
           MAE↓ / RMSE↓ = 小さいほど良い。<strong className="text-blue-600">太字</strong>はホライズン内最良モデル。
           Bias: 正=予測が実測より高め傾向、負=低め傾向。
+          † n = 評価サンプル数（ホライズンごとの予測点数）。上記ログ日数とは異なる。
         </p>
       </div>
 


### PR DESCRIPTION
## 関連 Issue

- 親 Issue: #368 バックテストのイベント除外 UX を実運用しやすく改善する
- 対応 Issue: #369 バックテスト結果の意味を誤解しにくい表示へ改善する
- 後続 Issue: #370 除外された日付を確認できるようにする（今回スコープ外）
- 後続 Issue: #371 手動 event period を実行しやすい導線へ改善する（今回スコープ外）

## 概要

`forecast-accuracy` 画面の比較表示について、評価件数・除外件数・全件除外の意味を初見でも理解しやすくする表示改善。ロジック変更なし。

## 変更内容

### BacktestPolicyComparison.tsx
- **ヘッダー注記の改善**: `all_days` と `exclude_flagged_plus_recovery` の定義を明示。「全日 = イベントを含む全サンプルで評価」「通常日 = cheat/travel + 回復2日を除外して評価」
- **評価サンプル数の明示**: summaryRow の表示を「評価サンプル計 N 件中 M 件除外 → 評価使用 K 件」に変更（実日数ではなく予測点数であることを明記）
- **手動イベント期間未設定の補足**: `n_excluded=0` のとき「自動タグのみが除外対象」の注記を追加
- **全件除外バッジの補足**: `title` 属性に「除外条件により評価対象サンプルがゼロになった状態。データ欠損ではありません。」を追加
- **モバイルカード全件除外**: 「全件除外（除外条件により評価対象なし）」に変更
- **モバイル脚注更新**: 「件数はホライズンごとの評価サンプル数（予測点数）。実日数ではない。」
- **フッター注記更新**: `†` 記法で「除外数は実日数ではなく評価サンプル数」を追記。全件除外とデータ欠損の区別を明示
- **テーブルヘッダー「除外数」→「除外†」**: フッター脚注と連携させ意味を補足

### BacktestResults.tsx
- **「データ点数」→「ログ日数（訓練データの実日数）」**: 評価サンプル数と混同されないよう明確化
- **詳細テーブル `n` 列 → `n†`**: `title` 属性と脚注で「評価サンプル数（予測点数）、ログ日数とは異なる」を追記

## 判断理由

- #364 で追加された比較 UI は維持しつつ、説明・ラベル・補足の追記のみで対応（差分を小さく保つ）
- 「件数は実日数か予測点数か」が最も誤読されやすい箇所のため、† 記法 + 脚注で一貫して説明
- 全件除外とデータ欠損を混同しないようにバッジ・テキスト・フッターの複数箇所で補足
- `n_excluded=0` ケースへの補足は、手動イベント期間未設定の現在の運用状況に対して必要最小限の情報

## #370 / #371 への引き継ぎ前提

- **#370（除外日一覧）**: 今回は除外された具体的な日付の表示はスコープ外。n_excluded の数値は今回で意味が明確化されたため、#370 では「どの日付が除外されたか」を追加すれば補完できる
- **#371（手動 event period 導線）**: 今回 `n_excluded=0` 時に「手動イベント期間未設定」の補足を追加済み。#371 ではそこから実行導線へのリンクや UI を追加する形で引き継げる

## テスト

- 既存の integration test 11件がすべてパス
- TypeScript 型チェック エラーなし

Closes #369