### PR TITLE
feat: modernize meal log entry flow with collapsible food section

### DIFF
--- a/src/components/dashboard/MobileMealLoggerSheet.tsx
+++ b/src/components/dashboard/MobileMealLoggerSheet.tsx
@@ -41,12 +41,12 @@ export function MobileMealLoggerSheet() {
   }, [open]);
 
   return (
-    <div>
+    <div className="flex justify-center">
       {/* ── Trigger ── */}
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className="flex w-full items-center justify-center gap-2 rounded-2xl border border-blue-100 bg-blue-50 py-3.5 text-sm font-semibold text-blue-700 transition-colors hover:bg-blue-100 active:bg-blue-200 dark:border-blue-900/50 dark:bg-blue-900/20 dark:text-blue-300 dark:hover:bg-blue-900/30"
+        className="flex w-full items-center justify-center gap-2 rounded-2xl border border-blue-100 bg-blue-50 py-3.5 text-sm font-semibold text-blue-700 transition-colors hover:bg-blue-100 active:bg-blue-200 dark:border-blue-900/50 dark:bg-blue-900/20 dark:text-blue-300 dark:hover:bg-blue-900/30 lg:max-w-sm"
       >
         <PenLine size={16} />
         食事・体重を記録する

--- a/src/components/meal/MealLogger.tsx
+++ b/src/components/meal/MealLogger.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Loader2, PenLine, X, Undo2 } from "lucide-react";
+import { Loader2, PenLine, X, Undo2, ChevronDown, Plus } from "lucide-react";
 import { Toast } from "@/components/ui/Toast";
 import { saveDailyLog } from "@/app/actions/saveDailyLog";
 import { FoodPicker } from "./FoodPicker";
@@ -118,6 +118,9 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
   // work_mode: 同上
   const [workMode, setWorkMode] = useState<WorkMode | null>(null);
   const [workModeTouched, setWorkModeTouched] = useState(false);
+
+  // 食品を追加セクションの開閉状態（初期: 非表示）
+  const [foodPickerOpen, setFoodPickerOpen] = useState(false);
 
   /**
    * 日付変更時にフォームを hydrate または空リセットする。
@@ -589,16 +592,47 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
         </div>
       </div>
 
-      {/* 食品検索 */}
-      <div>
-        <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">食品を追加</p>
-        <FoodPicker onAdd={addFood} onAddSet={addFromMenu} onAddTemp={addTempFood} />
-      </div>
+      {/* 食品を追加（開閉式） */}
+      <div className="flex flex-col gap-2">
+        <button
+          type="button"
+          onClick={() => setFoodPickerOpen((v) => !v)}
+          className="flex w-full items-center justify-between rounded-xl border border-dashed border-slate-200 bg-slate-50 px-3 py-2.5 transition-colors hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-800/60 dark:hover:bg-slate-700/60"
+        >
+          <span className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            <Plus size={13} />
+            食品を追加
+            {cartItems.length > 0 && !foodPickerOpen && (
+              <span className="ml-1 rounded-full bg-blue-100 px-1.5 py-0.5 text-[10px] font-semibold text-blue-600 dark:bg-blue-900/40 dark:text-blue-400">
+                {cartItems.length}品
+              </span>
+            )}
+          </span>
+          <ChevronDown
+            size={15}
+            className={`text-slate-400 transition-transform duration-200 dark:text-slate-500 ${foodPickerOpen ? "rotate-180" : ""}`}
+          />
+        </button>
 
-      {/* カート */}
-      <div>
-        <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">カート</p>
-        <Cart items={cartItems} onChange={setCartItems} />
+        {foodPickerOpen && (
+          <div className="flex flex-col gap-3">
+            <FoodPicker onAdd={addFood} onAddSet={addFromMenu} onAddTemp={addTempFood} />
+            {cartItems.length > 0 && (
+              <div>
+                <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-slate-400">カート</p>
+                <Cart items={cartItems} onChange={setCartItems} />
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* カート（閉じているときも品数があれば表示） */}
+        {!foodPickerOpen && cartItems.length > 0 && (
+          <div>
+            <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-slate-400">カート</p>
+            <Cart items={cartItems} onChange={setCartItems} />
+          </div>
+        )}
       </div>
 
       {/* 保存ボタン */}


### PR DESCRIPTION
## Summary
- 「食品を追加」セクションを初期非表示のアコーディオンに変更（`MealLogger.tsx`）
  - クリックで展開/折りたたみ、ChevronDown が 180° 回転して状態を表示
  - 閉じた状態でカートに品数があればトグルボタンにバッジ表示（例: `2品`）
  - カートは折りたたんでいても品数があれば常に表示（編集可能）
  - ダーク/ライトモード両対応
- PC 画面でトリガーボタンが横いっぱいになる問題を修正（`MobileMealLoggerSheet.tsx`）
  - `lg:max-w-sm` で大画面でのボタン幅を抑制、`justify-center` で中央揃え

Note: Issue #386 の導線全体のモダン化（余白・幅感・セクション構成）は別PRで対応予定。

## Test plan
- [ ] モーダルを開いた直後、「食品を追加」ボタンが折りたたまれた状態で表示される
- [ ] ボタンをクリックすると FoodPicker（単品/セット/一時）が展開される
- [ ] 食品を追加するとカートが表示され、品数バッジがトグルボタンに表示される
- [ ] 再度クリックで折りたたまれ、カートは引き続き表示される
- [ ] PC (lg+) でダッシュボードのトリガーボタンが横いっぱいにならない
- [ ] ダーク/ライトモードで見た目が崩れない
- [ ] 保存ロジック / touched state は変更なしで動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)