### PR TITLE
feat: add goal reach rationale and buffer to GoalNavigator

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,10 +7,12 @@ import { DataQualityBadge } from "@/components/dashboard/DataQualityBadge";
 import { GoalNavigator } from "@/components/dashboard/GoalNavigator";
 import { WeeklyReviewCard } from "@/components/dashboard/WeeklyReviewCard";
 import { calcDataQuality } from "@/lib/utils/calcDataQuality";
-import { calcReadiness } from "@/lib/utils/calcReadiness";
+import { calcReadiness, calcGoalReachDate } from "@/lib/utils/calcReadiness";
+import type { GoalReachResult } from "@/lib/utils/calcReadiness";
 import { calcWeeklyReview } from "@/lib/utils/calcWeeklyReview";
 import { calcMonthlyGoalProgress } from "@/lib/utils/calcMonthlyGoalProgress";
-import { toJstDateStr } from "@/lib/utils/date";
+import { toJstDateStr, addDaysStr, dateRangeStr } from "@/lib/utils/date";
+import { calcWeightTrend } from "@/lib/utils/calcTrend";
 import { buildMonthlyGoalPlan } from "@/lib/utils/monthlyGoalPlan";
 import { buildMonthlyGoalSummaryRows, buildMonthlyGoalComparisonRows } from "@/lib/utils/monthlyGoalVisualization";
 import { calcMonthlyBehaviorStats } from "@/lib/utils/calcMonthlyBehaviorStats";
@@ -136,6 +138,25 @@ export default async function DashboardPage() {
     goal_weight: goalWeight ?? null,
   });
 
+  // 到達予測の根拠（KpiCards と同じアルゴリズム: 7日平均 + 30日線形回帰）
+  // GoalNavigator のバッファ表示に渡す。KpiCards 側は引き続き自前で計算。
+  // TODO(#397): KpiCards の slopePerDay30 計算との重複は #397 の責務整理で解消する。
+  const goalReachResult: GoalReachResult = (() => {
+    const todayForReach = toJstDateStr();
+    const d30Start = addDaysStr(todayForReach, -29) ?? todayForReach;
+    const logByDate30 = new Map(logs.map((l) => [l.log_date, l]));
+    const trend30Data = dateRangeStr(d30Start, todayForReach)
+      .map((d) => ({ date: d, weight: logByDate30.get(d)?.weight ?? null }))
+      .filter((p): p is { date: string; weight: number } => p.weight !== null);
+    const slopePerDay30 = trend30Data.length >= 2 ? calcWeightTrend(trend30Data).slope : null;
+    return calcGoalReachDate(
+      readinessMetrics.weight_7d_avg,
+      slopePerDay30,
+      goalWeight ?? null,
+      todayForReach,
+    );
+  })();
+
   // enriched_logs から log_date → tdee_estimated の Map を構築
   const enrichedTdeeMap = new Map<string, number>();
   for (const row of enrichedRows) {
@@ -230,6 +251,7 @@ export default async function DashboardPage() {
             avgCalories={weeklyReview.nutrition.avgCalories}
             monthlyGoalProgress={monthlyGoalProgress}
             currentMonthMinWeight={currentMonthMinWeight}
+            goalReachResult={goalReachResult}
           />
           <WeeklyReviewCard data={weeklyReview} phase={phase} enrichedAvailability={enrichedAvailability} />
           <DataQualityBadge report={qualityReport} />

--- a/src/components/dashboard/GoalNavigator.tsx
+++ b/src/components/dashboard/GoalNavigator.tsx
@@ -26,9 +26,10 @@ import {
   HelpCircle,
   CalendarDays,
 } from "lucide-react";
-import type { ReadinessMetrics } from "@/lib/utils/calcReadiness";
+import type { ReadinessMetrics, GoalReachResult } from "@/lib/utils/calcReadiness";
 import { calcGoalStatus, calcKcalCorrection, PACE_CALC_MIN_DAYS } from "@/lib/utils/calcReadiness";
 import type { MonthlyGoalProgress } from "@/lib/utils/calcMonthlyGoalProgress";
+import { toJstDateStr, calcDaysLeft } from "@/lib/utils/date";
 import { SectionLabel } from "@/components/ui/SectionLabel";
 
 interface GoalNavigatorProps {
@@ -43,6 +44,11 @@ interface GoalNavigatorProps {
   monthlyGoalProgress: MonthlyGoalProgress;
   /** 当月内の最小実測体重 (kg) */
   currentMonthMinWeight?: number | null;
+  /**
+   * 目標到達予定日の計算結果 (KpiCards と同じ「7日平均 + 30日線形トレンド」ロジック)。
+   * 体重進捗列に根拠表示・バッファを追加するために page.tsx から渡す。
+   */
+  goalReachResult: GoalReachResult;
 }
 
 // ─── ステータス表示マップ ──────────────────────────────────────────────────
@@ -191,6 +197,7 @@ export function GoalNavigator({
   avgCalories,
   monthlyGoalProgress,
   currentMonthMinWeight,
+  goalReachResult,
 }: GoalNavigatorProps) {
   const isCut = phase !== "Bulk";
 
@@ -250,6 +257,20 @@ export function GoalNavigator({
       : status === "contest_imminent"
       ? `${deadlineLabel}直前`
       : statusCfg.label;
+
+  // ── 到達予測の根拠: 推定到達日 + バッファ (KpiCards 表示の補完) ──
+  // goalReachResult は page.tsx で「7日平均 + 30日線形トレンド」から計算済み。
+  // daysNeeded: 今日から推定到達日までの日数 (projected 状態のみ算出)
+  // bufferDays: 大会残日数 − daysNeeded。正=余裕、負=期限オーバー見込み
+  const todayStr = toJstDateStr();
+  const daysNeeded =
+    goalReachResult.status === "projected" && goalReachResult.date !== null
+      ? calcDaysLeft(todayStr, goalReachResult.date)
+      : null;
+  const bufferDays =
+    daysNeeded !== null && metrics.days_to_contest !== null
+      ? metrics.days_to_contest - daysNeeded
+      : null;
 
   // ── 設定欠落フォールバック ──
   const missingGoal = goalWeight === null;
@@ -331,6 +352,42 @@ export function GoalNavigator({
                     : undefined
                 }
               />
+
+              {/* ── 到達予測の根拠 ── */}
+              {goalReachResult.status !== "no_data" && (
+                <>
+                  <div className="my-1 border-t border-slate-100 dark:border-slate-700" />
+                  <MetricRow
+                    label="推定到達"
+                    value={goalReachResult.label}
+                    valueColor={
+                      goalReachResult.status === "achieved"
+                        ? "text-emerald-600 dark:text-emerald-400"
+                        : goalReachResult.status === "projected"
+                        ? "text-teal-600 dark:text-teal-400"
+                        : "text-slate-400 dark:text-slate-500"
+                    }
+                    note="(30日トレンド)"
+                  />
+                  {bufferDays !== null && (
+                    <MetricRow
+                      label="バッファ"
+                      value={
+                        bufferDays >= 0
+                          ? `+${bufferDays} 日`
+                          : `▲${Math.abs(bufferDays)} 日不足`
+                      }
+                      valueColor={
+                        bufferDays >= 14
+                          ? "text-emerald-600 dark:text-emerald-400"
+                          : bufferDays >= 0
+                          ? "text-amber-600 dark:text-amber-400"
+                          : "text-rose-600 dark:text-rose-400"
+                      }
+                    />
+                  )}
+                </>
+              )}
             </>
           )}
         </div>
@@ -538,7 +595,7 @@ export function GoalNavigator({
 
       {/* ── フッター注記 ── */}
       <div className="border-t border-slate-50 bg-slate-50 px-5 py-2 text-[11px] text-slate-400 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-500">
-        体重進捗は 7 日移動平均ベース / 今月進捗は最新体重ベース / ペースは 14 日線形回帰・kg/2週 表示 / 推定値のため目安としてご利用ください
+        体重進捗は 7 日移動平均ベース / 今月進捗は最新体重ベース / ペースは 14 日線形回帰・kg/2週 表示 / 到達予測は 30 日線形トレンドベース / 推定値のため目安としてご利用ください
       </div>
     </div>
   );


### PR DESCRIPTION
## 概要

GoalNavigator の「体重進捗」列に、KPI カードの「目標到達予定」を補完する根拠表示（推定到達日・バッファ）を追加する。

## 変更内容

- **`src/app/page.tsx`**
  - `goalReachResult`（7日平均 + 30日線形トレンド）を page レベルで計算し、GoalNavigator に `goalReachResult` prop として渡す
  - インポート追加: `calcGoalReachDate`, `GoalReachResult`, `calcWeightTrend`, `addDaysStr`, `dateRangeStr`

- **`src/components/dashboard/GoalNavigator.tsx`**
  - `GoalReachResult` 型と `calcDaysLeft`, `toJstDateStr` をインポート追加
  - Props に `goalReachResult: GoalReachResult` を追加
  - 体重進捗列の「残り」行の下に「到達予測の根拠」セクションを追加
  - フッター注記に「到達予測は 30 日線形トレンドベース」を追加

## 表示した到達予測根拠

体重進捗列に以下 2 行を追加（divider で残り行と分離）:

| 行 | 値の例 | 状態別ふるまい |
|---|---|---|
| 推定到達 | 2026-07-15 (30日トレンド) | projected=teal / achieved=emerald / stalled=slate |
| バッファ | +25 日 / ▲3 日不足 | ≥14日=emerald / 0〜13日=amber / 負=rose |

## KPI カードとの整合方針

- KpiCards と同じ計算式（`calcGoalReachDate(weight_7d_avg, slopePerDay30, goalWeight, today)`）を使用
- page.tsx で一元計算し GoalNavigator に渡す。KpiCards は現状維持（#397 で整理）
- `slopePerDay30` の重複計算は `TODO(#397)` コメントで明示

## フォールバック確認

| 条件 | ふるまい |
|---|---|
| `goalWeight === null` (目標未設定) | 既存の `missingGoal` ガードで根拠セクション丸ごと非表示 |
| 体重データなし (`status === "no_data"`) | `goalReachResult.status !== "no_data"` 条件で非表示 |
| 停滞中 (`status === "stalled"`) | 「停滞中」ラベルを slate 色で表示。bufferDays は null のため非表示 |
| 達成済み (`status === "achieved"`) | 「達成済み ✓」を emerald 色で表示。bufferDays は null |
| 大会直前 (`days_to_contest < PACE_CALC_MIN_DAYS`) | ペース分析は既存 fallback 維持。バッファは `daysNeeded !== null` 条件のため表示される場合あり |

## 補足

- ビルド・型チェック (`tsc --noEmit`) 共にエラーなし
- 無関係なリファクタは含まない

## 残課題（#397 スコープ）

- page.tsx と KpiCards の `slopePerDay30` 重複計算の解消
- KpiCards と GoalNavigator の責務境界の整理
- フッター注記体系の全面見直し

Closes #396