### PR TITLE
feat: add settings transition guide for ended cut and bulk phases

### DIFF
--- a/src/components/settings/SettingsForm.tsx
+++ b/src/components/settings/SettingsForm.tsx
@@ -4,7 +4,7 @@ import { useState, useMemo } from "react";
 import { Save, CheckCircle2, AlertCircle, Loader2, ChevronDown } from "lucide-react";
 import { saveSettings } from "@/app/settings/actions";
 import type { Setting } from "@/lib/supabase/types";
-import { toJstDateStr } from "@/lib/utils/date";
+import { toJstDateStr, calcDaysLeft } from "@/lib/utils/date";
 import type { MonthlyGoalOverride } from "@/lib/utils/monthlyGoalPlan";
 import { MonthlyGoalPlanSection } from "@/components/settings/MonthlyGoalPlanSection";
 import { resolveMonthlyPlanHistoryAnchor } from "@/lib/utils/monthlyPlanHistory";
@@ -210,6 +210,12 @@ export function SettingsForm({ initialSettings, currentWeight = null }: Settings
   // フェーズに応じた deadline 文言 (values はリアクティブなため切り替えが即反映される)
   const isBulk = values["current_phase"] === "Bulk";
   const deadlineLabel = isBulk ? "目標日" : "コンテスト日";
+
+  // 終了状態判定: 内部保存キーは contest_date のまま、UI 上は deadline / 大会日 / 目標日として扱う
+  // values["contest_date"] がリアクティブなため、フォーム編集で即時非表示になる
+  const deadlineStr = values["contest_date"] ?? "";
+  const daysLeft = deadlineStr ? calcDaysLeft(today, deadlineStr) : null;
+  const isDeadlineEnded = daysLeft !== null && daysLeft < 0;
   const seasonSectionTitle = isBulk ? "シーズン・目標" : "シーズン・コンテスト";
   const resolvedMonthlyPlanHistory = useMemo(
     () =>
@@ -304,8 +310,48 @@ export function SettingsForm({ initialSettings, currentWeight = null }: Settings
     }
   }
 
+  // 移行ガイドのリスト項目: Cut 終了時と Bulk 終了時で内容を分ける
+  const transitionGuideItems = isBulk
+    ? [
+        "目標日を更新",
+        "目標体重を更新",
+        "必要に応じてシーズン名・フェーズを変更",
+        "月次計画のオーバーライドをリセット",
+      ]
+    : [
+        "フェーズを Bulk に変更",
+        "目標日（増量終了日）を設定",
+        "目標体重を増量目標に更新",
+        "シーズン名を更新",
+        "月次計画のオーバーライドをリセット",
+      ];
+
   return (
     <div className="rounded-2xl border border-slate-100 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900 dark:shadow-none">
+
+      {/* ── フェーズ移行ガイド (deadline 終了時のみ表示) ──
+          表示条件: daysLeft < 0 (deadline 超過)。deadline を更新するとリアクティブに消える。
+          Cut 終了: フェーズ移行ガイド / Bulk 終了: 目標更新ガイド */}
+      {isDeadlineEnded && (
+        <div className="mb-6 rounded-xl border border-amber-100 bg-amber-50 px-5 py-4 dark:border-amber-700/50 dark:bg-amber-900/30">
+          <p className="text-sm font-semibold text-amber-800 dark:text-amber-300">
+            {isBulk ? "目標更新ガイド" : "フェーズ移行ガイド"}
+          </p>
+          <p className="mt-1 text-xs text-amber-700 dark:text-amber-400">
+            {isBulk
+              ? "増量期間終了後のため、次の目標設定を案内します。"
+              : "大会終了後のため、次フェーズへの移行準備を案内します。"}
+          </p>
+          <ul className="mt-3 space-y-1.5">
+            {transitionGuideItems.map((item) => (
+              <li key={item} className="flex items-center gap-2 text-xs text-amber-700 dark:text-amber-400">
+                <span className="h-1.5 w-1.5 flex-shrink-0 rounded-full bg-amber-400 dark:bg-amber-500" aria-hidden="true" />
+                {item}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
 
       {/* ── セクション 1: シーズン・コンテスト (デフォルト展開) ── */}
       <div>


### PR DESCRIPTION
## 概要

親 Issue #426「Cut / Bulk 切り替え運用の終了状態対応」配下の子 Issue #429 として、設定画面に終了状態の移行ガイドを追加しました。

## 担当範囲（#429）

- `SettingsForm.tsx` に移行ガイドを追加

## Settings ガイドの表示条件

`daysLeft < 0`（内部 `contest_date` が今日より前）のときのみ表示。  
`values["contest_date"]` はリアクティブなため、ユーザーが deadline フィールドを未来日に編集すると保存前でも即時非表示になります。

## Cut / Bulk での見出し・文言分岐

| 状態 | 見出し | 説明 |
|---|---|---|
| Cut 終了（`!isBulk && isDeadlineEnded`） | フェーズ移行ガイド | 大会終了後のため、次フェーズへの移行準備を案内します |
| Bulk 終了（`isBulk && isDeadlineEnded`） | 目標更新ガイド | 増量期間終了後のため、次の目標設定を案内します |

**Cut 終了のリスト項目（5件）:**
1. フェーズを Bulk に変更
2. 目標日（増量終了日）を設定
3. 目標体重を増量目標に更新
4. シーズン名を更新
5. 月次計画のオーバーライドをリセット

**Bulk 終了のリスト項目（4件）:**
1. 目標日を更新
2. 目標体重を更新
3. 必要に応じてシーズン名・フェーズを変更
4. 月次計画のオーバーライドをリセット

## internal contestDate と UI deadline の整理

- 内部保存キー: `contest_date`（変更なし）
- Cut UI: 「大会日」「コンテスト日」
- Bulk UI: 「目標日」

ガイド内の文言は `contest_date` に引きずられず、Cut 時は「大会終了後」、Bulk 時は「増量期間終了後」として自然な日本語に統一しました。`isDeadlineEnded` の算出にもコメントでこの整理を明記しています。

## 他子 Issue に残した論点

- **#427**: ダッシュボードの終了バナー・GoalNavigator ガイド → 対応済み
- **#428**: History / Forecast 表示制御 → 対応済み

## 影響範囲

| ファイル | 変更内容 |
|---|---|
| `src/components/settings/SettingsForm.tsx` | `calcDaysLeft` インポート追加、終了状態判定変数、移行ガイド UI 追加 |

## 補足

- ガイドは非インタラクティブな視覚リスト（状態管理なし）
- `buildMonthlyGoalPlan` / `DEADLINE_IN_PAST` の既存ロジックは未変更
- DB スキーマ・`contest_date` キー名の変更なし

Closes #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)