### PR TITLE
fix: update stale dashboard skeleton and fill dark mode gaps

### DIFF
--- a/src/app/foods/page.tsx
+++ b/src/app/foods/page.tsx
@@ -2,6 +2,7 @@ import { FoodTable } from "@/components/foods/FoodTable";
 import { MenuTable } from "@/components/foods/MenuTable";
 import { fetchFoods, fetchMenus } from "@/lib/queries/foods";
 import { PageShell } from "@/components/ui/PageShell";
+import { StatusNotice } from "@/components/ui/StatusNotice";
 
 export const revalidate = 0;
 
@@ -11,9 +12,9 @@ export default async function FoodsPage() {
   if (foodsResult.kind === "error" || menusResult.kind === "error") {
     return (
       <PageShell title="食品データベース">
-        <div className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+        <StatusNotice status="error">
           食品データベースの取得に失敗しました。しばらく経ってから再度お試しください。
-        </div>
+        </StatusNotice>
       </PageShell>
     );
   }

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,30 +1,26 @@
 /**
- * Dashboard loading skeleton — approximate DashboardLayout structure.
- * Sidebar (lg: visible) + main content area with KpiCards, chart, review sections.
+ * Dashboard loading skeleton — mirrors DashboardLayout structure.
+ *
+ * #361 でサイドバーが廃止され DashboardLayout は flex-col に統一された。
+ * MobileMealLoggerSheet トリガー + メインコンテンツの縦並び構成を反映する。
  */
 import { SkeletonBlock, SkeletonCardRow } from "@/components/ui/Skeleton";
 
 export default function DashboardLoading() {
   return (
-    <div className="flex flex-col min-h-screen bg-slate-50 py-6 gap-2 lg:flex-row lg:items-start lg:px-4">
-      {/* Main content */}
-      <div className="min-w-0 flex-1 flex flex-col gap-6 px-4 lg:px-0">
-        {/* KpiCards */}
-        <SkeletonCardRow count={3} height="h-24" cols="grid-cols-1 sm:grid-cols-3" />
-        {/* GoalNavigator */}
-        <SkeletonBlock className="h-48" />
-        {/* ForecastChart */}
-        <SkeletonBlock className="h-64" />
-        {/* WeeklyReview */}
-        <SkeletonBlock className="h-40" />
-        {/* LogsAndSummaryTabs */}
-        <SkeletonBlock className="h-56" />
-      </div>
-
-      {/* Sidebar (MealLogger) — visible on lg+ */}
-      <div className="hidden lg:flex w-80 shrink-0">
-        <SkeletonBlock className="w-full h-[600px]" />
-      </div>
+    <div className="flex flex-col min-h-screen bg-slate-50 py-6 gap-6 dark:bg-slate-950">
+      {/* MobileMealLoggerSheet trigger */}
+      <SkeletonBlock className="h-11 lg:max-w-xs" />
+      {/* KpiCards */}
+      <SkeletonCardRow count={3} height="h-24" cols="grid-cols-1 sm:grid-cols-3" />
+      {/* GoalNavigator */}
+      <SkeletonBlock className="h-48" />
+      {/* ForecastChart */}
+      <SkeletonBlock className="h-64" />
+      {/* WeeklyReview */}
+      <SkeletonBlock className="h-40" />
+      {/* LogsAndSummaryTabs */}
+      <SkeletonBlock className="h-56" />
     </div>
   );
 }

--- a/src/components/dashboard/KpiCards.tsx
+++ b/src/components/dashboard/KpiCards.tsx
@@ -33,7 +33,7 @@ function KpiCard({ label, value, unit, sub, icon, accent, iconColor, trendDir, t
   const isGood = trendDir === undefined || trendDir === "flat"
     ? null
     : trendDir === trendPositive;
-  const trendColor = isGood === null ? "text-slate-400" : isGood ? "text-emerald-600" : "text-rose-500";
+  const trendColor = isGood === null ? "text-slate-400" : isGood ? "text-emerald-600 dark:text-emerald-400" : "text-rose-500 dark:text-rose-400";
 
   return (
     <div className="relative overflow-hidden rounded-2xl border border-slate-100 bg-white p-5 shadow-sm transition-shadow hover:shadow-md dark:border-slate-700 dark:bg-slate-900 dark:shadow-none">
@@ -166,9 +166,9 @@ export function KpiCards({ logs, settings, currentWeight, currentSeason }: KpiCa
         <div className="mt-3">
           <span className={`text-2xl font-bold leading-none tracking-tight ${
             goalReachDate
-              ? "text-teal-600"
+              ? "text-teal-600 dark:text-teal-400"
               : goalReachLabel === "達成済み ✓"
-              ? "text-emerald-600"
+              ? "text-emerald-600 dark:text-emerald-400"
               : "text-slate-400"
           }`}>
             {goalReachLabel}


### PR DESCRIPTION
Closes #393

## Summary

- **`src/app/loading.tsx`**: サイドバー廃止（#361）後も残っていた旧レイアウト構造（`lg:flex-row` + サイドバースロット）を削除し、現行の `DashboardLayout`（flex-col + MobileMealLoggerSheet トリガー）に合わせて更新
- **`src/app/foods/page.tsx`**: エラーバナーを生 `<div>` から `StatusNotice` コンポーネントに置換し、他ページとの dark モード対応を統一
- **`src/components/dashboard/KpiCards.tsx`**: `trendColor` の `text-emerald-600` / `text-rose-500` および目標到達カードの `text-teal-600` / `text-emerald-600` に `dark:` バリアントを追加

## Test plan

- [ ] ダッシュボードへの遷移時にスケルトンが現行レイアウト（縦並び）と一致して見えることを確認
- [ ] ダークモードで foods ページのエラーバナー（再現困難なら実装コード目視）が暗色背景で表示されることを確認
- [ ] ダークモードで KpiCards のトレンドアイコン・目標到達予定テキストが適切なコントラストで表示されることを確認
- [ ] 型チェック通過済み (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)