### PR TITLE
fix: remove white flash on initial navigation to foods and settings

### DIFF
--- a/src/app/foods/loading.tsx
+++ b/src/app/foods/loading.tsx
@@ -1,0 +1,19 @@
+/**
+ * Foods page loading skeleton — mirrors PageShell + FoodTable + MenuTable layout.
+ */
+import { SkeletonBlock } from "@/components/ui/Skeleton";
+
+export default function FoodsLoading() {
+  return (
+    <main className="py-4 md:py-6">
+      <div className="mx-auto max-w-screen-xl px-4 flex flex-col gap-6">
+        {/* Page title */}
+        <SkeletonBlock className="h-8 w-48" />
+        {/* FoodTable (search + list) */}
+        <SkeletonBlock className="h-72" />
+        {/* MenuTable */}
+        <SkeletonBlock className="h-56" />
+      </div>
+    </main>
+  );
+}

--- a/src/components/ui/Skeleton.tsx
+++ b/src/components/ui/Skeleton.tsx
@@ -14,7 +14,7 @@ export function SkeletonBlock({ className }: SkeletonBlockProps) {
   return (
     <div
       aria-hidden="true"
-      className={`animate-pulse rounded-2xl bg-slate-200 ${className ?? ""}`}
+      className={`animate-pulse rounded-2xl bg-slate-200 dark:bg-slate-700 ${className ?? ""}`}
     />
   );
 }


### PR DESCRIPTION
## 概要
食品DBページ・設定ページで遷移時に ~1秒間白画面が見える問題を調査し、根本原因を特定して修正する。

## 原因調査結果

### なぜ foods と settings だけ白フラッシュが出るか

| ページ | revalidate | loading.tsx | 白フラッシュ |
|---|---|---|---|
| dashboard | 0 | ✅ あり | なし |
| history | 3600 | ✅ あり | なし |
| macro | 3600 | ✅ あり | なし |
| tdee | 3600 | ✅ あり | なし |
| **foods** | 0 | ❌ **なし** | **あり** |
| **settings** | 0 | ✅ あり | **あり (ダーク)** |

### 根本原因 1: foods — loading.tsx の欠如

`revalidate = 0` で毎回 DB fetch が走るが、`loading.tsx` が存在しなかった。  
Next.js は loading 状態を表示できず、layout の body 背景 (`#f8fafc` ≒ 白) が ~1s そのまま露出していた。

### 根本原因 2: settings (ダークモード) — SkeletonBlock のダーク対応欠如

`loading.tsx` は存在し Suspense に乗っているが、`SkeletonBlock` が `bg-slate-200`（`#e2e8f0`）のみで dark mode variant がなかった。  
ダークモードでは暗い背景 (`#0f172a`) 上に明るいブロック (`#e2e8f0`) が浮き、「白フラッシュ」に見えていた。  
history/macro/tdee が問題ない理由: `revalidate = 3600` でキャッシュが効き、暖機後は loading.tsx がほぼ表示されないため気づきにくかった。

## 他ページとの差分

- loading.tsx の有無: foods のみ欠如していた
- revalidate: foods/settings のみ `0`（毎回新鮮なデータ取得）
- SkeletonBlock: 全ページ共通だが、settings のように loading が毎回表示されるページで初めて暗モードの問題が露見

## 変更内容

### 1. `src/app/foods/loading.tsx` — 新規作成
PageShell + FoodTable + MenuTable の構造に合わせたスケルトンを追加。

### 2. `src/components/ui/Skeleton.tsx` — dark mode 対応追加
```
bg-slate-200 → bg-slate-200 dark:bg-slate-700
```
`dark:bg-slate-700` (`#334155`) は dark 背景 (`#0f172a`) に対して適切なコントラストで、「暗いが視認できる」loading ブロックになる。全 loading.tsx ページ（dashboard / history / macro / tdee / settings）に適用される。

## ライト / ダークへの影響

| モード | 変更前 | 変更後 |
|---|---|---|
| ライト | skeleton: `#e2e8f0` on `#f8fafc` (低コントラスト) | 同じ（変化なし） |
| ダーク | skeleton: `#e2e8f0` on `#0f172a` (過剰に明るい) | `#334155` on `#0f172a` (適切なコントラスト) |

## テスト / 確認内容
- TypeScript 型チェック: pass
- foods ページに loading.tsx が追加された
- Skeleton.tsx の dark variant が全ページのスケルトンに適用される
- ダークモードで skeleton が過剰に明るくならない

## 補足
- `revalidate = 0` は foods/settings ともに意図的（ログ保存後に即反映する必要あり）。キャッシュで隠すアプローチは採用しない
- forecast-accuracy には loading.tsx がないが `revalidate = 3600` で頻繁にアクセスされるページではないため本 Issue スコープ外とする

Closes #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)