### PR TITLE
fix: prevent wrapping in monthly plan vs actual table on mobile

### DIFF
--- a/src/components/dashboard/MonthlyGoalTable.tsx
+++ b/src/components/dashboard/MonthlyGoalTable.tsx
@@ -26,21 +26,21 @@ function ProgressBadge({ state }: { state: MonthlyPlanProgressState }) {
   }
   if (state === "on_track") {
     return (
-      <span className="rounded-full bg-slate-100 px-1.5 py-0.5 text-[9px] font-semibold text-slate-500 dark:bg-slate-700 dark:text-slate-400">
+      <span className="whitespace-nowrap rounded-full bg-slate-100 px-1.5 py-0.5 text-[9px] font-semibold text-slate-500 dark:bg-slate-700 dark:text-slate-400">
         計画内
       </span>
     );
   }
   if (state === "ahead") {
     return (
-      <span className="rounded-full bg-emerald-50 px-1.5 py-0.5 text-[9px] font-semibold text-emerald-600 dark:bg-emerald-900/30 dark:text-emerald-400">
+      <span className="whitespace-nowrap rounded-full bg-emerald-50 px-1.5 py-0.5 text-[9px] font-semibold text-emerald-600 dark:bg-emerald-900/30 dark:text-emerald-400">
         先行
       </span>
     );
   }
   // "behind"
   return (
-    <span className="rounded-full bg-rose-50 px-1.5 py-0.5 text-[9px] font-semibold text-rose-500 dark:bg-rose-900/30 dark:text-rose-400">
+    <span className="whitespace-nowrap rounded-full bg-rose-50 px-1.5 py-0.5 text-[9px] font-semibold text-rose-500 dark:bg-rose-900/30 dark:text-rose-400">
       遅れ
     </span>
   );
@@ -97,7 +97,7 @@ export function MonthlyGoalTable({ rows, phase }: MonthlyGoalTableProps) {
                     {row.monthEndTarget.toFixed(1)} kg
                   </td>
                   {/* 実績月末 */}
-                  <td className="py-2 pr-3 text-right text-xs font-semibold text-slate-700 dark:text-slate-200">
+                  <td className="py-2 pr-3 text-right text-xs font-semibold text-slate-700 whitespace-nowrap dark:text-slate-200">
                     {row.isFutureMonth ? (
                       <span className="font-normal text-slate-300 dark:text-slate-600">—</span>
                     ) : row.actualMonthEndWeight !== null ? (


### PR DESCRIPTION
## 概要

ダッシュボードの「月次計画 VS 実績」テーブルにおけるモバイル表示の改行崩れを修正します。

## 変更内容

- `MonthlyGoalTable.tsx` の「実績月末」`<td>` に `whitespace-nowrap` を追加
- `ProgressBadge` の `計画内` / `先行` / `遅れ` 各バッジ `<span>` に `whitespace-nowrap` を追加

差分は 4行変更（追加 4 / 削除 4）のみ。

## 原因

- **「実績月末」**: セルの内容が `{value} kg` テキストノード + `*` span の React Fragment で構成されており、`<td>` に `whitespace-nowrap` がなかったため、モバイル幅で `kg` と `*` の間（または `kg` の手前）で折り返しが発生していた。
- **「状態」バッジ**: `ProgressBadge` の各 `<span>` に `whitespace-nowrap` がなかったため、バッジ文字列（`遅れ` 等）がセル幅不足で途中改行されていた。

## 判断理由

いずれも `whitespace-nowrap` の追加のみで解決できる最小差分。集計ロジック・計算ロジック・テーブル構成には一切手を入れていない。

## 影響範囲

- 変更は表示レイヤーのみ
- `whitespace-nowrap` はセル内改行を禁止するだけで、テーブル全体の横スクロール（`overflow-x-auto` 済み）で吸収されるため、デスクトップ表示への悪影響なし
- `*` 注記の意味・表示条件・ステータス判定ロジックは変更なし

## 確認内容

- TypeScript 型チェック（`tsc --noEmit`）: エラーなし

## 補足

「月次計画 VS 実績」テーブルはダッシュボードの `LogsAndSummaryTabs` → 月別サマリータブ内の `MonthlyGoalTable` コンポーネントで描画されています（履歴画面ではなくダッシュボード）。

Closes #423