### PR TITLE
feat: add configurable horizons input to ml-backtest workflow

### DIFF
--- a/.github/workflows/ml-backtest.yml
+++ b/.github/workflows/ml-backtest.yml
@@ -6,10 +6,17 @@ on:
   schedule:
     - cron: "0 19 * * 5"
 
-  # 手動実行。manual event period を指定して backtest を再実行する場合に使用する。
+  # 手動実行。horizons 指定や manual event period 除外が必要な場合に使用する。
   # スケジュール実行は入力なしで常にデフォルト動作を維持する。
   workflow_dispatch:
     inputs:
+      horizons:
+        description: |
+          評価ホライズン (カンマ区切り)。
+          デフォルト運用: 7,14,30
+          D+60/D+90 を試す場合: 7,14,30,60,90
+        type: string
+        default: '7,14,30'
       enable_manual_event_period:
         description: '手動イベント期間を除外対象に追加する (true にすると start_date / end_date が有効になる)'
         type: boolean
@@ -62,10 +69,16 @@ jobs:
         run: |
           EXTRA_ARGS=""
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            # horizons: カンマ区切りをスペース区切りに変換して --horizons に渡す
+            # schedule 実行は このブロックに入らないため Python デフォルト (7,14,30) を使用する
+            HORIZONS_RAW="${{ inputs.horizons }}"
+            HORIZONS_ARGS=$(echo "${HORIZONS_RAW:-7,14,30}" | tr ',' ' ')
+            EXTRA_ARGS="--horizons $HORIZONS_ARGS"
+
             # recovery_days: デフォルト (2) 以外が指定された場合のみ追加
             RECOVERY="${{ inputs.recovery_days }}"
             if [[ -n "$RECOVERY" && "$RECOVERY" != "2" ]]; then
-              EXTRA_ARGS="--recovery-days $RECOVERY"
+              EXTRA_ARGS="$EXTRA_ARGS --recovery-days $RECOVERY"
             fi
 
             # manual event period: enable フラグが true かつ開始・終了日が指定された場合のみ追加


### PR DESCRIPTION
## 概要

ml-backtest workflow の手動実行時に評価ホライズンをカンマ区切りで指定できるようにする。
D+60 / D+90 の試験実行準備。デフォルト運用 (7,14,30) は変更なし。

## 変更内容

- `.github/workflows/ml-backtest.yml` のみ変更（CLI / スクリプト側は変更なし）
- `workflow_dispatch.inputs.horizons` を追加（default: `'7,14,30'`）
- `Build extra backtest args` ステップで入力をカンマ → スペース変換し `--horizons` に渡す
- `backtest.py` が既に `--horizons 7 14 30` (nargs="+") を受け付けるため、スクリプト側変更不要

## horizons 入力の追加方法

```yaml
horizons:
  description: |
    評価ホライズン (カンマ区切り)。
    デフォルト運用: 7,14,30
    D+60/D+90 を試す場合: 7,14,30,60,90
  type: string
  default: '7,14,30'
```

シェル側変換:
```bash
HORIZONS_ARGS=$(echo "${HORIZONS_RAW:-7,14,30}" | tr ',' ' ')
EXTRA_ARGS="--horizons $HORIZONS_ARGS"
```

## デフォルト運用の維持方法

`schedule` トリガーは `github.event_name == "workflow_dispatch"` ブロックに入らないため、
`EXTRA_ARGS` は空のまま。`backtest.py` は `_DEFAULT_HORIZONS = [7, 14, 30]` を使用し、
従来と全く同じ週次実行を維持する。

## 手動実行時の想定挙動

| inputs.horizons | --horizons 渡し値 |
|---|---|
| `7,14,30`（デフォルト） | `--horizons 7 14 30` |
| `7,14,30,60,90` | `--horizons 7 14 30 60 90` |
| `60,90` | `--horizons 60 90` |

## 判断理由

- `backtest.py` の `--horizons` CLI が既に存在するため workflow 側のみの変更で完結できる
- カンマ区切り入力 → スペース区切り変換は1行 (`tr ',' ' '`) で済み、差分が最小
- `schedule` と `workflow_dispatch` の分岐を既存の `if` ブロックで自然に吸収できる

## 影響範囲

- `schedule` 実行: 影響なし（デフォルト挙動を維持）
- `workflow_dispatch` 実行: horizons を明示指定できるようになる（デフォルト値のまま実行も可）
- CLI / Python スクリプト: 変更なし

## 確認内容

- `backtest.py --horizons` が `nargs="+"` でスペース区切り複数値を受け取ることを確認
- `_DEFAULT_HORIZONS = [7, 14, 30]` が Python 側デフォルトとして維持されていることを確認
- `schedule` 実行時に `EXTRA_ARGS` が空になる既存ロジックを確認

## 補足: あわせて修正した既存バグ

`recovery_days` 分岐で `EXTRA_ARGS="--recovery-days $RECOVERY"` と上書きしており、
先に設定したオプションが消える問題があった。`EXTRA_ARGS="$EXTRA_ARGS --recovery-days $RECOVERY"` に修正。
（`recovery_days` がデフォルト値 `2` の場合はこのブロックに入らないため、既存の実行への影響はない）

## 残課題 / スコープ外

- D+60 / D+90 の本格評価実施（クリーンデータ蓄積後）
- horizon 別モデル選択ロジック
- Bias 補正導入

Closes #409