### PR TITLE
feat: remove unused actual column from monthly target plan table

### DIFF
--- a/src/components/settings/MonthlyGoalPlanSection.tsx
+++ b/src/components/settings/MonthlyGoalPlanSection.tsx
@@ -313,7 +313,6 @@ function PlanContent({
               <th className="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500">目標体重</th>
               <th className="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500">前月比</th>
               <th className="px-3 py-2 text-center text-xs font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500">種別</th>
-              <th className="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500">実績</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-slate-50 dark:divide-slate-700/60">
@@ -429,14 +428,6 @@ function PlanContent({
                     )}
                   </td>
 
-                  {/* 実績 */}
-                  <td className="px-3 py-2 text-right">
-                    {entry.actualWeight !== null ? (
-                      <span className="text-slate-600 dark:text-slate-300">{entry.actualWeight.toFixed(1)} kg</span>
-                    ) : (
-                      <span className="text-slate-300 dark:text-slate-600">—</span>
-                    )}
-                  </td>
                 </tr>
               );
             })}


### PR DESCRIPTION
## 概要

設定画面の月次目標計画テーブルから、未使用の「実績」列を削除します。

## 変更内容

- `MonthlyGoalPlanSection.tsx` の `<thead>` から「実績」列ヘッダー (`<th>`) を削除
- 各月行の `<tbody>` から「実績」セル (`<td>`) を削除
- テーブルは 5 列 → 4 列（月・目標体重・前月比・種別）に変更

## 判断理由

「実績」列は `entry.actualWeight` が常に `null` のため全行で `—` 表示となっており、情報を持たない未使用 UI でした。削除することで可読性が向上し、列数不整合のリスクもなくなります。

## 影響範囲

- 変更は表示レイヤーのみ（ヘッダー + 行セルの削除）
- 月次目標計画の計算ロジック（`buildMonthlyGoalPlan`）・保存ロジックには一切変更なし
- 編集機能（目標体重インライン入力・手動 override・解除ボタン）は影響なし

## 確認内容

- TypeScript 型チェック（`tsc --noEmit`）: エラーなし
- テーブルのヘッダー列数と行セル数が 4 列で一致していることを目視確認
- 将来の実績表示再導入は `entry.actualWeight` の値を使い `<td>` を追加するだけで対応可能

## 補足

`entry.actualWeight` フィールドは `MonthlyGoalPlanEntry` 型に引き続き存在するため、将来の再導入余地は保たれています。

Closes #421