### PR TITLE
refactor: simplify goal reach UI responsibilities

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -247,7 +247,7 @@ export default async function DashboardPage() {
         </p>
       ) : logs.length > 0 ? (
         <>
-          <KpiCards logs={logs} settings={settings} avgTdee={latestTdee} currentWeight={readinessMetrics.current_weight} currentSeason={currentSeason} goalReachResult={goalReachResult} />
+          <KpiCards logs={logs} settings={settings} avgTdee={latestTdee} currentWeight={readinessMetrics.current_weight} currentSeason={currentSeason} goalReachResult={goalReachResult} bufferDays={bufferDays} />
           <GoalNavigator
             metrics={readinessMetrics}
             phase={phase}
@@ -256,7 +256,6 @@ export default async function DashboardPage() {
             avgCalories={weeklyReview.nutrition.avgCalories}
             monthlyGoalProgress={monthlyGoalProgress}
             currentMonthMinWeight={currentMonthMinWeight}
-            bufferDays={bufferDays}
           />
           <WeeklyReviewCard data={weeklyReview} phase={phase} enrichedAvailability={enrichedAvailability} />
           <DataQualityBadge report={qualityReport} />

--- a/src/components/dashboard/GoalNavigator.tsx
+++ b/src/components/dashboard/GoalNavigator.tsx
@@ -43,11 +43,6 @@ interface GoalNavigatorProps {
   monthlyGoalProgress: MonthlyGoalProgress;
   /** 当月内の最小実測体重 (kg) */
   currentMonthMinWeight?: number | null;
-  /**
-   * 到達予測バッファ (日数)。page.tsx で「30日線形トレンド到達日 − 大会残日数」から算出。
-   * 正=余裕あり / 負=期限超過見込み / null=到達日が算出不能 (停滞中・データ不足・達成済み)
-   */
-  bufferDays: number | null;
 }
 
 // ─── ステータス表示マップ ──────────────────────────────────────────────────
@@ -196,7 +191,6 @@ export function GoalNavigator({
   avgCalories,
   monthlyGoalProgress,
   currentMonthMinWeight,
-  bufferDays,
 }: GoalNavigatorProps) {
   const isCut = phase !== "Bulk";
 
@@ -338,28 +332,6 @@ export function GoalNavigator({
                 }
               />
 
-              {/* ── 到達予測バッファ: KPI カードの到達予定日を補完 ── */}
-              {bufferDays !== null && (
-                <>
-                  <div className="my-1 border-t border-slate-100 dark:border-slate-700" />
-                  <MetricRow
-                    label="バッファ"
-                    value={
-                      bufferDays >= 0
-                        ? `+${bufferDays} 日`
-                        : `▲${Math.abs(bufferDays)} 日不足`
-                    }
-                    valueColor={
-                      bufferDays >= 14
-                        ? "text-emerald-600 dark:text-emerald-400"
-                        : bufferDays >= 0
-                        ? "text-amber-600 dark:text-amber-400"
-                        : "text-rose-600 dark:text-rose-400"
-                    }
-                    note="(30日トレンドベース)"
-                  />
-                </>
-              )}
             </>
           )}
         </div>

--- a/src/components/dashboard/KpiCards.tsx
+++ b/src/components/dashboard/KpiCards.tsx
@@ -15,6 +15,11 @@ interface KpiCardsProps {
   currentSeason?: string | null;
   /** 目標到達予定日の計算結果 (page.tsx で算出した共通値) */
   goalReachResult: GoalReachResult;
+  /**
+   * 到達予測バッファ (日数)。page.tsx で「30日線形トレンド到達日 − 大会残日数」から算出。
+   * 正=余裕あり / 負=期限超過見込み / null=到達日が算出不能 (停滞中・データ不足・達成済み)
+   */
+  bufferDays: number | null;
 }
 
 interface KpiCardProps {
@@ -60,7 +65,7 @@ function KpiCard({ label, value, unit, sub, icon, accent, iconColor, trendDir, t
   );
 }
 
-export function KpiCards({ logs, settings, currentWeight, currentSeason, goalReachResult }: KpiCardsProps) {
+export function KpiCards({ logs, settings, currentWeight, currentSeason, goalReachResult, bufferDays }: KpiCardsProps) {
   const sorted = [...logs].sort((a, b) => a.log_date.localeCompare(b.log_date));
   const isCut = settings.currentPhase !== "Bulk";
   const deadlineLabel = isCut ? "大会日" : "目標日";
@@ -159,6 +164,17 @@ export function KpiCards({ logs, settings, currentWeight, currentSeason, goalRea
         {goalReachDate && goalWeight !== null && (
           <p className="mt-2 text-xs text-slate-400 dark:text-slate-500">
             {goalWeight.toFixed(1)} kg 到達の推定日（7日平均 + 30日トレンド）
+          </p>
+        )}
+        {goalReachDate && bufferDays !== null && (
+          <p className={`mt-1 text-xs font-medium ${
+            bufferDays >= 14
+              ? "text-emerald-600 dark:text-emerald-400"
+              : bufferDays >= 0
+              ? "text-amber-600 dark:text-amber-400"
+              : "text-rose-600 dark:text-rose-400"
+          }`}>
+            バッファ {bufferDays >= 0 ? `+${bufferDays} 日` : `▲${Math.abs(bufferDays)} 日不足`}
           </p>
         )}
         {!goalWeight && (


### PR DESCRIPTION
## 概要

#396 で追加した到達予測根拠表示をベースに、KPI カードと GoalNavigator の役割分担を明確化し、重複計算・重複表示を解消する。

## 変更内容

### `src/app/page.tsx`
- `today = toJstDateStr()` を `readinessMetrics` より前に移動し、全計算で共有（二重呼び出しを解消）
- `slopePerDay30 / goalReachResult / bufferDays` を page レベルで一元計算（IIFE をフラット化）
- KpiCards に `goalReachResult` を渡す（KpiCards の内部計算を置換）
- GoalNavigator の prop を `goalReachResult` → `bufferDays` に変更

### `src/components/dashboard/KpiCards.tsx`
- `goalReachResult: GoalReachResult` prop を受け取り、内部の 30 日回帰計算を削除（`w7 / weight_7d_avg / trend30Data / slopePerDay30` 約 20 行削除）
- `calcGoalReachDate` インポートを削除; `GoalReachResult` 型インポートに差し替え
- 表示は変更なし（到達日ラベル + 「7日平均 + 30日トレンド」注記）

### `src/components/dashboard/GoalNavigator.tsx`
- `goalReachResult: GoalReachResult` prop を `bufferDays: number | null` に置換
- `GoalReachResult` 型 / `toJstDateStr` / `calcDaysLeft` インポートを削除
- `todayStr / daysNeeded / bufferDays` ローカル計算を削除（prop から受け取る）
- 「推定到達」行を削除（日付は KPI カードに集約済み）
- 「バッファ」行を維持し `note="(30日トレンドベース)"` を追加
- フッター注記から「到達予測は 30 日線形トレンドベース」を削除（行内 note で代替）

## KPI カードと GoalNavigator の役割分担

| コンポーネント | 役割 | 到達予測関連の表示 |
|---|---|---|
| KpiCards | 一目で分かる概要 | 到達予定日ラベル（YYYY-MM-DD / 達成済み ✓ / 停滞中）+ 算出根拠注記 |
| GoalNavigator 体重進捗列 | 判断に必要な最小限の根拠 | バッファ（+N日 / ▲N日不足）のみ（30日トレンドベース note 付き）|

## 削減・統合した表示項目

| 項目 | 変更前 | 変更後 | 理由 |
|---|---|---|---|
| 到達予定日 | KpiCards + GoalNavigator 両方に表示 | KpiCards のみ | 重複削除 |
| 計算ソース | page.tsx IIFE + KpiCards 内部で二重計算 | page.tsx のみ | 単一ソース化 |
| 基準日取得 | page.tsx 内で 2 回 + GoalNavigator で 1 回 = 計 3 回 | page.tsx で 1 回のみ | 二重呼び出し解消 |
| フッター注記 | 5 エントリ | 4 エントリ（到達予測行を削除） | 行内 note に集約 |

## フォールバック確認

| 状態 | バッファ行の表示 | その他の影響 |
|---|---|---|
| `goalReachResult.status === "no_data"` (体重 or 目標なし) | `bufferDays = null` → 非表示 | 既存 `missingGoal` ガード維持 |
| `status === "achieved"` (達成済み) | `bufferDays = null` → 非表示 | ヘッダー「目標達成」バッジで十分 |
| `status === "stalled"` (停滞中) | `bufferDays = null` → 非表示 | ペース分析の「差」行で示す |
| `status === "projected"` (予測可能) | `bufferDays` 表示 | KPI カードに日付、GoalNavigator にバッファ |

## 補足

- 型チェック・ビルド共にエラーなし
- 差分: +54 / -95 行（削除超過で純減）

Closes #397