### PR TITLE
feat: preserve monthly goal plan history with explicit start month

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,6 +15,7 @@ import { calcWeightTrend } from "@/lib/utils/calcTrend";
 import { buildMonthlyGoalPlan } from "@/lib/utils/monthlyGoalPlan";
 import { buildMonthlyGoalSummaryRows, buildMonthlyGoalComparisonRows } from "@/lib/utils/monthlyGoalVisualization";
 import { calcMonthlyBehaviorStats } from "@/lib/utils/calcMonthlyBehaviorStats";
+import { resolveMonthlyPlanHistoryAnchor } from "@/lib/utils/monthlyPlanHistory";
 import { fetchDashboardDailyLogs, fetchPredictions, fetchCareerLogsForDashboard } from "@/lib/queries/dailyLogs";
 import { fetchSettings } from "@/lib/queries/settings";
 import { fetchEnrichedLogs } from "@/lib/queries/analytics";
@@ -180,6 +181,14 @@ export default async function DashboardPage() {
   // 今月目標進捗の比較値: 最新体重優先 (単日ノイズ込みの実測値で進捗を把握する)
   // GoalNavigator のペース分析 (refWeight) は引き続き 7日平均優先のままとする
   const comparisonWeight = readinessMetrics.current_weight ?? readinessMetrics.weight_7d_avg;
+  const monthlyPlanHistory = resolveMonthlyPlanHistoryAnchor({
+    explicitStartMonth: settings.monthlyPlanStartMonth,
+    explicitStartWeight: settings.monthlyPlanStartWeight,
+    goalDeadlineDate: contestDate ?? null,
+    overrides: settings.monthlyPlanOverrides,
+    currentWeight: comparisonWeight,
+    today,
+  });
 
   // 当月最小体重: 今月の実測ログから最小値を導出
   const currentMonthPrefix = today.slice(0, 7);
@@ -192,6 +201,8 @@ export default async function DashboardPage() {
   const monthlyGoalProgress = calcMonthlyGoalProgress({
     contestDate: contestDate ?? null,
     targetWeight: goalWeight ?? null,
+    monthlyPlanStartMonth: monthlyPlanHistory.startMonth,
+    monthlyPlanStartWeight: monthlyPlanHistory.startWeight,
     monthlyPlanOverrides: settings.monthlyPlanOverrides,
     comparisonWeight,
     today,
@@ -201,10 +212,11 @@ export default async function DashboardPage() {
   // 月次計画 (#101) を構築して可視化用データを生成する。
   // comparisonWeight が null (体重記録なし) の場合はプランを構築しない。
   const monthlyGoalPlan =
-    contestDate && goalWeight !== undefined && comparisonWeight !== null
+    contestDate && goalWeight !== undefined && monthlyPlanHistory.startWeight !== null
       ? buildMonthlyGoalPlan({
-          currentWeight: comparisonWeight,
+          currentWeight: monthlyPlanHistory.startWeight,
           today,
+          planStartMonth: monthlyPlanHistory.startMonth,
           finalGoalWeight: goalWeight,
           goalDeadlineDate: contestDate,
           monthlyActuals: [],

--- a/src/app/settings/actions.test.ts
+++ b/src/app/settings/actions.test.ts
@@ -2,11 +2,14 @@ import { normalizeMonthlyPlanOverridesBeforeSave } from "@/lib/utils/normalizeMo
 import { EMPTY_SETTINGS_INPUT } from "@/lib/schemas/settingsSchema";
 
 describe("normalizeMonthlyPlanOverridesBeforeSave", () => {
-  it("前月・期限月・期限後の override を保存前に除外する", () => {
+  it("開始月より前・期限月・期限後の override を保存前に除外する", () => {
     const result = normalizeMonthlyPlanOverridesBeforeSave({
       ...EMPTY_SETTINGS_INPUT,
       contest_date: "2026-06-30",
+      monthly_plan_start_month: "2026-03",
+      monthly_plan_start_weight: "78.0",
       monthly_plan_overrides: JSON.stringify([
+        { month: "2026-02", targetWeight: 77.5 },
         { month: "2026-03", targetWeight: 76.0 },
         { month: "2026-04", targetWeight: 75.0 },
         { month: "2026-06", targetWeight: 72.5 },
@@ -15,8 +18,11 @@ describe("normalizeMonthlyPlanOverridesBeforeSave", () => {
     }, "2026-04-02");
 
     expect(JSON.parse(result.monthly_plan_overrides)).toEqual([
+      { month: "2026-03", targetWeight: 76.0 },
       { month: "2026-04", targetWeight: 75.0 },
     ]);
+    expect(result.monthly_plan_start_month).toBe("2026-03");
+    expect(result.monthly_plan_start_weight).toBe("78");
   });
 
   it("有効な期限日がない場合は monthly_plan_overrides を変更しない", () => {

--- a/src/components/settings/MonthlyGoalPlanSection.integration.test.tsx
+++ b/src/components/settings/MonthlyGoalPlanSection.integration.test.tsx
@@ -179,6 +179,8 @@ describe("MonthlyGoalPlanSection — 月別テーブル表示", () => {
         contestDate="2026-06-30"
         currentWeight={75}
         today="2026-04-02"
+        planStartMonth="2026-03"
+        planStartWeight={76}
         overrides={[
           { month: "2026-03", targetWeight: 74 },
           { month: "2026-05", targetWeight: 71.5 },
@@ -188,6 +190,7 @@ describe("MonthlyGoalPlanSection — 月別テーブル表示", () => {
     );
 
     expect(screen.queryByText(/計画期間外の月に手動設定が含まれています/)).not.toBeInTheDocument();
+    expect(screen.getByText("2026年3月")).toBeInTheDocument();
     expect(screen.getByText("2026年4月")).toBeInTheDocument();
     expect(screen.getByText("2026年6月")).toBeInTheDocument();
   });

--- a/src/components/settings/MonthlyGoalPlanSection.tsx
+++ b/src/components/settings/MonthlyGoalPlanSection.tsx
@@ -35,6 +35,8 @@ interface MonthlyGoalPlanSectionProps {
   phase?: string;
   currentWeight: number | null;
   today: string;
+  planStartMonth?: string | null;
+  planStartWeight?: number | null;
   overrides: MonthlyGoalOverride[];
   onOverridesChange: (overrides: MonthlyGoalOverride[]) => void;
 }
@@ -110,6 +112,8 @@ export function MonthlyGoalPlanSection({
   phase,
   currentWeight,
   today,
+  planStartMonth,
+  planStartWeight,
   overrides,
   onOverridesChange,
 }: MonthlyGoalPlanSectionProps) {
@@ -144,6 +148,8 @@ export function MonthlyGoalPlanSection({
       contestDate={contestDate}
       currentWeight={currentWeight}
       today={today}
+      planStartMonth={planStartMonth}
+      planStartWeight={planStartWeight}
       overrides={overrides}
       onOverridesChange={onOverridesChange}
       deadlineLabel={deadlineLabel}
@@ -179,6 +185,8 @@ interface PlanContentProps {
   contestDate: string;
   currentWeight: number;
   today: string;
+  planStartMonth?: string | null;
+  planStartWeight?: number | null;
   overrides: MonthlyGoalOverride[];
   onOverridesChange: (overrides: MonthlyGoalOverride[]) => void;
   deadlineLabel: string;
@@ -189,6 +197,8 @@ function PlanContent({
   contestDate,
   currentWeight,
   today,
+  planStartMonth,
+  planStartWeight,
   overrides,
   onOverridesChange,
   deadlineLabel,
@@ -199,8 +209,9 @@ function PlanContent({
   const plan = useMemo(
     () =>
       buildMonthlyGoalPlan({
-        currentWeight,
+        currentWeight: planStartWeight ?? currentWeight,
         today,
+        planStartMonth,
         finalGoalWeight: goalWeight,
         goalDeadlineDate: contestDate,
         monthlyActuals: [],
@@ -309,6 +320,7 @@ function PlanContent({
             {plan.entries.map((entry, idx) => {
               const isLast = idx === plan.entries.length - 1;
               const isCurrent = entry.month === today_month;
+              const isPast = entry.month < today_month;
               const isManual = entry.source === "manual";
 
               return (
@@ -333,7 +345,7 @@ function PlanContent({
 
                   {/* 目標体重 */}
                   <td className="px-3 py-2 text-right">
-                    {isLast ? (
+                    {isLast || isPast ? (
                       <span className="font-semibold text-teal-600 dark:text-teal-400">
                         {entry.targetWeight.toFixed(1)} kg
                       </span>
@@ -382,6 +394,19 @@ function PlanContent({
                     {isLast ? (
                       <span className="rounded-full bg-teal-50 px-2 py-0.5 text-[10px] font-semibold text-teal-600 dark:bg-teal-900/30 dark:text-teal-400">
                         終点
+                      </span>
+                    ) : isPast && isManual ? (
+                      <div className="flex flex-col items-center gap-0.5">
+                        <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-semibold text-slate-500 dark:bg-slate-700 dark:text-slate-400">
+                          履歴
+                        </span>
+                        <span className="rounded-full bg-blue-50 px-2 py-0.5 text-[10px] font-semibold text-blue-600 dark:bg-blue-900/30 dark:text-blue-400">
+                          手動
+                        </span>
+                      </div>
+                    ) : isPast ? (
+                      <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-semibold text-slate-500 dark:bg-slate-700 dark:text-slate-400">
+                        履歴
                       </span>
                     ) : isManual ? (
                       <div className="flex flex-col items-center gap-0.5">
@@ -436,7 +461,7 @@ function PlanContent({
 
       {/* 補足説明 */}
       <p className="mt-2 text-xs text-slate-400 dark:text-slate-500">
-        目標体重欄を編集して Enter / フォーカスアウトで確定。複数月を手動設定すると各月が anchor として扱われ、間の月が自動配分されます。「解除」で自動に戻せます。設定画面上部の「保存」で確定します。
+        過去月は履歴として固定表示し、今月以降のみ編集できます。複数月を手動設定すると各月が anchor として扱われ、間の月が自動配分されます。「解除」で自動に戻せます。設定画面上部の「保存」で確定します。
       </p>
     </div>
   );

--- a/src/components/settings/SettingsForm.tsx
+++ b/src/components/settings/SettingsForm.tsx
@@ -7,6 +7,7 @@ import type { Setting } from "@/lib/supabase/types";
 import { toJstDateStr } from "@/lib/utils/date";
 import type { MonthlyGoalOverride } from "@/lib/utils/monthlyGoalPlan";
 import { MonthlyGoalPlanSection } from "@/components/settings/MonthlyGoalPlanSection";
+import { resolveMonthlyPlanHistoryAnchor } from "@/lib/utils/monthlyPlanHistory";
 
 interface SettingsFormProps {
   initialSettings: Setting[];
@@ -210,6 +211,21 @@ export function SettingsForm({ initialSettings, currentWeight = null }: Settings
   const isBulk = values["current_phase"] === "Bulk";
   const deadlineLabel = isBulk ? "目標日" : "コンテスト日";
   const seasonSectionTitle = isBulk ? "シーズン・目標" : "シーズン・コンテスト";
+  const resolvedMonthlyPlanHistory = useMemo(
+    () =>
+      resolveMonthlyPlanHistoryAnchor({
+        explicitStartMonth: values["monthly_plan_start_month"] || null,
+        explicitStartWeight: (() => {
+          const parsed = parseFloat(values["monthly_plan_start_weight"] ?? "");
+          return isFinite(parsed) ? parsed : null;
+        })(),
+        goalDeadlineDate: values["contest_date"] || null,
+        overrides: monthlyPlanOverrides,
+        currentWeight,
+        today,
+      }),
+    [values, monthlyPlanOverrides, currentWeight, today]
+  );
 
   /** PFC由来kcal と target_calories_kcal の差分（絶対値 > 100 kcal で警告）*/
   const pfcConsistencyWarning = useMemo((): string | null => {
@@ -253,6 +269,10 @@ export function SettingsForm({ initialSettings, currentWeight = null }: Settings
       current_phase:           values["current_phase"] ?? "",
       sex:                     values["sex"] ?? "",
       contest_date:            values["contest_date"] ?? "",
+      monthly_plan_start_month: resolvedMonthlyPlanHistory.startMonth ?? "",
+      monthly_plan_start_weight: resolvedMonthlyPlanHistory.startWeight !== null
+        ? String(resolvedMonthlyPlanHistory.startWeight)
+        : "",
       monthly_plan_overrides:  monthlyPlanOverrides.length > 0
         ? JSON.stringify(monthlyPlanOverrides)
         : "",
@@ -401,6 +421,8 @@ export function SettingsForm({ initialSettings, currentWeight = null }: Settings
           phase={values["current_phase"] ?? "Cut"}
           currentWeight={currentWeight}
           today={today}
+          planStartMonth={resolvedMonthlyPlanHistory.startMonth}
+          planStartWeight={resolvedMonthlyPlanHistory.startWeight}
           overrides={monthlyPlanOverrides}
           onOverridesChange={setMonthlyPlanOverrides}
         />

--- a/src/lib/domain/settings.test.ts
+++ b/src/lib/domain/settings.test.ts
@@ -16,6 +16,8 @@ const fullRows = [
   { key: "age",                 value_num: 30,     value_str: null },
   { key: "height_cm",           value_num: 175,    value_str: null },
   { key: "activity_factor",     value_num: 1.55,   value_str: null },
+  { key: "monthly_plan_start_weight", value_num: 78.2, value_str: null },
+  { key: "monthly_plan_start_month",  value_num: null, value_str: "2026-03" },
 ];
 
 // ─── 正常系 ──────────────────────────────────────────────────────────────────
@@ -40,6 +42,8 @@ describe("mapToAppSettings — 正常系", () => {
     expect(result.age).toBe(30);
     expect(result.height).toBe(175);
     expect(result.activityFactor).toBe(1.55);
+    expect(result.monthlyPlanStartWeight).toBe(78.2);
+    expect(result.monthlyPlanStartMonth).toBe("2026-03");
   });
 
   test("value_num フィールドが number 型として返る", () => {
@@ -48,6 +52,7 @@ describe("mapToAppSettings — 正常系", () => {
     expect(typeof result.age).toBe("number");
     expect(typeof result.height).toBe("number");
     expect(typeof result.activityFactor).toBe("number");
+    expect(typeof result.monthlyPlanStartWeight).toBe("number");
   });
 
   test("value_str フィールドが string 型として返る", () => {
@@ -55,6 +60,7 @@ describe("mapToAppSettings — 正常系", () => {
     expect(typeof result.currentSeason).toBe("string");
     expect(typeof result.currentPhase).toBe("string");
     expect(typeof result.gender).toBe("string");
+    expect(typeof result.monthlyPlanStartMonth).toBe("string");
   });
 });
 
@@ -79,6 +85,8 @@ describe("mapToAppSettings — 欠損系", () => {
     expect(result.age).toBeNull();
     expect(result.height).toBeNull();
     expect(result.activityFactor).toBeNull();
+    expect(result.monthlyPlanStartWeight).toBeNull();
+    expect(result.monthlyPlanStartMonth).toBeNull();
   });
 
   test("空配列を渡すと全フィールドが null の AppSettings を返す", () => {

--- a/src/lib/domain/settings.ts
+++ b/src/lib/domain/settings.ts
@@ -40,6 +40,10 @@ export interface AppSettings {
   height: number | null;
   /** 活動係数 */
   activityFactor: number | null;
+  /** 月次計画の開始時基準体重 (kg) */
+  monthlyPlanStartWeight: number | null;
+  /** 月次計画の開始月 ("YYYY-MM") */
+  monthlyPlanStartMonth: string | null;
   /** 月次目標体重の手動 override リスト。DB: monthly_plan_overrides (value_str に JSON 格納) */
   monthlyPlanOverrides: MonthlyGoalOverride[] | null;
 }
@@ -94,6 +98,8 @@ export function mapToAppSettings(rows: SettingsRow[]): AppSettings {
     age:            getNum("age"),
     height:         getNum("height_cm"),
     activityFactor: getNum("activity_factor"),
+    monthlyPlanStartWeight: getNum("monthly_plan_start_weight"),
+    monthlyPlanStartMonth: getStr("monthly_plan_start_month"),
 
     // JSON 配列文字列 — value_str を JSON.parse して返す
     monthlyPlanOverrides: (() => {

--- a/src/lib/schemas/settingsSchema.test.ts
+++ b/src/lib/schemas/settingsSchema.test.ts
@@ -106,6 +106,22 @@ describe("parseSettings — 正常系", () => {
     const rec = result.records.find((r) => r.key === "current_season");
     expect(rec!.value_str).toBe("2026_TokyoNovice");
   });
+
+  it("monthly_plan_start_month が YYYY-MM 形式で通る", () => {
+    const result = parseSettings({ ...EMPTY_SETTINGS_INPUT, monthly_plan_start_month: "2026-03" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const rec = result.records.find((r) => r.key === "monthly_plan_start_month");
+    expect(rec!.value_str).toBe("2026-03");
+  });
+
+  it("monthly_plan_start_weight が数値で通る", () => {
+    const result = parseSettings({ ...EMPTY_SETTINGS_INPUT, monthly_plan_start_weight: "78.2" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const rec = result.records.find((r) => r.key === "monthly_plan_start_weight");
+    expect(rec!.value_num).toBe(78.2);
+  });
 });
 
 // ─── 異常系 ─────────────────────────────────────────────────────────────────
@@ -179,6 +195,14 @@ describe("parseSettings — 異常系", () => {
     expect(err).toBeDefined();
   });
 
+  it("monthly_plan_start_month が不正な形式で失敗する", () => {
+    const result = parseSettings({ ...EMPTY_SETTINGS_INPUT, monthly_plan_start_month: "2026/03" });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    const err = result.errors.find((e) => e.field === "monthly_plan_start_month");
+    expect(err).toBeDefined();
+  });
+
   it("複数フィールドが不正な場合、全エラーが返される", () => {
     const input: SettingsInput = {
       ...EMPTY_SETTINGS_INPUT,
@@ -223,13 +247,15 @@ describe("parseSettings — DB レコード構造", () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     const keys = result.records.map((r) => r.key);
-    // 数値系 8 キー + 文字列系 5 キー = 13 キー
-    expect(keys).toHaveLength(13);
+    // 数値系 9 キー + 文字列系 6 キー = 15 キー
+    expect(keys).toHaveLength(15);
     expect(keys).toContain("goal_weight");
     expect(keys).toContain("contest_date");
     expect(keys).toContain("current_phase");
     expect(keys).toContain("sex");
     expect(keys).toContain("current_season");
+    expect(keys).toContain("monthly_plan_start_month");
+    expect(keys).toContain("monthly_plan_start_weight");
     expect(keys).toContain("monthly_plan_overrides");
   });
 });
@@ -237,12 +263,12 @@ describe("parseSettings — DB レコード構造", () => {
 // ─── SettingsInput 型契約の検証 ───────────────────────────────────────────
 
 describe("SettingsInput — 全フィールド必須の契約", () => {
-  it("EMPTY_SETTINGS_INPUT は全 13 フィールドを持つ", () => {
+  it("EMPTY_SETTINGS_INPUT は全 15 フィールドを持つ", () => {
     // SettingsInput が全フィールド必須であることを、
     // EMPTY_SETTINGS_INPUT の実際のキー数で確認する。
     // フィールドを追加/削除した場合はここも追従する。
     const keys = Object.keys(EMPTY_SETTINGS_INPUT);
-    expect(keys).toHaveLength(13);
+    expect(keys).toHaveLength(15);
   });
 
   it("EMPTY_SETTINGS_INPUT の全フィールドが空文字", () => {
@@ -268,6 +294,8 @@ describe("SettingsInput — 全フィールド必須の契約", () => {
       current_phase: "Cut",
       sex: "male",
       contest_date: "2026-11-01",
+      monthly_plan_start_month: "2026-03",
+      monthly_plan_start_weight: "78.2",
       // monthly_plan_overrides: 未設定のケース
     };
 
@@ -284,6 +312,8 @@ describe("SettingsInput — 全フィールド必須の契約", () => {
       current_phase:           mockValues["current_phase"] ?? "",
       sex:                     mockValues["sex"] ?? "",
       contest_date:            mockValues["contest_date"] ?? "",
+      monthly_plan_start_month: mockValues["monthly_plan_start_month"] ?? "",
+      monthly_plan_start_weight: mockValues["monthly_plan_start_weight"] ?? "",
       monthly_plan_overrides:  mockValues["monthly_plan_overrides"] ?? "",
     };
 
@@ -294,6 +324,8 @@ describe("SettingsInput — 全フィールド必須の契約", () => {
     // 有効値フィールドが正しく変換されている
     expect(result.records.find((r) => r.key === "goal_weight")?.value_num).toBe(65.0);
     expect(result.records.find((r) => r.key === "current_phase")?.value_str).toBe("Cut");
+    expect(result.records.find((r) => r.key === "monthly_plan_start_month")?.value_str).toBe("2026-03");
+    expect(result.records.find((r) => r.key === "monthly_plan_start_weight")?.value_num).toBe(78.2);
     // monthly_plan_overrides は "" → null
     expect(result.records.find((r) => r.key === "monthly_plan_overrides")?.value_str).toBeNull();
   });

--- a/src/lib/schemas/settingsSchema.ts
+++ b/src/lib/schemas/settingsSchema.ts
@@ -20,6 +20,7 @@ export const NUMERIC_SETTING_KEYS = [
   "target_protein_g",
   "target_fat_g",
   "target_carbs_g",
+  "monthly_plan_start_weight",
 ] as const;
 
 /** value_str に保存する文字列系キー */
@@ -28,6 +29,7 @@ export const STRING_SETTING_KEYS = [
   "current_phase",
   "sex",
   "contest_date",
+  "monthly_plan_start_month",
   "monthly_plan_overrides",
 ] as const;
 
@@ -78,6 +80,8 @@ export interface SettingsInput {
   current_phase: string;
   sex: string;
   contest_date: string;
+  monthly_plan_start_month: string;
+  monthly_plan_start_weight: string;
   /** JSON 文字列化した MonthlyGoalOverride[]。空のときは "" を渡す。 */
   monthly_plan_overrides: string;
 }
@@ -102,6 +106,8 @@ export const EMPTY_SETTINGS_INPUT: SettingsInput = {
   current_phase: "",
   sex: "",
   contest_date: "",
+  monthly_plan_start_month: "",
+  monthly_plan_start_weight: "",
   monthly_plan_overrides: "",
 };
 
@@ -143,11 +149,13 @@ const NUMERIC_RULES: Record<NumericSettingKey, NumericRule> = {
   target_protein_g:     { min: 0,   max: 500,  label: "目標タンパク質" },
   target_fat_g:         { min: 0,   max: 300,  label: "目標脂質" },
   target_carbs_g:       { min: 0,   max: 800,  label: "目標炭水化物" },
+  monthly_plan_start_weight: { min: 20, max: 300, label: "月次計画開始時体重" },
 };
 
 const VALID_PHASES = ["Cut", "Bulk"] as const;
 const VALID_SEXES = ["male", "female"] as const;
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const YEAR_MONTH_PATTERN = /^\d{4}-\d{2}$/;
 
 // ─── ヘルパー ────────────────────────────────────────────────────────────────
 
@@ -173,6 +181,12 @@ function isValidDate(s: string): boolean {
     d.getUTCMonth() + 1 === month &&
     d.getUTCDate() === day
   );
+}
+
+function isValidYearMonth(s: string): boolean {
+  if (!YEAR_MONTH_PATTERN.test(s)) return false;
+  const [year, month] = s.split("-").map(Number) as [number, number];
+  return year >= 1900 && year <= 9999 && month >= 1 && month <= 12;
 }
 
 // ─── メインのパース・バリデーション関数 ─────────────────────────────────────
@@ -248,6 +262,16 @@ export function parseSettings(input: SettingsInput): ParseSettingsResult {
       errors.push({ field: "contest_date", message: "コンテスト日は YYYY-MM-DD 形式の有効な日付で入力してください" });
     } else {
       records.push({ key: "contest_date", value_num: null, value_str: raw !== "" ? raw : null });
+    }
+  }
+
+  // ── monthly_plan_start_month ─────────────────────────────────────────────
+  {
+    const raw = (input.monthly_plan_start_month ?? "").trim();
+    if (raw !== "" && !isValidYearMonth(raw)) {
+      errors.push({ field: "monthly_plan_start_month", message: "月次計画開始月は YYYY-MM 形式の有効な年月で入力してください" });
+    } else {
+      records.push({ key: "monthly_plan_start_month", value_num: null, value_str: raw !== "" ? raw : null });
     }
   }
 

--- a/src/lib/utils/calcMonthlyGoalProgress.test.ts
+++ b/src/lib/utils/calcMonthlyGoalProgress.test.ts
@@ -99,6 +99,8 @@ describe("calcMonthlyGoalProgress — unavailable (前提条件欠損)", () => {
   const BASE = {
     contestDate: "2026-07-31",
     targetWeight: 73.8,
+    monthlyPlanStartMonth: null,
+    monthlyPlanStartWeight: null,
     monthlyPlanOverrides: null,
     comparisonWeight: 75.0,
     today: "2026-07-15",
@@ -148,6 +150,8 @@ describe("calcMonthlyGoalProgress — 今月目標の表示", () => {
   const BASE = {
     contestDate: "2026-07-31",
     targetWeight: 73.8,
+    monthlyPlanStartMonth: null,
+    monthlyPlanStartWeight: null,
     monthlyPlanOverrides: null,
     comparisonWeight: 74.9,
     today: "2026-07-15",
@@ -207,7 +211,7 @@ describe("calcMonthlyGoalProgress — 今月目標の表示", () => {
 
     expect(result.hasData).toBe(true);
     expect(result.state).not.toBe("unavailable");
-    expect(result.monthlyTargetWeight).toBeCloseTo(74.3, 1);
+    expect(result.monthlyTargetWeight).toBeCloseTo(74.8, 1);
   });
 });
 
@@ -224,6 +228,8 @@ describe("calcMonthlyGoalProgress — 状態判定 (Cut)", () => {
     return calcMonthlyGoalProgress({
       contestDate: "2026-07-31",
       targetWeight: 73.8,
+      monthlyPlanStartMonth: null,
+      monthlyPlanStartWeight: null,
       monthlyPlanOverrides: null,
       comparisonWeight,
       today: "2026-07-15",
@@ -269,6 +275,8 @@ describe("calcMonthlyGoalProgress — 状態判定 (Bulk)", () => {
     return calcMonthlyGoalProgress({
       contestDate: "2026-07-31",
       targetWeight: 73.8,
+      monthlyPlanStartMonth: null,
+      monthlyPlanStartWeight: null,
       monthlyPlanOverrides: null,
       comparisonWeight,
       today: "2026-07-15",
@@ -302,6 +310,8 @@ describe("calcMonthlyGoalProgress — 月末当日 (daysToMonthEnd = 0)", () => 
     const result = calcMonthlyGoalProgress({
       contestDate: "2026-07-31",
       targetWeight: 73.8,
+      monthlyPlanStartMonth: null,
+      monthlyPlanStartWeight: null,
       monthlyPlanOverrides: null,
       comparisonWeight: 75.0, // 未達
       today: "2026-07-31",   // 月末当日
@@ -317,6 +327,8 @@ describe("calcMonthlyGoalProgress — 月末当日 (daysToMonthEnd = 0)", () => 
     const result = calcMonthlyGoalProgress({
       contestDate: "2026-07-31",
       targetWeight: 73.8,
+      monthlyPlanStartMonth: null,
+      monthlyPlanStartWeight: null,
       monthlyPlanOverrides: null,
       comparisonWeight: 73.5, // 達成済み
       today: "2026-07-31",
@@ -333,6 +345,8 @@ describe("calcMonthlyGoalProgress — hasWarnings", () => {
     const result = calcMonthlyGoalProgress({
       contestDate: "2026-07-31",
       targetWeight: 73.8,
+      monthlyPlanStartMonth: null,
+      monthlyPlanStartWeight: null,
       monthlyPlanOverrides: null,
       comparisonWeight: 75.0,
       today: "2026-07-15",
@@ -346,6 +360,8 @@ describe("calcMonthlyGoalProgress — hasWarnings", () => {
     const result = calcMonthlyGoalProgress({
       contestDate: "2026-12-31",
       targetWeight: 73.0,
+      monthlyPlanStartMonth: null,
+      monthlyPlanStartWeight: null,
       monthlyPlanOverrides: null,
       comparisonWeight: 75.0,
       today: "2026-07-15",
@@ -363,6 +379,8 @@ describe("calcMonthlyGoalProgress — 多月プラン", () => {
     const result = calcMonthlyGoalProgress({
       contestDate: "2026-11-30",
       targetWeight: 70.0,
+      monthlyPlanStartMonth: null,
+      monthlyPlanStartWeight: null,
       monthlyPlanOverrides: null,
       comparisonWeight: 75.0,
       today: "2026-07-15",

--- a/src/lib/utils/calcMonthlyGoalProgress.ts
+++ b/src/lib/utils/calcMonthlyGoalProgress.ts
@@ -15,6 +15,7 @@ import {
 } from "@/lib/utils/monthlyGoalPlan";
 import type { MonthlyGoalOverride } from "@/lib/utils/monthlyGoalPlan";
 import { calcDaysLeft } from "@/lib/utils/date";
+import { resolveMonthlyPlanHistoryAnchor } from "@/lib/utils/monthlyPlanHistory";
 
 // ─── 閾値定数 ─────────────────────────────────────────────────────────────────
 
@@ -162,12 +163,23 @@ function calcMonthlyProgressState(
 export function calcMonthlyGoalProgress(input: {
   contestDate: string | null;
   targetWeight: number | null;
+  monthlyPlanStartMonth: string | null;
+  monthlyPlanStartWeight: number | null;
   monthlyPlanOverrides: MonthlyGoalOverride[] | null;
   comparisonWeight: number | null;
   today: string;
   phase: string;
 }): MonthlyGoalProgress {
-  const { contestDate, targetWeight, monthlyPlanOverrides, comparisonWeight, today, phase } = input;
+  const {
+    contestDate,
+    targetWeight,
+    monthlyPlanStartMonth,
+    monthlyPlanStartWeight,
+    monthlyPlanOverrides,
+    comparisonWeight,
+    today,
+    phase,
+  } = input;
 
   const unavailable: MonthlyGoalProgress = {
     hasData: false,
@@ -186,11 +198,23 @@ export function calcMonthlyGoalProgress(input: {
     return unavailable;
   }
 
-  // buildMonthlyGoalPlan は currentWeight を起点として使う。
-  // GoalNavigator と同じ refWeight (7日平均優先) を渡すことでプランの起点を統一する。
-  const plan = buildMonthlyGoalPlan({
+  const history = resolveMonthlyPlanHistoryAnchor({
+    explicitStartMonth: monthlyPlanStartMonth,
+    explicitStartWeight: monthlyPlanStartWeight,
+    goalDeadlineDate: contestDate,
+    overrides: monthlyPlanOverrides,
     currentWeight: comparisonWeight,
     today,
+  });
+
+  if (history.startWeight === null) {
+    return unavailable;
+  }
+
+  const plan = buildMonthlyGoalPlan({
+    currentWeight: history.startWeight,
+    today,
+    planStartMonth: history.startMonth,
     finalGoalWeight: targetWeight,
     goalDeadlineDate: contestDate,
     monthlyActuals: [],

--- a/src/lib/utils/monthlyGoalPlan.test.ts
+++ b/src/lib/utils/monthlyGoalPlan.test.ts
@@ -308,7 +308,7 @@ describe("buildMonthlyGoalPlan", () => {
       );
     });
 
-    test("過去月 override は stale data として無視され、plan は invalid 化しない", () => {
+    test("planStartMonth より前の override は計画期間外として無視され、plan は invalid 化しない", () => {
       const plan = buildMonthlyGoalPlan(
         makeInput({
           overrides: [{ month: "2025-12", targetWeight: 75.0 }],
@@ -335,6 +335,25 @@ describe("buildMonthlyGoalPlan", () => {
       expect(plan.entries.at(-1)?.targetWeight).toBe(72.0);
     });
 
+    test("開始月を過去に固定すると履歴月も entries に含まれる", () => {
+      const plan = buildMonthlyGoalPlan(
+        makeInput({
+          today: "2026-04-02",
+          planStartMonth: "2026-03",
+          currentWeight: 78.0,
+          overrides: [{ month: "2026-05", targetWeight: 74.0 }],
+        })
+      );
+      expect(plan.isValid).toBe(true);
+      expect(plan.entries.map((entry) => entry.month)).toEqual([
+        "2026-03",
+        "2026-04",
+        "2026-05",
+        "2026-06",
+      ]);
+      expect(plan.entries[0]?.targetWeight).toBeCloseTo(76.7, 1);
+    });
+
     test("errors がある場合 entries は空配列", () => {
       const plan = buildMonthlyGoalPlan(
         makeInput({ goalDeadlineDate: "bad-date" })
@@ -345,7 +364,7 @@ describe("buildMonthlyGoalPlan", () => {
 });
 
 describe("normalizeMonthlyGoalOverrides", () => {
-  test("current month より前・期限月・期限後の override を除外する", () => {
+  test("planStartMonth より前・期限月・期限後の override を除外する", () => {
     const result = normalizeMonthlyGoalOverrides({
       overrides: [
         { month: "2026-02", targetWeight: 77.0 },
@@ -354,7 +373,7 @@ describe("normalizeMonthlyGoalOverrides", () => {
         { month: "2026-06", targetWeight: 72.5 },
         { month: "2026-07", targetWeight: 71.0 },
       ],
-      today: "2026-03-15",
+      planStartMonth: "2026-03",
       goalDeadlineDate: "2026-06-30",
     });
 
@@ -368,7 +387,7 @@ describe("normalizeMonthlyGoalOverrides", () => {
     const overrides = [{ month: "2026-03", targetWeight: 76.0 }];
     const result = normalizeMonthlyGoalOverrides({
       overrides,
-      today: "2026-03-15",
+      planStartMonth: "2026-03",
       goalDeadlineDate: "invalid-date",
     });
 

--- a/src/lib/utils/monthlyGoalPlan.ts
+++ b/src/lib/utils/monthlyGoalPlan.ts
@@ -8,9 +8,9 @@
  *   月別サマリー・月末実績と対応づけやすく、月単位の計画として最も自然な単位。
  *
  * ## 計画の範囲
- * - currentMonth (today の YYYY-MM) から deadlineMonth (goalDeadlineDate の YYYY-MM) まで。
- * - 過去月 (currentMonth より前) はこの計画に含めない。
- *   過去実績は monthlyActuals として入力され、表示用に actualWeight へ記録する。
+ * - planStartMonth から deadlineMonth (goalDeadlineDate の YYYY-MM) まで。
+ * - planStartMonth を省略した場合は today の当月を開始月とみなす。
+ * - 履歴 plan では過去月も entries に含み、月次計画 vs 実績の比較に利用する。
  *
  * ## 再配分ルール
  * - override を「アンカー」として扱い、アンカー間を線形補間で均等配分する。
@@ -18,8 +18,8 @@
  * - 最終月への override は無視し、常に finalGoalWeight を使う。
  *
  * ## override の寿命管理
- * - override は currentMonth (today の YYYY-MM) から deadlineMonth までだけを有効とする。
- * - currentMonth より前の override は stale data とみなし無視する。
+ * - override は planStartMonth から deadlineMonth までだけを有効とする。
+ * - planStartMonth より前の override は計画期間外データとして無視する。
  * - deadlineMonth より後の override も計画外データとして無視する。
  * - deadlineMonth 自体の override は無視する。最終月は常に finalGoalWeight が唯一の正規値。
  *
@@ -99,12 +99,14 @@ export interface MonthlyActual {
 /** buildMonthlyGoalPlan への入力 */
 export interface MonthlyGoalPlanInput {
   /**
-   * 現在体重 (kg)。
-   * 7日平均推奨。なければ最新の daily_logs weight。
+   * 計画起点体重 (kg)。
+   * 履歴 plan では開始時基準体重、rolling plan では currentWeight を渡す。
    */
   currentWeight: number;
   /** 今日の日付 "YYYY-MM-DD" (JST)。toJstDateStr() の値を渡すこと。 */
   today: string;
+  /** 月次計画の開始月 "YYYY-MM"。省略時は today の当月。 */
+  planStartMonth?: string | null;
   /** 最終目標体重 (kg)。settings.targetWeight に対応。 */
   finalGoalWeight: number;
   /** 大会・目標期限 "YYYY-MM-DD"。settings.contestDate に対応。 */
@@ -159,7 +161,7 @@ export interface MonthlyGoalPlan {
 
 interface NormalizeMonthlyGoalOverridesInput {
   overrides: MonthlyGoalOverride[];
-  today: string;
+  planStartMonth: string;
   goalDeadlineDate: string;
 }
 
@@ -246,10 +248,18 @@ function validateInput(input: MonthlyGoalPlanInput): MonthlyGoalError[] {
   if (errors.length > 0) return errors;
 
   const todayMonth = toYearMonth(input.today);
+  const planStartMonth =
+    input.planStartMonth && /^\d{4}-\d{2}$/.test(input.planStartMonth)
+      ? input.planStartMonth
+      : todayMonth;
   const deadlineMonth = toYearMonth(input.goalDeadlineDate);
 
   if (deadlineMonth < todayMonth) {
     errors.push({ code: "DEADLINE_IN_PAST" });
+  }
+
+  if (deadlineMonth < planStartMonth) {
+    errors.push({ code: "NO_MONTHS" });
   }
 
   return errors;
@@ -259,7 +269,7 @@ function validateInput(input: MonthlyGoalPlanInput): MonthlyGoalError[] {
  * 月次計画で有効な override だけを残す。
  *
  * ルール:
- * - currentMonth より前の stale override は除外
+ * - planStartMonth より前の override は除外
  * - deadlineMonth より後の override は除外
  * - deadlineMonth は finalGoalWeight が唯一の正規値なので除外
  *
@@ -276,12 +286,11 @@ export function normalizeMonthlyGoalOverrides(
     return input.overrides;
   }
 
-  const todayMonth = toYearMonth(input.today);
   const deadlineMonth = toYearMonth(input.goalDeadlineDate);
 
   return input.overrides.filter((override) => {
     if (typeof override.month !== "string") return false;
-    return override.month >= todayMonth && override.month < deadlineMonth;
+    return override.month >= input.planStartMonth && override.month < deadlineMonth;
   });
 }
 
@@ -306,8 +315,12 @@ export function buildMonthlyGoalPlan(
   }
 
   const todayMonth = toYearMonth(input.today);
+  const planStartMonth =
+    input.planStartMonth && /^\d{4}-\d{2}$/.test(input.planStartMonth)
+      ? input.planStartMonth
+      : todayMonth;
   const deadlineMonth = toYearMonth(input.goalDeadlineDate);
-  const months = buildMonthRange(todayMonth, deadlineMonth);
+  const months = buildMonthRange(planStartMonth, deadlineMonth);
 
   if (months.length === 0) {
     return {
@@ -321,7 +334,7 @@ export function buildMonthlyGoalPlan(
   // stale / out-of-range / 最終月 override は無視し、有効範囲だけを使う。
   const normalizedOverrides = normalizeMonthlyGoalOverrides({
     overrides: input.overrides,
-    today: input.today,
+    planStartMonth,
     goalDeadlineDate: input.goalDeadlineDate,
   });
 

--- a/src/lib/utils/monthlyGoalVisualization.test.ts
+++ b/src/lib/utils/monthlyGoalVisualization.test.ts
@@ -281,6 +281,26 @@ describe("buildMonthlyGoalSummaryRows — 過去月", () => {
   });
 });
 
+describe("buildMonthlyGoalSummaryRows — 履歴 plan", () => {
+  it("planStartMonth を過去に固定すると過去月の計画行も保持される", () => {
+    const plan = buildMonthlyGoalPlan({
+      currentWeight: 78.0,
+      today: "2026-04-02",
+      planStartMonth: "2026-03",
+      finalGoalWeight: 72.0,
+      goalDeadlineDate: "2026-06-30",
+      monthlyActuals: [],
+      overrides: [{ month: "2026-05", targetWeight: 74.0 }],
+    });
+
+    const rows = buildMonthlyGoalSummaryRows(plan, [log("2026-03-31", 76.8)], "2026-04-02");
+    expect(rows.map((row) => row.month)).toEqual(["2026-03", "2026-04", "2026-05", "2026-06"]);
+    expect(rows[0]?.actualMonthEndWeight).toBe(76.8);
+    expect(rows[0]?.isCurrentMonth).toBe(false);
+    expect(rows[0]?.isFutureMonth).toBe(false);
+  });
+});
+
 // ─── buildMonthlyGoalSummaryRows — 月初体重 ─────────────────────────────────
 
 describe("buildMonthlyGoalSummaryRows — 月初体重の定義", () => {

--- a/src/lib/utils/monthlyPlanHistory.test.ts
+++ b/src/lib/utils/monthlyPlanHistory.test.ts
@@ -1,0 +1,57 @@
+import { resolveMonthlyPlanHistoryAnchor } from "./monthlyPlanHistory";
+
+describe("resolveMonthlyPlanHistoryAnchor", () => {
+  it("保存済み start metadata があればそれを優先する", () => {
+    const result = resolveMonthlyPlanHistoryAnchor({
+      explicitStartMonth: "2026-03",
+      explicitStartWeight: 78.2,
+      goalDeadlineDate: "2026-06-30",
+      overrides: [{ month: "2026-04", targetWeight: 75.0 }],
+      currentWeight: 74.8,
+      today: "2026-04-02",
+    });
+
+    expect(result).toEqual({
+      startMonth: "2026-03",
+      startWeight: 78.2,
+      source: "explicit",
+    });
+  });
+
+  it("legacy data では最古 override を開始アンカーとして使う", () => {
+    const result = resolveMonthlyPlanHistoryAnchor({
+      explicitStartMonth: null,
+      explicitStartWeight: null,
+      goalDeadlineDate: "2026-06-30",
+      overrides: [
+        { month: "2026-05", targetWeight: 73.5 },
+        { month: "2026-03", targetWeight: 76.0 },
+      ],
+      currentWeight: 74.8,
+      today: "2026-04-02",
+    });
+
+    expect(result).toEqual({
+      startMonth: "2026-03",
+      startWeight: 76.0,
+      source: "legacy_override",
+    });
+  });
+
+  it("履歴 metadata も override もなければ current month/current weight を使う", () => {
+    const result = resolveMonthlyPlanHistoryAnchor({
+      explicitStartMonth: null,
+      explicitStartWeight: null,
+      goalDeadlineDate: "2026-06-30",
+      overrides: [],
+      currentWeight: 74.8,
+      today: "2026-04-02",
+    });
+
+    expect(result).toEqual({
+      startMonth: "2026-04",
+      startWeight: 74.8,
+      source: "current_month",
+    });
+  });
+});

--- a/src/lib/utils/monthlyPlanHistory.ts
+++ b/src/lib/utils/monthlyPlanHistory.ts
@@ -1,0 +1,91 @@
+import type { MonthlyGoalOverride } from "@/lib/utils/monthlyGoalPlan";
+import { parseLocalDateStr } from "@/lib/utils/date";
+
+export interface ResolveMonthlyPlanHistoryInput {
+  explicitStartMonth?: string | null;
+  explicitStartWeight?: number | null;
+  goalDeadlineDate?: string | null;
+  overrides?: MonthlyGoalOverride[] | null;
+  currentWeight?: number | null;
+  today: string;
+}
+
+export interface MonthlyPlanHistoryAnchor {
+  startMonth: string | null;
+  startWeight: number | null;
+  source: "explicit" | "legacy_override" | "current_month" | "unavailable";
+}
+
+export function isValidYearMonth(value: string | null | undefined): value is string {
+  return typeof value === "string" && /^\d{4}-\d{2}$/.test(value);
+}
+
+function isValidWeight(value: number | null | undefined): value is number {
+  return typeof value === "number" && isFinite(value) && value > 0 && value <= 300;
+}
+
+function toDeadlineMonth(goalDeadlineDate: string | null | undefined): string | null {
+  if (!goalDeadlineDate || parseLocalDateStr(goalDeadlineDate) === null) return null;
+  return goalDeadlineDate.slice(0, 7);
+}
+
+/**
+ * 月次計画の履歴アンカー (開始月 + 開始時基準体重) を解決する。
+ *
+ * 優先順位:
+ * 1. 保存済みの explicit start metadata
+ * 2. legacy data の最古 override 月 (その月の手動 target を開始アンカーとみなす)
+ * 3. 現在月 + 現在体重
+ *
+ * legacy データでは開始時の基準体重が保存されていないため、
+ * 最古 override 月を plan start とし、その targetWeight を開始アンカーとして扱う。
+ * これにより past override を履歴として残しつつ、過去月の plan rows を継続表示できる。
+ */
+export function resolveMonthlyPlanHistoryAnchor(
+  input: ResolveMonthlyPlanHistoryInput
+): MonthlyPlanHistoryAnchor {
+  const deadlineMonth = toDeadlineMonth(input.goalDeadlineDate);
+  const todayMonth = input.today.slice(0, 7);
+
+  if (
+    isValidYearMonth(input.explicitStartMonth) &&
+    isValidWeight(input.explicitStartWeight) &&
+    (deadlineMonth === null || input.explicitStartMonth <= deadlineMonth)
+  ) {
+    return {
+      startMonth: input.explicitStartMonth,
+      startWeight: input.explicitStartWeight,
+      source: "explicit",
+    };
+  }
+
+  const validOverrides = (input.overrides ?? [])
+    .filter((override) =>
+      isValidYearMonth(override.month) &&
+      isValidWeight(override.targetWeight) &&
+      (deadlineMonth === null || override.month <= deadlineMonth)
+    )
+    .sort((a, b) => a.month.localeCompare(b.month));
+
+  if (validOverrides.length > 0) {
+    return {
+      startMonth: validOverrides[0]!.month,
+      startWeight: validOverrides[0]!.targetWeight,
+      source: "legacy_override",
+    };
+  }
+
+  if (deadlineMonth !== null && isValidWeight(input.currentWeight)) {
+    return {
+      startMonth: todayMonth,
+      startWeight: input.currentWeight,
+      source: "current_month",
+    };
+  }
+
+  return {
+    startMonth: null,
+    startWeight: null,
+    source: "unavailable",
+  };
+}

--- a/src/lib/utils/normalizeMonthlyPlanOverridesBeforeSave.ts
+++ b/src/lib/utils/normalizeMonthlyPlanOverridesBeforeSave.ts
@@ -1,5 +1,6 @@
 import { parseLocalDateStr } from "@/lib/utils/date";
 import { normalizeMonthlyGoalOverrides } from "@/lib/utils/monthlyGoalPlan";
+import { resolveMonthlyPlanHistoryAnchor } from "@/lib/utils/monthlyPlanHistory";
 import type { SettingsInput } from "@/lib/schemas/settingsSchema";
 
 export function normalizeMonthlyPlanOverridesBeforeSave(
@@ -17,14 +18,34 @@ export function normalizeMonthlyPlanOverridesBeforeSave(
     const parsed = JSON.parse(rawOverrides);
     if (!Array.isArray(parsed)) return input;
 
-    const normalized = normalizeMonthlyGoalOverrides({
-      overrides: parsed,
-      today,
+    const history = resolveMonthlyPlanHistoryAnchor({
+      explicitStartMonth: input.monthly_plan_start_month || null,
+      explicitStartWeight: (() => {
+        const parsedWeight = parseFloat(input.monthly_plan_start_weight ?? "");
+        return isFinite(parsedWeight) ? parsedWeight : null;
+      })(),
       goalDeadlineDate: contestDate,
+      overrides: parsed,
+      currentWeight: (() => {
+        const parsedWeight = parseFloat(input.monthly_plan_start_weight ?? "");
+        return isFinite(parsedWeight) ? parsedWeight : null;
+      })(),
+      today,
     });
+
+    const normalized = history.startMonth
+      ? normalizeMonthlyGoalOverrides({
+          overrides: parsed,
+          planStartMonth: history.startMonth,
+          goalDeadlineDate: contestDate,
+        })
+      : parsed;
 
     return {
       ...input,
+      monthly_plan_start_month: history.startMonth ?? "",
+      monthly_plan_start_weight:
+        history.startWeight !== null ? String(history.startWeight) : "",
       monthly_plan_overrides:
         normalized.length > 0 ? JSON.stringify(normalized) : "",
     };


### PR DESCRIPTION
## 概要
月次目標計画に開始月と開始時基準体重を持たせ、today 起点の rolling plan ではなく履歴として再構築できるようにしました。これにより、3月に設定した月次計画や手動 override を4月以降も履歴として参照でき、ダッシュボードの「月次計画 vs 実績」で過去月の差分・状態・累積ズレを継続表示できます。

## 現状仕様とのズレ
従来の `monthlyGoalPlan` は `today` / current month を起点に month range を再構築していたため、月をまたぐたびに過去月の auto plan と override が計画から脱落していました。その結果、過去月の計画履歴を継続参照できず、ダッシュボード側の比較表も rolling plan 前提の表示になっていました。

## 変更内容
- settings に `monthly_plan_start_month` と `monthly_plan_start_weight` を追加し、履歴 plan の固定アンカーを保存
- `resolveMonthlyPlanHistoryAnchor` を追加し、開始月の canonical な解決ロジックを導入
- `buildMonthlyGoalPlan` を `planStartMonth -> deadlineMonth` で計画を組み立てる履歴 plan に変更
- override 正規化も `today` 基準ではなく `planStartMonth` 基準に更新
- Settings の月次計画 UI は過去月行を履歴として表示し、今月以降のみ編集可能に変更
- Dashboard は履歴 plan アンカーを使って月次比較表・差分・累積ズレを継続表示するよう調整
- `calcMonthlyGoalProgress` は履歴 plan 上の今月 target を参照するよう更新

## 開始月の保存・解釈方針
- canonical source は settings の `monthly_plan_start_month` / `monthly_plan_start_weight`
- 明示アンカーがあればそれを最優先で使用
- 明示アンカーが未保存の既存データでは、最古 override を開始月アンカーとして採用
- override もアンカーも無い場合のみ、current month / current weight 起点の初期挙動にフォールバック

## 既存データの扱い
- 既存ユーザーでも保存済み override があれば、最古 override をアンカーに履歴 plan を再構築します
- 明示 start metadata が無い legacy settings でも、可能な限り過去月履歴を救済します
- 完全に新規または override なしのデータだけ current month 起点の初期値にフォールバックします

## テスト / 確認内容
- `npm test -- --runInBand src/lib/utils/monthlyGoalPlan.test.ts src/lib/utils/monthlyGoalVisualization.test.ts src/lib/utils/calcMonthlyGoalProgress.test.ts src/lib/utils/monthlyPlanHistory.test.ts src/lib/domain/settings.test.ts src/lib/schemas/settingsSchema.test.ts src/components/settings/MonthlyGoalPlanSection.integration.test.tsx src/app/settings/actions.test.ts`
- `npx tsc --noEmit`

## 影響範囲
- Settings の月次目標計画表示
- Dashboard の「月次計画 vs 実績」
- 今月目標進捗の計算
- 月次 override の保存時正規化

Closes #418