### PR TITLE
feat: refine weekly %BW guidance and simplify WeeklyReview

### DIFF
--- a/src/components/dashboard/WeeklyReviewCard.tsx
+++ b/src/components/dashboard/WeeklyReviewCard.tsx
@@ -246,11 +246,6 @@ export function WeeklyReviewCard({ data, phase, enrichedAvailability }: Props) {
                     : "text-slate-500"
                 }
               />
-              <StatRow
-                label="14日トレンド"
-                value={`${fmtSigned1(weight.trendKgPerWeek)} kg/週`}
-                valueColor={trendColor}
-              />
               {/* %BW/週 + ペースステータス */}
               {(() => {
                 const bwRate = weight.bwRatePctPerWeek;
@@ -265,7 +260,7 @@ export function WeeklyReviewCard({ data, phase, enrichedAvailability }: Props) {
                       valueColor={cfg.color}
                     />
                     <div className="flex items-center justify-between py-0.5">
-                      <span className="text-[10px] text-slate-400 dark:text-slate-500">推奨 0.5〜1.0% BW/週</span>
+                      <span className="text-[10px] text-slate-400 dark:text-slate-500">推奨レンジ 0.5〜1.0% BW/週（Helms 2014）</span>
                       <span className={`text-[11px] font-semibold ${cfg.color}`}>{cfg.label}</span>
                     </div>
                   </>
@@ -357,7 +352,7 @@ export function WeeklyReviewCard({ data, phase, enrichedAvailability }: Props) {
 
       {/* ── フッター ── */}
       <div className="flex items-center justify-between border-t border-slate-50 bg-slate-50 px-5 py-2 text-[11px] text-slate-400 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-500">
-        <span>ローリング集計（今日を含む直近7暦日）/ トレンドは直近14暦日の線形回帰 / あくまで推定値</span>
+        <span>%BW/週 = 14日線形回帰÷7日平均体重 / GoalNavigator の必要ペースは絶対量（kg/2週）/ 直近7暦日ローリング集計 / あくまで推定値</span>
         <span className={`font-semibold ${qualityScoreColor(quality.score)}`}>
           品質 {quality.score}/100
         </span>


### PR DESCRIPTION
## 概要

WeeklyReview に追加された %BW/週 指標の説明テキスト・根拠注記を整備し、14日トレンド行の冗長な表示を整理。Issue #403 の完了。

## 変更内容

| ファイル | 変更内容 |
|---|---|
| `src/components/dashboard/WeeklyReviewCard.tsx` | 14日トレンド行の削除・推奨レンジ注記に Helms 2014 を追記・フッター更新 |

## 説明文 / 根拠注記の整理方針

**推奨レンジ注記（%BW/週 表示の直下）**:
- 変更前: `推奨 0.5〜1.0% BW/週`
- 変更後: `推奨レンジ 0.5〜1.0% BW/週（Helms 2014）`

Helms 2014 が直接支持する 0.5〜1.0% の根拠が画面上で確認できるようになる。それ以外の帯（かなり緩やか / 緩やか / やや速め / 速すぎ）は UI 解釈用であることが "推奨レンジ" の限定表現で示唆される。

**フッター**:
- 変更前: `ローリング集計（今日を含む直近7暦日）/ トレンドは直近14暦日の線形回帰 / あくまで推定値`
- 変更後: `%BW/週 = 14日線形回帰÷7日平均体重 / GoalNavigator の必要ペースは絶対量（kg/2週）/ 直近7暦日ローリング集計 / あくまで推定値`

%BW/週 の算出基盤（14日回帰ベース）と GoalNavigator の kg/2週（絶対量・必要ペース比較用）との違いを最小限の文言で補足。

## 14日トレンド表示の扱いと判断理由

**削除**。

理由:
- `前週比（7日平均差）` と `%BW/週（14日回帰÷体重）` が並ぶことで、方向・規模・体重比の3軸が揃う
- `14日トレンド（kg/週）` は %BW/週 の算出元を別単位で再掲しているだけで、解釈上の追加情報がない
- 直近7日サマリーとして体重セクションをコンパクトにすることで可読性が改善する

ロジックへの影響:
- `weight.trendKgPerWeek` は TrendIcon・trendColor・停滞バッジ・`bwRatePctPerWeek` 算出のすべてで引き続き使用される
- 表示行（`StatRow`）の削除のみ。算出ロジックへの変更ゼロ

## 影響範囲

- `WeeklyReviewCard.tsx` のみ（3箇所の文字列 / 1行の StatRow 削除）
- `calcWeeklyReview.ts` への変更なし
- テスト・型定義への変更なし

## テスト / 確認内容

- 全テスト 1192 件通過
- `npx tsc --noEmit` クリーン
- `npm run build` クリーン

## 補足

残課題・別 Issue 化が必要な内容は特になし。%BW/週 の過去4〜8週ミニチャート追加は親 Issue #401 の将来課題として保留。

Closes #403