### PR TITLE
feat: add excluded dates visibility for backtest runs

### DIFF
--- a/src/app/forecast-accuracy/page.tsx
+++ b/src/app/forecast-accuracy/page.tsx
@@ -1,9 +1,11 @@
 import { BacktestResults } from "@/components/charts/BacktestResults";
 import { BacktestComparison } from "@/components/charts/BacktestComparison";
 import { BacktestPolicyComparison } from "@/components/charts/BacktestPolicyComparison";
+import { BacktestExcludedDates } from "@/components/charts/BacktestExcludedDates";
 import { ForecastAccuracyRefreshButton } from "@/components/charts/ForecastAccuracyRefreshButton";
 import { BarChart2 } from "lucide-react";
-import { fetchLatestRuns, fetchMetrics } from "@/lib/queries/backtest";
+import { fetchLatestRuns, fetchMetrics, fetchFlaggedLogsForRun } from "@/lib/queries/backtest";
+import { parseRunConfig, buildExclusionList } from "@/lib/utils/backtestExclusion";
 import { PageShell } from "@/components/ui/PageShell";
 
 export const revalidate = 3600; // 1時間キャッシュ (バッチは週1回)
@@ -64,14 +66,30 @@ export default async function ForecastAccuracyPage() {
     );
   }
 
-  // metrics を並列取得
-  const [dailyMetricsResult, sma7MetricsResult] = await Promise.all([
+  // metrics と除外日用フラグログを並列取得
+  const [dailyMetricsResult, sma7MetricsResult, flaggedLogs] = await Promise.all([
     dailyRun ? fetchMetrics(dailyRun.id) : Promise.resolve({ kind: "ok" as const, data: [] }),
     sma7Run ? fetchMetrics(sma7Run.id) : Promise.resolve({ kind: "ok" as const, data: [] }),
+    // dailyRun の除外日一覧再導出用 (ベストエフォート: 失敗しても空配列)
+    dailyRun?.train_min_date && dailyRun?.train_max_date
+      ? fetchFlaggedLogsForRun(dailyRun.train_min_date, dailyRun.train_max_date)
+      : Promise.resolve([]),
   ]);
 
   const dailyMetrics = dailyMetricsResult.kind === "ok" ? dailyMetricsResult.data : [];
   const sma7Metrics = sma7MetricsResult.kind === "ok" ? sma7MetricsResult.data : [];
+
+  // dailyRun の除外日一覧を再導出 (exclude_flagged_plus_recovery policy が存在する場合のみ表示)
+  const hasExcludePolicy = dailyMetrics.some((m) => m.eval_policy === "exclude_flagged_plus_recovery");
+  const excludedDateEntries = (() => {
+    if (!hasExcludePolicy || !dailyRun) return null;
+    const { recoveryDays, manualEventPeriods } = parseRunConfig(dailyRun.config);
+    return {
+      entries: buildExclusionList(flaggedLogs, recoveryDays, manualEventPeriods),
+      recoveryDays,
+      manualEventPeriods,
+    };
+  })();
 
   return (
     <PageShell
@@ -94,6 +112,17 @@ export default async function ForecastAccuracyPage() {
             exclude policy 行がない旧 run では BacktestPolicyComparison が null を返すため表示されない。 */}
         {dailyMetrics.length > 0 && (
           <BacktestPolicyComparison metrics={dailyMetrics} />
+        )}
+
+        {/* ── 除外対象日の確認 (#370) ──
+            exclude_flagged_plus_recovery policy が存在する run のみ表示。
+            daily_logs のフラグと run.config から除外日一覧を再導出して表示する。 */}
+        {excludedDateEntries && (
+          <BacktestExcludedDates
+            entries={excludedDateEntries.entries}
+            recoveryDays={excludedDateEntries.recoveryDays}
+            manualEventPeriods={excludedDateEntries.manualEventPeriods}
+          />
         )}
 
         {/* ── 単日評価の詳細 ── */}

--- a/src/components/charts/BacktestExcludedDates.tsx
+++ b/src/components/charts/BacktestExcludedDates.tsx
@@ -1,0 +1,210 @@
+/**
+ * BacktestExcludedDates — バックテスト除外日一覧表示
+ *
+ * forecast_backtest_runs.config と daily_logs から再導出した除外日一覧を表示する。
+ * #370 で追加: 除外件数だけでなく「どの日付が除外対象になったか」を確認できるようにする。
+ *
+ * 表示内容:
+ *   - 除外理由別の集計サマリー
+ *   - 日付 / 除外理由 / 由来 の一覧テーブル
+ *   - 除外対象日数と評価サンプル除外件数は別概念である旨の補足
+ *
+ * 除外が 0 件の場合も表示し、「フラグなし・手動期間未設定」の状態を確認できるようにする。
+ *
+ * #371 での手動 event period 実行導線追加後も、この表示は変更なしで自然に機能する
+ * (manualEventPeriods が埋まれば自動でリストに表示される)。
+ */
+
+import { CalendarX2 } from "lucide-react";
+import type { ExcludedDateEntry, ExcludedReason, ExcludedSource } from "@/lib/utils/backtestExclusion";
+
+// ── 表示定数 ──────────────────────────────────────────────────────────────
+
+const REASON_CONFIG: Record<
+  ExcludedReason,
+  { label: string; badgeClass: string }
+> = {
+  cheat_day:           { label: "チートデイ",   badgeClass: "bg-orange-100 text-orange-600" },
+  travel_day:          { label: "旅行日",        badgeClass: "bg-sky-100 text-sky-600" },
+  manual_event_period: { label: "手動イベント期間", badgeClass: "bg-violet-100 text-violet-600" },
+  recovery_day:        { label: "回復日",        badgeClass: "bg-slate-100 text-slate-500" },
+};
+
+const SOURCE_LABELS: Record<ExcludedSource, string> = {
+  daily_logs: "DBフラグ",
+  derived:    "自動付与",
+  manual:     "手動設定",
+};
+
+// ── Props ─────────────────────────────────────────────────────────────────
+
+interface Props {
+  entries: ExcludedDateEntry[];
+  recoveryDays: number;
+  manualEventPeriods: Array<{ start: string; end: string }>;
+}
+
+// ── コンポーネント ────────────────────────────────────────────────────────
+
+export function BacktestExcludedDates({
+  entries,
+  recoveryDays,
+  manualEventPeriods,
+}: Props) {
+  // 理由別集計
+  const counts: Record<ExcludedReason, number> = {
+    cheat_day:           0,
+    travel_day:          0,
+    manual_event_period: 0,
+    recovery_day:        0,
+  };
+  for (const e of entries) {
+    counts[e.reason]++;
+  }
+
+  const totalDays = entries.length;
+  const hasManualPeriods = manualEventPeriods.length > 0;
+
+  // サマリー: 0以外の理由を列挙
+  const summaryCounts = (
+    Object.entries(counts) as Array<[ExcludedReason, number]>
+  ).filter(([, n]) => n > 0);
+
+  return (
+    <details className="group overflow-hidden rounded-2xl border border-slate-100 bg-white shadow-sm">
+      {/* ── サマリー行（クリックで展開） ── */}
+      <summary className="flex cursor-pointer list-none items-center justify-between gap-3 border-b border-slate-100 bg-slate-50 px-5 py-3 [&::-webkit-details-marker]:hidden">
+        <div className="flex items-center gap-2">
+          <CalendarX2 size={15} className="flex-shrink-0 text-slate-400" />
+          <span className="text-sm font-bold text-slate-700">
+            除外対象日の確認
+          </span>
+          {totalDays > 0 ? (
+            <span className="rounded-full bg-slate-200 px-2 py-0.5 text-[11px] font-semibold text-slate-600">
+              {totalDays} 日
+            </span>
+          ) : (
+            <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-[11px] font-semibold text-emerald-600">
+              除外なし
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-3">
+          {summaryCounts.length > 0 && (
+            <div className="hidden gap-2 sm:flex">
+              {summaryCounts.map(([reason, n]) => (
+                <span
+                  key={reason}
+                  className={`rounded-full px-2 py-0.5 text-[11px] font-medium ${REASON_CONFIG[reason].badgeClass}`}
+                >
+                  {REASON_CONFIG[reason].label}: {n}
+                </span>
+              ))}
+            </div>
+          )}
+          <span className="text-xs text-slate-400 group-open:hidden">▼ 展開</span>
+          <span className="hidden text-xs text-slate-400 group-open:inline">▲ 閉じる</span>
+        </div>
+      </summary>
+
+      {/* ── 展開コンテンツ ── */}
+      <div className="divide-y divide-slate-50">
+        {/* 設定情報 */}
+        <div className="bg-slate-50/60 px-5 py-2.5 text-[11px] text-slate-500">
+          <span className="font-medium">除外条件:</span>{" "}
+          回復期間 {recoveryDays} 日 /{" "}
+          {hasManualPeriods ? (
+            <>
+              手動イベント期間{" "}
+              {manualEventPeriods.map((ep, i) => (
+                <span key={i} className="font-mono">
+                  {i > 0 && " / "}
+                  {ep.start}〜{ep.end}
+                </span>
+              ))}
+            </>
+          ) : (
+            <span>手動イベント期間 未設定（自動タグのみ対象）</span>
+          )}
+        </div>
+
+        {totalDays === 0 ? (
+          /* 除外なしの場合 */
+          <div className="px-5 py-4 text-sm text-slate-500">
+            <p>除外対象日はありません。</p>
+            <p className="mt-1 text-xs text-slate-400">
+              daily_logs に cheat_day / travel_day フラグが立っている日がなく、
+              手動イベント期間も未設定のため、除外なしで全日が評価されています。
+            </p>
+          </div>
+        ) : (
+          <>
+            {/* モバイル: シンプルリスト */}
+            <div className="md:hidden divide-y divide-slate-50">
+              {entries.map((e) => {
+                const cfg = REASON_CONFIG[e.reason];
+                return (
+                  <div key={e.date} className="flex items-center justify-between px-5 py-2.5">
+                    <span className="font-mono text-xs text-slate-700">{e.date}</span>
+                    <div className="flex items-center gap-2">
+                      <span
+                        className={`rounded-full px-2 py-0.5 text-[11px] font-medium ${cfg.badgeClass}`}
+                      >
+                        {cfg.label}
+                      </span>
+                      <span className="text-[10px] text-slate-400">
+                        {SOURCE_LABELS[e.source]}
+                      </span>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+
+            {/* デスクトップ: テーブル */}
+            <div className="hidden overflow-x-auto md:block">
+              <table className="w-full text-xs">
+                <thead>
+                  <tr className="border-b border-slate-100 bg-slate-50 text-left text-[11px] font-semibold uppercase tracking-wide text-slate-400">
+                    <th className="px-5 py-2">日付</th>
+                    <th className="px-4 py-2">除外理由</th>
+                    <th className="px-4 py-2">由来</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-50">
+                  {entries.map((e) => {
+                    const cfg = REASON_CONFIG[e.reason];
+                    return (
+                      <tr key={e.date} className="hover:bg-slate-50/60">
+                        <td className="px-5 py-2 font-mono text-slate-700">{e.date}</td>
+                        <td className="px-4 py-2">
+                          <span
+                            className={`rounded-full px-2 py-0.5 text-[11px] font-medium ${cfg.badgeClass}`}
+                          >
+                            {cfg.label}
+                          </span>
+                        </td>
+                        <td className="px-4 py-2 text-slate-400">
+                          {SOURCE_LABELS[e.source]}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </>
+        )}
+
+        {/* 補足注記 */}
+        <div className="bg-slate-50/60 px-5 py-2.5 text-[11px] text-slate-400">
+          ここに表示される「除外対象日数」は、評価ウィンドウ内の実際の日数カウントです。
+          比較テーブルの「除外†」（評価サンプル除外件数）とは異なります。
+          同じ日付でも複数の予測起点から target_date として評価される場合、
+          サンプル除外件数は日数より多くなります。
+          回復日 = イベント日直後 {recoveryDays} 日間を自動付与。
+        </div>
+      </div>
+    </details>
+  );
+}

--- a/src/lib/queries/backtest.ts
+++ b/src/lib/queries/backtest.ts
@@ -1,8 +1,10 @@
 /**
  * forecast_backtest_runs / forecast_backtest_metrics テーブルの read 責務を集約する。
  *
- * - fetchLatestRuns()   : 最新 20 件の run を取得し、daily / sma7 それぞれの最新 run を返す
- * - fetchMetrics()      : 指定 run_id のメトリクスを取得する
+ * - fetchLatestRuns()          : 最新 20 件の run を取得し、daily / sma7 それぞれの最新 run を返す
+ * - fetchMetrics()             : 指定 run_id のメトリクスを取得する
+ * - fetchFlaggedLogsForRun()   : 指定日付範囲の cheat / travel フラグ付き daily_logs を取得する
+ *                                (除外日一覧の再導出に使用)
  *
  * write 系はここに含めない。
  * UI 固有の表示文言はここに含めない。
@@ -79,4 +81,35 @@ export async function fetchMetrics(runId: string): Promise<QueryResult<ForecastB
     return { kind: "error", message: error.message };
   }
   return { kind: "ok", data: (data as ForecastBacktestMetric[]) ?? [] };
+}
+
+/**
+ * 指定日付範囲の daily_logs から cheat / travel フラグのある行を取得する。
+ *
+ * 用途: BacktestExcludedDates コンポーネントが除外日一覧を再導出するために使用する。
+ *       (除外日は DB に保存されていないため、フロント側で run.config + daily_logs から再構築する)
+ *
+ * ベストエフォート: エラー時は空配列を返しページをブロックしない。
+ * 意図的に QueryResult 化しない: 除外日一覧表示は補助情報であり、失敗してもページ全体に影響しない。
+ *
+ * @param minDate - 取得開始日 (YYYY-MM-DD、含む)
+ * @param maxDate - 取得終了日 (YYYY-MM-DD、含む)
+ */
+export async function fetchFlaggedLogsForRun(
+  minDate: string,
+  maxDate: string,
+): Promise<Array<{ log_date: string; is_cheat_day: boolean | null; is_travel_day: boolean | null }>> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("daily_logs")
+    .select("log_date, is_cheat_day, is_travel_day")
+    .gte("log_date", minDate)
+    .lte("log_date", maxDate)
+    .order("log_date", { ascending: true });
+
+  if (error) {
+    console.error("[fetchFlaggedLogsForRun] daily_logs fetch error:", error.message);
+    return [];
+  }
+  return (data as Array<{ log_date: string; is_cheat_day: boolean | null; is_travel_day: boolean | null }>) ?? [];
 }

--- a/src/lib/utils/backtestExclusion.test.ts
+++ b/src/lib/utils/backtestExclusion.test.ts
@@ -1,0 +1,220 @@
+/**
+ * backtestExclusion.ts のユニットテスト
+ *
+ * Python の build_exclusion_dates() と同等の動作を検証する。
+ */
+
+import {
+  buildExclusionList,
+  parseRunConfig,
+  type ExcludedDateEntry,
+} from "./backtestExclusion";
+import type { Json } from "@/lib/supabase/types";
+
+// ── parseRunConfig ────────────────────────────────────────────────────────
+
+describe("parseRunConfig", () => {
+  it("正常な config から各フィールドを抽出できる", () => {
+    const config: Json = {
+      recovery_days: 3,
+      manual_event_periods: [
+        { start: "2026-02-01", end: "2026-02-05" },
+      ],
+      eval_policies: ["all_days", "exclude_flagged_plus_recovery"],
+    };
+    const result = parseRunConfig(config);
+    expect(result.recoveryDays).toBe(3);
+    expect(result.manualEventPeriods).toEqual([
+      { start: "2026-02-01", end: "2026-02-05" },
+    ]);
+    expect(result.evalPolicies).toEqual([
+      "all_days",
+      "exclude_flagged_plus_recovery",
+    ]);
+  });
+
+  it("recovery_days が欠損している場合はデフォルト 2 を使う", () => {
+    const config: Json = { eval_policies: ["all_days"] };
+    const result = parseRunConfig(config);
+    expect(result.recoveryDays).toBe(2);
+  });
+
+  it("manual_event_periods が空配列の場合は空を返す", () => {
+    const config: Json = { manual_event_periods: [] };
+    const result = parseRunConfig(config);
+    expect(result.manualEventPeriods).toEqual([]);
+  });
+
+  it("config が null の場合はデフォルト値を返す", () => {
+    const result = parseRunConfig(null);
+    expect(result.recoveryDays).toBe(2);
+    expect(result.manualEventPeriods).toEqual([]);
+    expect(result.evalPolicies).toEqual([]);
+  });
+
+  it("manual_event_periods 内に不正なエントリが含まれても無視する", () => {
+    const config: Json = {
+      manual_event_periods: [
+        { start: "2026-01-01", end: "2026-01-03" },
+        { start: 12345 },            // 不正: start が number
+        null,                        // 不正: null エントリ
+        { start: "2026-02-01" },     // 不正: end 欠損
+      ],
+    };
+    const result = parseRunConfig(config);
+    expect(result.manualEventPeriods).toEqual([
+      { start: "2026-01-01", end: "2026-01-03" },
+    ]);
+  });
+});
+
+// ── buildExclusionList ────────────────────────────────────────────────────
+
+describe("buildExclusionList", () => {
+  it("フラグなし・手動期間なしの場合は空配列を返す", () => {
+    const logs = [
+      { log_date: "2026-01-01", is_cheat_day: false, is_travel_day: false },
+      { log_date: "2026-01-02", is_cheat_day: null,  is_travel_day: null },
+    ];
+    const result = buildExclusionList(logs, 2, []);
+    expect(result).toHaveLength(0);
+  });
+
+  it("cheat_day の当日と回復日 (recoveryDays 日分) を除外する", () => {
+    const logs = [
+      { log_date: "2026-01-05", is_cheat_day: true, is_travel_day: false },
+    ];
+    const result = buildExclusionList(logs, 2, []);
+    // 当日 + 回復 2 日 = 3 件
+    expect(result).toHaveLength(3);
+
+    const cheat = result.find((e) => e.date === "2026-01-05");
+    expect(cheat?.reason).toBe("cheat_day");
+    expect(cheat?.source).toBe("daily_logs");
+
+    const rec1 = result.find((e) => e.date === "2026-01-06");
+    expect(rec1?.reason).toBe("recovery_day");
+    expect(rec1?.source).toBe("derived");
+
+    const rec2 = result.find((e) => e.date === "2026-01-07");
+    expect(rec2?.reason).toBe("recovery_day");
+    expect(rec2?.source).toBe("derived");
+  });
+
+  it("travel_day の当日と回復日を除外する", () => {
+    const logs = [
+      { log_date: "2026-02-10", is_cheat_day: false, is_travel_day: true },
+    ];
+    const result = buildExclusionList(logs, 2, []);
+    expect(result).toHaveLength(3);
+
+    const travel = result.find((e) => e.date === "2026-02-10");
+    expect(travel?.reason).toBe("travel_day");
+    expect(travel?.source).toBe("daily_logs");
+  });
+
+  it("手動 event period の全日と end 後の回復日を除外する", () => {
+    const result = buildExclusionList(
+      [],
+      2,
+      [{ start: "2026-03-01", end: "2026-03-03" }],
+    );
+    // 期間内 3 日 + 回復 2 日 = 5 件
+    expect(result).toHaveLength(5);
+
+    expect(result.find((e) => e.date === "2026-03-01")?.reason).toBe("manual_event_period");
+    expect(result.find((e) => e.date === "2026-03-01")?.source).toBe("manual");
+    expect(result.find((e) => e.date === "2026-03-04")?.reason).toBe("recovery_day");
+    expect(result.find((e) => e.date === "2026-03-05")?.reason).toBe("recovery_day");
+    // 回復 2 日のみ (3 日目は含まれない)
+    expect(result.find((e) => e.date === "2026-03-06")).toBeUndefined();
+  });
+
+  it("結果は日付昇順でソートされる", () => {
+    const logs = [
+      { log_date: "2026-01-10", is_cheat_day: true, is_travel_day: false },
+      { log_date: "2026-01-05", is_cheat_day: true, is_travel_day: false },
+    ];
+    const result = buildExclusionList(logs, 1, []);
+    const dates = result.map((e) => e.date);
+    expect(dates).toEqual([...dates].sort());
+  });
+
+  it("cheat_day と recovery_day が同日に重複する場合は cheat_day が優先される", () => {
+    // 2026-01-05 が cheat_day で、2026-01-06 が回復日
+    // 2026-01-06 も別の cheat_day の当日なら cheat_day が優先
+    const logs = [
+      { log_date: "2026-01-05", is_cheat_day: true,  is_travel_day: false },
+      { log_date: "2026-01-06", is_cheat_day: true,  is_travel_day: false },
+    ];
+    const result = buildExclusionList(logs, 2, []);
+    const jan06 = result.find((e) => e.date === "2026-01-06");
+    // 2026-01-06 は 01-05 の回復日だが、自身も cheat_day なので cheat_day が優先
+    expect(jan06?.reason).toBe("cheat_day");
+    expect(jan06?.source).toBe("daily_logs");
+  });
+
+  it("travel_day は recovery_day より優先される", () => {
+    // 2026-01-05 が cheat_day → 回復日: 01-06, 01-07
+    // 2026-01-06 が travel_day → travel_day が優先
+    const logs = [
+      { log_date: "2026-01-05", is_cheat_day: true,  is_travel_day: false },
+      { log_date: "2026-01-06", is_cheat_day: false, is_travel_day: true },
+    ];
+    const result = buildExclusionList(logs, 2, []);
+    const jan06 = result.find((e) => e.date === "2026-01-06");
+    expect(jan06?.reason).toBe("travel_day");
+  });
+
+  it("cheat_day は manual_event_period より優先される", () => {
+    const logs = [
+      { log_date: "2026-02-05", is_cheat_day: true, is_travel_day: false },
+    ];
+    const result = buildExclusionList(
+      logs,
+      2,
+      [{ start: "2026-02-03", end: "2026-02-07" }],
+    );
+    const feb05 = result.find((e) => e.date === "2026-02-05");
+    // manual_event_period 範囲内だが cheat_day が優先
+    expect(feb05?.reason).toBe("cheat_day");
+  });
+
+  it("recoveryDays=0 の場合はイベント当日のみ除外する", () => {
+    const logs = [
+      { log_date: "2026-01-15", is_cheat_day: true, is_travel_day: false },
+    ];
+    const result = buildExclusionList(logs, 0, []);
+    expect(result).toHaveLength(1);
+    const entry = result[0] as ExcludedDateEntry;
+    expect(entry.date).toBe("2026-01-15");
+    expect(entry.reason).toBe("cheat_day");
+  });
+
+  it("複数の手動 event period を正しく処理する", () => {
+    const result = buildExclusionList(
+      [],
+      1,
+      [
+        { start: "2026-01-01", end: "2026-01-02" }, // 2日 + 回復1日
+        { start: "2026-02-10", end: "2026-02-10" }, // 1日 + 回復1日
+      ],
+    );
+    // 2026-01-01, 01-02, 01-03(回復), 02-10, 02-11(回復) = 5件
+    expect(result).toHaveLength(5);
+    expect(result.find((e) => e.date === "2026-01-01")?.reason).toBe("manual_event_period");
+    expect(result.find((e) => e.date === "2026-01-03")?.reason).toBe("recovery_day");
+    expect(result.find((e) => e.date === "2026-02-10")?.reason).toBe("manual_event_period");
+    expect(result.find((e) => e.date === "2026-02-11")?.reason).toBe("recovery_day");
+  });
+
+  it("重複カウントせず一意な日付エントリを返す", () => {
+    // cheat_day と travel_day が同日: 1エントリのみ
+    const logs = [
+      { log_date: "2026-01-20", is_cheat_day: true, is_travel_day: true },
+    ];
+    const result = buildExclusionList(logs, 2, []);
+    const jan20 = result.filter((e) => e.date === "2026-01-20");
+    expect(jan20).toHaveLength(1);
+  });
+});

--- a/src/lib/utils/backtestExclusion.ts
+++ b/src/lib/utils/backtestExclusion.ts
@@ -1,0 +1,185 @@
+/**
+ * backtestExclusion.ts — バックテスト除外日一覧の再導出ユーティリティ
+ *
+ * Python の backtest.py `build_exclusion_dates()` を TypeScript に移植したもの。
+ * forecast_backtest_runs.config と daily_logs のフラグから除外日一覧を再構築する。
+ *
+ * 除外日は DB に保存されていないため、フロント側で再導出する方式を採用している。
+ * Python 側のロジックと一致を保つこと。
+ *
+ * 優先度 (同日が複数理由に該当する場合):
+ *   cheat_day > travel_day > manual_event_period > recovery_day
+ */
+
+import type { Json } from "@/lib/supabase/types";
+
+// ── 型定義 ──────────────────────────────────────────────────────────────────
+
+export type ExcludedReason =
+  | "cheat_day"
+  | "travel_day"
+  | "manual_event_period"
+  | "recovery_day";
+
+export type ExcludedSource =
+  | "daily_logs"   // daily_logs の is_cheat_day / is_travel_day フラグ由来
+  | "derived"      // イベント日後の回復日として自動付与
+  | "manual";      // --event-periods 引数で手動指定された期間
+
+export type ExcludedDateEntry = {
+  date: string;          // "YYYY-MM-DD"
+  reason: ExcludedReason;
+  source: ExcludedSource;
+};
+
+// ── run.config パース ──────────────────────────────────────────────────────
+
+const DEFAULT_RECOVERY_DAYS = 2;
+
+export type ParsedRunConfig = {
+  recoveryDays: number;
+  manualEventPeriods: Array<{ start: string; end: string }>;
+  evalPolicies: string[];
+};
+
+/**
+ * forecast_backtest_runs.config から除外日計算に必要なフィールドを安全に取り出す。
+ * フィールド不在や型不整合は graceful fallback する。
+ */
+export function parseRunConfig(config: Json): ParsedRunConfig {
+  if (config === null || typeof config !== "object" || Array.isArray(config)) {
+    return {
+      recoveryDays: DEFAULT_RECOVERY_DAYS,
+      manualEventPeriods: [],
+      evalPolicies: [],
+    };
+  }
+  const obj = config as Record<string, Json>;
+
+  const recoveryDays =
+    typeof obj["recovery_days"] === "number"
+      ? obj["recovery_days"]
+      : DEFAULT_RECOVERY_DAYS;
+
+  const manualEventPeriods: Array<{ start: string; end: string }> = [];
+  const rawPeriods = obj["manual_event_periods"];
+  if (Array.isArray(rawPeriods)) {
+    for (const p of rawPeriods) {
+      if (p !== null && typeof p === "object" && !Array.isArray(p)) {
+        const po = p as Record<string, Json>;
+        if (typeof po["start"] === "string" && typeof po["end"] === "string") {
+          manualEventPeriods.push({ start: po["start"], end: po["end"] });
+        }
+      }
+    }
+  }
+
+  const rawPolicies = obj["eval_policies"];
+  const evalPolicies: string[] = Array.isArray(rawPolicies)
+    ? rawPolicies.filter((p): p is string => typeof p === "string")
+    : [];
+
+  return { recoveryDays, manualEventPeriods, evalPolicies };
+}
+
+// ── 日付計算ヘルパー ──────────────────────────────────────────────────────
+
+/** YYYY-MM-DD 文字列に n 日加算した文字列を返す。タイムゾーン非依存。 */
+function addDays(dateStr: string, n: number): string {
+  const parts = dateStr.split("-").map(Number);
+  const y = parts[0] ?? 2000;
+  const m = parts[1] ?? 1;
+  const d = parts[2] ?? 1;
+  const dt = new Date(y, m - 1, d + n);
+  const yyyy = dt.getFullYear();
+  const mm = String(dt.getMonth() + 1).padStart(2, "0");
+  const dd = String(dt.getDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+/** start から end（含む）まで 1 日刻みで日付文字列を yield する。 */
+function* dateRange(start: string, end: string): Generator<string> {
+  let cur = start;
+  while (cur <= end) {
+    yield cur;
+    cur = addDays(cur, 1);
+  }
+}
+
+// ── メイン関数 ────────────────────────────────────────────────────────────
+
+const REASON_PRIORITY: ExcludedReason[] = [
+  "cheat_day",
+  "travel_day",
+  "manual_event_period",
+  "recovery_day",
+];
+
+/**
+ * Python の build_exclusion_dates() と同等のロジックで除外日一覧を構築する。
+ *
+ * 除外対象:
+ *   1. is_cheat_day=true の日 + 後続 recoveryDays 日間
+ *   2. is_travel_day=true の日 + 後続 recoveryDays 日間
+ *   3. manualEventPeriods の各期間 + end 後 recoveryDays 日間
+ *
+ * 同日が複数の理由に該当する場合は REASON_PRIORITY の昇順（優先度高）で記録する。
+ */
+export function buildExclusionList(
+  dailyLogs: Array<{
+    log_date: string;
+    is_cheat_day: boolean | null;
+    is_travel_day: boolean | null;
+  }>,
+  recoveryDays: number,
+  manualEventPeriods: Array<{ start: string; end: string }>,
+): ExcludedDateEntry[] {
+  const map = new Map<string, ExcludedDateEntry>();
+
+  function set(date: string, reason: ExcludedReason, source: ExcludedSource) {
+    const existing = map.get(date);
+    if (
+      !existing ||
+      REASON_PRIORITY.indexOf(reason) < REASON_PRIORITY.indexOf(existing.reason)
+    ) {
+      map.set(date, { date, reason, source });
+    }
+  }
+
+  function addWithRecovery(
+    eventDate: string,
+    eventReason: Exclude<ExcludedReason, "recovery_day">,
+    eventSource: ExcludedSource,
+  ) {
+    set(eventDate, eventReason, eventSource);
+    for (let i = 1; i <= recoveryDays; i++) {
+      set(addDays(eventDate, i), "recovery_day", "derived");
+    }
+  }
+
+  // 1. is_cheat_day 由来
+  for (const log of dailyLogs) {
+    if (log.is_cheat_day) {
+      addWithRecovery(log.log_date, "cheat_day", "daily_logs");
+    }
+  }
+
+  // 2. is_travel_day 由来
+  for (const log of dailyLogs) {
+    if (log.is_travel_day) {
+      addWithRecovery(log.log_date, "travel_day", "daily_logs");
+    }
+  }
+
+  // 3. 手動 event period 由来
+  for (const ep of manualEventPeriods) {
+    for (const d of dateRange(ep.start, ep.end)) {
+      set(d, "manual_event_period", "manual");
+    }
+    for (let i = 1; i <= recoveryDays; i++) {
+      set(addDays(ep.end, i), "recovery_day", "derived");
+    }
+  }
+
+  return Array.from(map.values()).sort((a, b) => a.date.localeCompare(b.date));
+}


### PR DESCRIPTION
## 関連 Issue

- 親 Issue: #368 バックテストのイベント除外 UX を実運用しやすく改善する
- 前提 Issue: #369 バックテスト結果の意味を誤解しにくい表示へ改善する（マージ済み）
- 対応 Issue: #370 バックテストで除外された日付を確認できるようにする
- 後続 Issue: #371 手動 event period を実行しやすい導線へ改善する

## 概要

バックテスト run ごとに「どの日付が除外対象になったか」を forecast-accuracy 画面で確認できるようにする。

除外日は DB に保存されていないため、`daily_logs` の cheat/travel フラグと `run.config` の `recovery_days` / `manual_event_periods` からフロント側で再導出する方式を採用した。Python の `build_exclusion_dates()` と同等のロジックを TypeScript に移植している。

## 変更内容

### `src/lib/utils/backtestExclusion.ts` (新規)
- `buildExclusionList()`: Python `build_exclusion_dates()` の TypeScript 移植。date / reason / source 付きで除外日一覧を返す
  - reason: `cheat_day` / `travel_day` / `manual_event_period` / `recovery_day`
  - source: `daily_logs` / `derived` / `manual`
  - 優先度: cheat_day > travel_day > manual_event_period > recovery_day（同日重複時）
- `parseRunConfig()`: `run.config` (Json) から `recoveryDays` / `manualEventPeriods` / `evalPolicies` を安全に抽出

### `src/lib/queries/backtest.ts`
- `fetchFlaggedLogsForRun(minDate, maxDate)` を追加: 指定日付範囲の `log_date`, `is_cheat_day`, `is_travel_day` のみ軽量取得。ベストエフォート（失敗時は空配列）

### `src/components/charts/BacktestExcludedDates.tsx` (新規)
- `<details>/<summary>` による折り畳み可能なコンポーネント（JS 不要）
- 除外理由バッジ（色分け）と由来（DBフラグ / 自動付与 / 手動設定）を表示
- 除外 0 件の場合も「フラグなし・手動期間未設定」と明示
- 除外対象日数と評価サンプル除外件数が別概念であることを補足

### `src/app/forecast-accuracy/page.tsx`
- `fetchFlaggedLogsForRun` と metrics を並列取得
- `exclude_flagged_plus_recovery` policy が存在する run のみ `BacktestExcludedDates` を表示
- `BacktestPolicyComparison` の直後に配置

### `src/lib/utils/backtestExclusion.test.ts` (新規)
- 16 件のユニットテスト（parseRunConfig / buildExclusionList）

## 判断理由

- DB 変更なし・既存 run にも対応する方式として「フロント側再導出」を採用
- `run.config` に `recovery_days` / `manual_event_periods` が保存済みのため、再導出に必要な情報がすでに揃っている
- `fetchFlaggedLogsForRun` はベストエフォートとし、失敗しても除外日一覧が表示されないだけでページはブロックしない
- `<details>/<summary>` で折り畳み可能にし、通常は閉じた状態でコンテンツ量を抑える

## #371 への引き継ぎ

- 手動 event period が `run.config.manual_event_periods` に記録されれば、今回の表示は変更なしで自動的に反映される
- `BacktestExcludedDates` には「手動イベント期間未設定」の状態表示も実装済みのため、#371 での実行導線追加後の Before/After が自然に比較できる

## テスト

- `backtestExclusion.test.ts`: 16 件パス
- `BacktestResults.integration.test.tsx`: 11 件パス（既存テスト全通過）
- TypeScript 型チェック: エラーなし

Closes #370