### PR TITLE
feat: add manual event period workflow inputs for backtests

### DIFF
--- a/.github/workflows/ml-backtest.yml
+++ b/.github/workflows/ml-backtest.yml
@@ -5,7 +5,32 @@ on:
   # 日次バッチ(ml-daily.yml)より後に起動して最新データを使う
   schedule:
     - cron: "0 19 * * 5"
-  workflow_dispatch: # 手動実行も可能
+
+  # 手動実行。manual event period を指定して backtest を再実行する場合に使用する。
+  # スケジュール実行は入力なしで常にデフォルト動作を維持する。
+  workflow_dispatch:
+    inputs:
+      enable_manual_event_period:
+        description: '手動イベント期間を除外対象に追加する (true にすると start_date / end_date が有効になる)'
+        type: boolean
+        default: false
+        required: true
+      start_date:
+        description: '除外開始日 (YYYY-MM-DD) — enable_manual_event_period=true の場合に有効'
+        type: string
+        default: ''
+      end_date:
+        description: '除外終了日 (YYYY-MM-DD, 開始日以降) — enable_manual_event_period=true の場合に有効'
+        type: string
+        default: ''
+      recovery_days:
+        description: 'イベント日後の回復期間 (日数, デフォルト 2) — cheat/travel フラグにも適用される'
+        type: string
+        default: '2'
+      reason:
+        description: 'イベント内容メモ (例: 遠征 / 海外旅行 / チートウィーク) — スペースはアンダースコア推奨'
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -28,9 +53,44 @@ jobs:
       - name: Install dependencies
         run: pip install -r ml-pipeline/requirements.txt
 
+      # workflow_dispatch 時のみ追加 CLI 引数を組み立てる。
+      # schedule 実行時は github.event_name == "schedule" のため EXTRA_ARGS は空になり、
+      # 通常の週次実行と全く同じ挙動を維持する。
+      - name: Build extra backtest args (workflow_dispatch only)
+        id: build_args
+        shell: bash
+        run: |
+          EXTRA_ARGS=""
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            # recovery_days: デフォルト (2) 以外が指定された場合のみ追加
+            RECOVERY="${{ inputs.recovery_days }}"
+            if [[ -n "$RECOVERY" && "$RECOVERY" != "2" ]]; then
+              EXTRA_ARGS="--recovery-days $RECOVERY"
+            fi
+
+            # manual event period: enable フラグが true かつ開始・終了日が指定された場合のみ追加
+            if [[ "${{ inputs.enable_manual_event_period }}" == "true" ]]; then
+              START="${{ inputs.start_date }}"
+              END="${{ inputs.end_date }}"
+              # スペースをアンダースコアに変換してシェル展開を安全にする
+              REASON=$(echo "${{ inputs.reason }}" | tr ' ' '_')
+              if [[ -n "$START" && -n "$END" ]]; then
+                if [[ -n "$REASON" ]]; then
+                  EXTRA_ARGS="$EXTRA_ARGS --event-periods ${START}:${END}:${REASON}"
+                else
+                  EXTRA_ARGS="$EXTRA_ARGS --event-periods ${START}:${END}"
+                fi
+              else
+                echo "::warning::enable_manual_event_period=true ですが start_date または end_date が未指定です。manual event period は追加されません。"
+              fi
+            fi
+          fi
+          echo "extra_args=$EXTRA_ARGS" >> "$GITHUB_OUTPUT"
+          echo "Backtest extra_args: '$EXTRA_ARGS'"
+
       - name: Run forecast backtest (daily)
-        run: python ml-pipeline/backtest.py
+        run: python ml-pipeline/backtest.py ${{ steps.build_args.outputs.extra_args }}
         continue-on-error: true
 
       - name: Run forecast backtest (sma7)
-        run: python ml-pipeline/backtest.py --series-type sma7
+        run: python ml-pipeline/backtest.py --series-type sma7 ${{ steps.build_args.outputs.extra_args }}

--- a/ml-pipeline/backtest.py
+++ b/ml-pipeline/backtest.py
@@ -128,20 +128,27 @@ class ManualEventPeriod:
     フィールド:
       start_date : イベント開始日 (含む)
       end_date   : イベント終了日 (含む)。start_date <= end_date であること。
+      reason     : イベント内容メモ (任意)。run.config に記録され除外日一覧で確認できる。
+                   例: "遠征", "海外旅行", "チートウィーク"
     """
     start_date: date
     end_date: date
+    reason: str = ""
 
 
 def parse_event_period(s: str) -> ManualEventPeriod:
-    """'YYYY-MM-DD:YYYY-MM-DD' 形式の文字列を ManualEventPeriod に変換する。
+    """'YYYY-MM-DD:YYYY-MM-DD' または 'YYYY-MM-DD:YYYY-MM-DD:REASON' 形式の文字列を
+    ManualEventPeriod に変換する。
 
     CLI の --event-periods 引数パーサとして使用する。
+    REASON は省略可能。空白はアンダースコアで代替するとシェル展開の問題を避けられる。
+    REASON にコロンを含めることはできない。
     """
-    parts = s.split(":")
-    if len(parts) != 2:
+    parts = s.split(":", 2)  # 最大 2 分割 → ["START", "END"] or ["START", "END", "REASON"]
+    if len(parts) < 2:
         raise argparse.ArgumentTypeError(
-            f"イベント期間は 'START:END' 形式で指定してください (例: 2026-03-01:2026-03-10). 受け取った値: {s!r}"
+            f"イベント期間は 'START:END' または 'START:END:REASON' 形式で指定してください "
+            f"(例: 2026-03-01:2026-03-10). 受け取った値: {s!r}"
         )
     try:
         start = date.fromisoformat(parts[0].strip())
@@ -154,7 +161,8 @@ def parse_event_period(s: str) -> ManualEventPeriod:
         raise argparse.ArgumentTypeError(
             f"start_date ({start}) は end_date ({end}) 以前である必要があります"
         )
-    return ManualEventPeriod(start_date=start, end_date=end)
+    reason = parts[2].strip() if len(parts) > 2 else ""
+    return ManualEventPeriod(start_date=start, end_date=end, reason=reason)
 
 
 # ── 実験 config ─────────────────────────────────────────────────────────────────
@@ -787,7 +795,11 @@ def save_results(
             "eval_policies":           config.eval_policies,
             "recovery_days":           config.recovery_days,
             "manual_event_periods": [
-                {"start": ep.start_date.isoformat(), "end": ep.end_date.isoformat()}
+                {
+                    "start": ep.start_date.isoformat(),
+                    "end":   ep.end_date.isoformat(),
+                    **( {"reason": ep.reason} if ep.reason else {} ),
+                }
                 for ep in config.manual_event_periods
             ],
         },

--- a/ml-pipeline/test_backtest.py
+++ b/ml-pipeline/test_backtest.py
@@ -552,6 +552,7 @@ class TestManualEventPeriod:
         ep = parse_event_period("2026-03-01:2026-03-10")
         assert ep.start_date == date(2026, 3, 1)
         assert ep.end_date   == date(2026, 3, 10)
+        assert ep.reason == ""  # reason 未指定はデフォルト空文字
 
     def test_parse_single_day_period(self):
         ep = parse_event_period("2026-04-05:2026-04-05")
@@ -562,6 +563,23 @@ class TestManualEventPeriod:
         ep = parse_event_period(" 2026-03-01 : 2026-03-10 ")
         assert ep.start_date == date(2026, 3, 1)
         assert ep.end_date   == date(2026, 3, 10)
+
+    def test_parse_with_reason(self):
+        """START:END:REASON 形式で reason が正しくパースされる。"""
+        ep = parse_event_period("2026-03-01:2026-03-10:遠征")
+        assert ep.start_date == date(2026, 3, 1)
+        assert ep.end_date   == date(2026, 3, 10)
+        assert ep.reason     == "遠征"
+
+    def test_parse_with_reason_underscores(self):
+        """reason にアンダースコアが含まれても正常にパースされる (スペース代替)。"""
+        ep = parse_event_period("2026-04-01:2026-04-07:海外旅行_7日間")
+        assert ep.reason == "海外旅行_7日間"
+
+    def test_parse_with_reason_strips_whitespace(self):
+        """reason の前後スペースはトリムされる。"""
+        ep = parse_event_period("2026-03-01:2026-03-05: チートウィーク ")
+        assert ep.reason == "チートウィーク"
 
     def test_parse_invalid_format_raises(self):
         import argparse as _ap

--- a/src/components/charts/BacktestExcludedDates.tsx
+++ b/src/components/charts/BacktestExcludedDates.tsx
@@ -41,7 +41,8 @@ const SOURCE_LABELS: Record<ExcludedSource, string> = {
 interface Props {
   entries: ExcludedDateEntry[];
   recoveryDays: number;
-  manualEventPeriods: Array<{ start: string; end: string }>;
+  /** reason は #371 で追加されたオプションフィールド。旧 run には存在しない場合がある。 */
+  manualEventPeriods: Array<{ start: string; end: string; reason?: string }>;
 }
 
 // ── コンポーネント ────────────────────────────────────────────────────────
@@ -120,6 +121,11 @@ export function BacktestExcludedDates({
                 <span key={i} className="font-mono">
                   {i > 0 && " / "}
                   {ep.start}〜{ep.end}
+                  {ep.reason && (
+                    <span className="ml-1 font-sans not-italic text-violet-600">
+                      ({ep.reason})
+                    </span>
+                  )}
                 </span>
               ))}
             </>

--- a/src/lib/utils/backtestExclusion.test.ts
+++ b/src/lib/utils/backtestExclusion.test.ts
@@ -33,6 +33,41 @@ describe("parseRunConfig", () => {
     ]);
   });
 
+  it("manual_event_periods に reason フィールドがある場合は抽出できる", () => {
+    const config: Json = {
+      manual_event_periods: [
+        { start: "2026-03-01", end: "2026-03-10", reason: "遠征" },
+      ],
+    };
+    const result = parseRunConfig(config);
+    expect(result.manualEventPeriods).toEqual([
+      { start: "2026-03-01", end: "2026-03-10", reason: "遠征" },
+    ]);
+  });
+
+  it("reason が空文字の場合は reason フィールドなしで返す (falsy 除外)", () => {
+    const config: Json = {
+      manual_event_periods: [
+        { start: "2026-03-01", end: "2026-03-05", reason: "" },
+      ],
+    };
+    const result = parseRunConfig(config);
+    // reason が空文字はプロパティ自体を含まない
+    expect(result.manualEventPeriods[0]).not.toHaveProperty("reason");
+  });
+
+  it("旧 run (reason なし) と新 run (reason あり) が混在しても正しく処理する", () => {
+    const config: Json = {
+      manual_event_periods: [
+        { start: "2026-01-01", end: "2026-01-05" },             // 旧 run 形式
+        { start: "2026-02-01", end: "2026-02-05", reason: "旅行" }, // 新 run 形式
+      ],
+    };
+    const result = parseRunConfig(config);
+    expect(result.manualEventPeriods[0]).not.toHaveProperty("reason");
+    expect(result.manualEventPeriods[1]?.reason).toBe("旅行");
+  });
+
   it("recovery_days が欠損している場合はデフォルト 2 を使う", () => {
     const config: Json = { eval_policies: ["all_days"] };
     const result = parseRunConfig(config);

--- a/src/lib/utils/backtestExclusion.ts
+++ b/src/lib/utils/backtestExclusion.ts
@@ -38,7 +38,8 @@ const DEFAULT_RECOVERY_DAYS = 2;
 
 export type ParsedRunConfig = {
   recoveryDays: number;
-  manualEventPeriods: Array<{ start: string; end: string }>;
+  /** reason は #371 で追加された任意フィールド。旧 run には存在しない場合がある。 */
+  manualEventPeriods: Array<{ start: string; end: string; reason?: string }>;
   evalPolicies: string[];
 };
 
@@ -68,7 +69,11 @@ export function parseRunConfig(config: Json): ParsedRunConfig {
       if (p !== null && typeof p === "object" && !Array.isArray(p)) {
         const po = p as Record<string, Json>;
         if (typeof po["start"] === "string" && typeof po["end"] === "string") {
-          manualEventPeriods.push({ start: po["start"], end: po["end"] });
+          manualEventPeriods.push({
+            start: po["start"],
+            end: po["end"],
+            ...(typeof po["reason"] === "string" && po["reason"] ? { reason: po["reason"] } : {}),
+          });
         }
       }
     }
@@ -132,7 +137,7 @@ export function buildExclusionList(
     is_travel_day: boolean | null;
   }>,
   recoveryDays: number,
-  manualEventPeriods: Array<{ start: string; end: string }>,
+  manualEventPeriods: Array<{ start: string; end: string; reason?: string }>,
 ): ExcludedDateEntry[] {
   const map = new Map<string, ExcludedDateEntry>();
 


### PR DESCRIPTION
## 関連 Issue

- 親 Issue: #368 バックテストのイベント除外 UX を実運用しやすく改善する
- 前提 Issue: #369 バックテスト結果の意味を誤解しにくい表示へ改善する（マージ済み）
- 前提 Issue: #370 バックテストで除外された日付を確認できるようにする（マージ済み）
- 対応 Issue: #371 手動 event period を実行しやすい導線へ改善する

## 概要

GitHub Actions の手動実行フォームから manual event period を指定してバックテストを再実行できるようにする。
これにより「CLI 依存」だった手動除外指定が、GitHub 上のフォームからほぼワンクリックで実行できる導線になる。

**週次スケジュール実行への影響はゼロ。** `github.event_name == "schedule"` 時は `EXTRA_ARGS` が常に空になり、従来通りの通常実行を維持する。

## 変更内容

### `.github/workflows/ml-backtest.yml`
- `workflow_dispatch.inputs` に以下のフィールドを追加:
  - `enable_manual_event_period` (boolean, デフォルト false): 手動期間除外の有効化スイッチ
  - `start_date` (string): 除外開始日 (YYYY-MM-DD)
  - `end_date` (string): 除外終了日 (YYYY-MM-DD)
  - `recovery_days` (string, デフォルト "2"): 回復期間日数
  - `reason` (string): イベント内容メモ
- `Build extra backtest args` ステップを追加:
  - `schedule` イベント時は `EXTRA_ARGS=""` (通常実行と同一)
  - `workflow_dispatch` 時のみ `recovery_days` / `event_periods` を組み立てる
  - `reason` のスペースはアンダースコアに変換してシェル展開を安全にする
  - `enable_manual_event_period=true` かつ日付が未入力の場合は Warning を出してスキップ

### `ml-pipeline/backtest.py`
- `ManualEventPeriod` に `reason: str = ""` を追加（後方互換）
- `parse_event_period()` を `START:END:REASON` 形式に対応 (`split(":", 2)` で 3 部分まで許容)
- `run.config.manual_event_periods` に `reason` フィールドを保存（非空の場合のみ）

### `src/lib/utils/backtestExclusion.ts`
- `ParsedRunConfig.manualEventPeriods` に `reason?: string` を追加
- `parseRunConfig()` で `reason` フィールドを抽出（旧 run との混在は graceful fallback）
- `buildExclusionList` の `manualEventPeriods` 引数型に `reason?` を追加

### `src/components/charts/BacktestExcludedDates.tsx`
- 設定情報欄に `reason` を表示: `期間 2026-03-01〜10 (遠征)` の形式

## 週次実行への影響なし

```yaml
# schedule 実行時は github.event_name == "schedule"
if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
  # この中が実行されないため EXTRA_ARGS="" のまま
fi
```

- 週次 cron はこれまでと全く同一の `python ml-pipeline/backtest.py` が走る
- `extra_args` が空でも `python ml-pipeline/backtest.py ` (末尾スペース) は正常に動作する

## #369 / #370 との接続

- `run.config.manual_event_periods[].reason` が記録されれば、`BacktestExcludedDates`（#370 で追加）の設定情報欄に reason が自然に表示される
- 手動実行後の結果は自動的に `BacktestExcludedDates` に反映される（追加実装不要）

## テスト

- `test_backtest.py::TestManualEventPeriod`: 9 件パス（reason テスト 3 件追加）
- `backtestExclusion.test.ts`: 19 件パス（parseRunConfig の reason テスト 4 件追加）
- `BacktestResults.integration.test.tsx`: 11 件パス（既存テスト全通過）
- TypeScript 型チェック: エラーなし

Closes #371