### PR TITLE
feat: reflect ended deadline states in history and forecast views

### DIFF
--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -119,8 +119,10 @@ export default async function HistoryPage() {
       <div className="space-y-6">
         {allCareerLogs.length > 0 ? (
           <>
-            {/* 今日基準近傍比較 (メイン判断用) — Bulk 時は非表示 */}
-            {isCut && todayDaysOut !== null && (
+            {/* 今日基準近傍比較 (メイン判断用) — Bulk 時・大会後は非表示
+                todayDaysOut > 0: deadline を超過しているため比較は意味をなさない。
+                todayDaysOut = 0 (deadline 当日) は進行中として表示を維持する。 */}
+            {isCut && todayDaysOut !== null && todayDaysOut <= 0 && (
               <TodayWindowComparison
                 entries={todayWindowEntries}
                 currentSeason={currentSeasonLabel}

--- a/src/components/charts/ForecastChart.tsx
+++ b/src/components/charts/ForecastChart.tsx
@@ -132,6 +132,10 @@ export function ForecastChart({
     monthlyGoalTarget: monthlyGoalDateMap.get(date),
   }));
 
+  // contestDate が今日より前かどうか (参照線のスタイル切り替えに使用)
+  // 未来・当日: 実線 + 赤、過去: 点線 + 低コントラスト + "（終了）" ラベル
+  const isContestPast = contestDate ? contestDate < today : false;
+
   // Y 軸範囲
   const visibleActual = allDates
     .map((d) => actualMap.get(d))
@@ -259,9 +263,15 @@ export function ForecastChart({
           {showFutureSeries && contestDate && (
             <ReferenceLine
               x={contestDate}
-              stroke="#ef4444"
-              strokeWidth={2}
-              label={{ value: phase === "Bulk" ? "目標日" : "大会", fontSize: 10, fill: "#ef4444", position: "top" }}
+              stroke={isContestPast ? (isDark ? "#64748b" : "#94a3b8") : "#ef4444"}
+              strokeWidth={isContestPast ? 1 : 2}
+              strokeDasharray={isContestPast ? "4 4" : undefined}
+              label={{
+                value: `${phase === "Bulk" ? "目標日" : "大会"}${isContestPast ? "（終了）" : ""}`,
+                fontSize: 10,
+                fill: isContestPast ? (isDark ? "#64748b" : "#94a3b8") : "#ef4444",
+                position: "top",
+              }}
             />
           )}
 


### PR DESCRIPTION
## 概要

親 Issue #426「Cut / Bulk 切り替え運用の終了状態対応」配下の子 Issue #428 の担当範囲として、History ページと ForecastChart における「終了後の見え方」を整理しました。

## 担当範囲（#428）

- `history/page.tsx`: `TodayWindowComparison` の表示制御
- `ForecastChart.tsx`: `contestDate` 参照線のスタイル切り替え

## History 側の非表示条件

**採用条件: `isCut && todayDaysOut !== null && todayDaysOut <= 0`**

`todayDaysOut` = `today - contestDate`（日数差）であり:
- `< 0`: deadline 前（表示）
- `= 0`: deadline 当日（表示。`deadline_today` 相当でまだ進行中）
- `> 0`: deadline 超過（非表示。大会後は近傍比較が意味をなさない）

Issue 本文の `todayDaysOut > 0` 条件と自然言語「大会後」は一致しており、曖昧さなし。  
Bulk はすでに `isCut` 条件で非表示のため影響なし。

## ForecastChart 側の過去日参照線の扱い

`contestDate < today` のとき:
- stroke: 低コントラスト（`#94a3b8` / dark: `#64748b`）
- strokeWidth: 2 → 1
- strokeDasharray: `"4 4"`（点線）
- label: `"大会"` / `"目標日"` → `"大会（終了）"` / `"目標日（終了）"`

未来・当日の場合は既存の見え方（赤実線）を維持。予測ロジック・データ整形・モデル判定には一切触れていません。

## 他子 Issue に残した論点

- **#427 向け**: ダッシュボードの終了状態表示はすでに対応済み
- **#429 向け**: Settings の移行ガイド・フェーズ切り替え導線は今回スコープ外

## 影響範囲

| ファイル | 変更内容 |
|---|---|
| `src/app/history/page.tsx` | TodayWindowComparison の表示条件に `todayDaysOut <= 0` を追加 |
| `src/components/charts/ForecastChart.tsx` | contestDate 参照線のスタイルを `isContestPast` で分岐 |

## 補足

- 表示のみの変更。予測値・ペース計算・モデル選択には触れていません
- `contest_date` の rename や DB 変更は行っていません
- `isCut` / `todayDaysOut` / `isDark` はすべて既存変数を再利用

Closes #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)