### PR TITLE
feat: add previous-run MAE delta badges to BacktestComparison

### DIFF
--- a/src/app/forecast-accuracy/page.tsx
+++ b/src/app/forecast-accuracy/page.tsx
@@ -37,7 +37,7 @@ export default async function ForecastAccuracyPage() {
     );
   }
 
-  const { dailyRun, sma7Run } = runsResult.data;
+  const { dailyRun, sma7Run, prevDailyRun, prevSma7Run } = runsResult.data;
 
   // 両方ともデータなし
   if (!dailyRun && !sma7Run) {
@@ -67,17 +67,22 @@ export default async function ForecastAccuracyPage() {
   }
 
   // metrics と除外日用フラグログを並列取得
-  const [dailyMetricsResult, sma7MetricsResult, flaggedLogs] = await Promise.all([
-    dailyRun ? fetchMetrics(dailyRun.id) : Promise.resolve({ kind: "ok" as const, data: [] }),
-    sma7Run ? fetchMetrics(sma7Run.id) : Promise.resolve({ kind: "ok" as const, data: [] }),
+  const [dailyMetricsResult, sma7MetricsResult, prevDailyMetricsResult, prevSma7MetricsResult, flaggedLogs] = await Promise.all([
+    dailyRun     ? fetchMetrics(dailyRun.id)     : Promise.resolve({ kind: "ok" as const, data: [] }),
+    sma7Run      ? fetchMetrics(sma7Run.id)      : Promise.resolve({ kind: "ok" as const, data: [] }),
+    // 前回 run の metrics (前回比バッジ用。run 不在時は正常系として空配列)
+    prevDailyRun ? fetchMetrics(prevDailyRun.id) : Promise.resolve({ kind: "ok" as const, data: [] }),
+    prevSma7Run  ? fetchMetrics(prevSma7Run.id)  : Promise.resolve({ kind: "ok" as const, data: [] }),
     // dailyRun の除外日一覧再導出用 (ベストエフォート: 失敗しても空配列)
     dailyRun?.train_min_date && dailyRun?.train_max_date
       ? fetchFlaggedLogsForRun(dailyRun.train_min_date, dailyRun.train_max_date)
       : Promise.resolve([]),
   ]);
 
-  const dailyMetrics = dailyMetricsResult.kind === "ok" ? dailyMetricsResult.data : [];
-  const sma7Metrics = sma7MetricsResult.kind === "ok" ? sma7MetricsResult.data : [];
+  const dailyMetrics     = dailyMetricsResult.kind     === "ok" ? dailyMetricsResult.data     : [];
+  const sma7Metrics      = sma7MetricsResult.kind      === "ok" ? sma7MetricsResult.data      : [];
+  const prevDailyMetrics = prevDailyMetricsResult.kind === "ok" ? prevDailyMetricsResult.data : [];
+  const prevSma7Metrics  = prevSma7MetricsResult.kind  === "ok" ? prevSma7MetricsResult.data  : [];
 
   // dailyRun の除外日一覧を再導出 (exclude_flagged_plus_recovery policy が存在する場合のみ表示)
   const hasExcludePolicy = dailyMetrics.some((m) => m.eval_policy === "exclude_flagged_plus_recovery");
@@ -105,6 +110,8 @@ export default async function ForecastAccuracyPage() {
         <BacktestComparison
           dailyMetrics={dailyMetrics}
           sma7Metrics={sma7Metrics}
+          prevDailyMetrics={prevDailyMetrics}
+          prevSma7Metrics={prevSma7Metrics}
         />
 
         {/* ── 全日 vs イベント除外 評価条件別比較 (#364) ──

--- a/src/components/charts/BacktestComparison.tsx
+++ b/src/components/charts/BacktestComparison.tsx
@@ -27,6 +27,8 @@ import { MODEL_DESCRIPTIONS, ModelInfoTooltip } from "./ModelInfoTooltip";
 interface BacktestComparisonProps {
   dailyMetrics: ForecastBacktestMetric[];
   sma7Metrics: ForecastBacktestMetric[];
+  prevDailyMetrics?: ForecastBacktestMetric[];
+  prevSma7Metrics?: ForecastBacktestMetric[];
 }
 
 const HORIZONS = [7, 14, 30] as const;
@@ -45,6 +47,29 @@ const MODEL_LABELS: Record<string, string> = {
 
 function fmt3(v: number | null): string {
   return v !== null ? v.toFixed(3) : "—";
+}
+
+/** 前回比バッジ要素を返す。prev が null のときは null */
+function MaeDeltaBadge({ current, prev }: { current: number | null; prev: number | null }) {
+  if (current === null || prev === null) return null;
+  const delta = current - prev;
+  if (delta < -0.005) {
+    return (
+      <span className="ml-1 text-[10px] font-semibold text-emerald-600 dark:text-emerald-400">
+        ▼{Math.abs(delta).toFixed(2)}
+      </span>
+    );
+  }
+  if (delta > 0.005) {
+    return (
+      <span className="ml-1 text-[10px] font-semibold text-rose-600 dark:text-rose-400">
+        ▲{Math.abs(delta).toFixed(2)}
+      </span>
+    );
+  }
+  return (
+    <span className="ml-1 text-[10px] text-slate-400 dark:text-slate-500">±0</span>
+  );
 }
 
 /** metrics から (model, horizon) → mae の Map を構築 */
@@ -91,6 +116,8 @@ function noiseReductionColor(pct: number | null): string {
 export function BacktestComparison({
   dailyMetrics,
   sma7Metrics,
+  prevDailyMetrics = [],
+  prevSma7Metrics  = [],
 }: BacktestComparisonProps) {
   // #363 以降の run は複数 policy の行を含む。
   // BacktestComparison は評価軸（単日 vs 7日均）の比較が目的のため、
@@ -104,7 +131,11 @@ export function BacktestComparison({
   if (!hasDailyData && !hasSma7Data) return null;
 
   const dailyMap = buildMaeMap(dailyAll);
-  const sma7Map = buildMaeMap(sma7All);
+  const sma7Map  = buildMaeMap(sma7All);
+
+  // 前回比バッジ用 MAE マップ (all_days のみ)
+  const prevDailyMap = buildMaeMap(prevDailyMetrics.filter((m) => m.eval_policy === "all_days"));
+  const prevSma7Map  = buildMaeMap(prevSma7Metrics.filter((m) => m.eval_policy === "all_days"));
 
   // ホライズン別ベスト MAE (ノイズ除去率計算用)
   const dailyBest: Record<Horizon, { model: string; mae: number } | null> = {
@@ -163,6 +194,8 @@ export function BacktestComparison({
           const dBest = dailyBest[h];
           const sBest = sma7Best[h];
           const nrPct = noiseReductionPct(dBest?.mae ?? null, sBest?.mae ?? null);
+          const prevDailyMaeBest = dBest ? (prevDailyMap.get(`${dBest.model}:${h}`) ?? null) : null;
+          const prevSma7MaeBest  = sBest ? (prevSma7Map.get(`${sBest.model}:${h}`) ?? null) : null;
           return (
             <div key={h} className="rounded-xl border border-slate-100 bg-slate-50 px-4 py-3 dark:border-slate-700 dark:bg-slate-800">
               <p className="mb-2 text-xs font-bold text-slate-600 dark:text-slate-300">D+{h} 日先</p>
@@ -171,14 +204,20 @@ export function BacktestComparison({
                   <div>
                     <p className="mb-0.5 font-medium text-blue-500">単日評価 ★</p>
                     <p className="font-semibold text-slate-700 dark:text-slate-200">{MODEL_LABELS[dBest.model] ?? dBest.model}</p>
-                    <p className="font-mono text-slate-500 dark:text-slate-400">MAE {fmt3(dBest.mae)}</p>
+                    <p className="font-mono text-slate-500 dark:text-slate-400">
+                      MAE {fmt3(dBest.mae)}
+                      <MaeDeltaBadge current={dBest.mae} prev={prevDailyMaeBest} />
+                    </p>
                   </div>
                 )}
                 {hasSma7Data && sBest && (
                   <div>
                     <p className="mb-0.5 font-medium text-emerald-600">7日平均評価 ★</p>
                     <p className="font-semibold text-slate-700 dark:text-slate-200">{MODEL_LABELS[sBest.model] ?? sBest.model}</p>
-                    <p className="font-mono text-slate-500 dark:text-slate-400">MAE {fmt3(sBest.mae)}</p>
+                    <p className="font-mono text-slate-500 dark:text-slate-400">
+                      MAE {fmt3(sBest.mae)}
+                      <MaeDeltaBadge current={sBest.mae} prev={prevSma7MaeBest} />
+                    </p>
                   </div>
                 )}
                 {hasDailyData && hasSma7Data && nrPct !== null && (
@@ -236,10 +275,12 @@ export function BacktestComparison({
                     </span>
                   </td>
                   {HORIZONS.map((h) => {
-                    const dailyMae = dailyMap.get(`${model}:${h}`) ?? null;
-                    const sma7Mae  = sma7Map.get(`${model}:${h}`) ?? null;
-                    const isDailyBest = dailyBest[h]?.model === model;
-                    const isSma7Best  = sma7Best[h]?.model === model;
+                    const dailyMae     = dailyMap.get(`${model}:${h}`) ?? null;
+                    const sma7Mae      = sma7Map.get(`${model}:${h}`) ?? null;
+                    const prevDailyMae = prevDailyMap.get(`${model}:${h}`) ?? null;
+                    const prevSma7Mae  = prevSma7Map.get(`${model}:${h}`) ?? null;
+                    const isDailyBest  = dailyBest[h]?.model === model;
+                    const isSma7Best   = sma7Best[h]?.model === model;
                     return (
                       <Fragment key={`${model}-${h}`}>
                         <td
@@ -253,6 +294,7 @@ export function BacktestComparison({
                           {isDailyBest && hasDailyData && (
                             <span className="ml-1 text-[9px] text-blue-400">★</span>
                           )}
+                          <MaeDeltaBadge current={dailyMae} prev={prevDailyMae} />
                         </td>
                         <td
                           className={`px-3 py-2.5 text-center tabular-nums ${
@@ -266,6 +308,9 @@ export function BacktestComparison({
                           {hasSma7Data ? fmt3(sma7Mae) : "—"}
                           {isSma7Best && hasSma7Data && (
                             <span className="ml-1 text-[9px] text-emerald-600">★</span>
+                          )}
+                          {hasSma7Data && (
+                            <MaeDeltaBadge current={sma7Mae} prev={prevSma7Mae} />
                           )}
                         </td>
                       </Fragment>

--- a/src/lib/queries/backtest.ts
+++ b/src/lib/queries/backtest.ts
@@ -27,11 +27,11 @@ function getSeriesType(run: ForecastBacktestRun): string {
 }
 
 /**
- * 最新 20 件の run を取得し、daily / sma7 それぞれの最新 run を返す。
+ * 最新 20 件の run を取得し、daily / sma7 それぞれの最新 run と直前 run を返す。
  * 旧来の run (config.series_type なし) は daily として扱う。
  *
  * 戻り値:
- *   kind: "ok"    — 取得成功。dailyRun / sma7Run が null = バックテスト未実行（正常な空状態）。
+ *   kind: "ok"    — 取得成功。各 run が null = バックテスト未実行 / 前回なし（正常な空状態）。
  *   kind: "error" — DB フェッチ失敗。呼び出し側で error banner を表示すること。
  *
  * エラー時に null を返すと「バックテスト未実行」と誤表示されるため QueryResult を使用する。
@@ -39,6 +39,8 @@ function getSeriesType(run: ForecastBacktestRun): string {
 export async function fetchLatestRuns(): Promise<QueryResult<{
   dailyRun: ForecastBacktestRun | null;
   sma7Run: ForecastBacktestRun | null;
+  prevDailyRun: ForecastBacktestRun | null;
+  prevSma7Run: ForecastBacktestRun | null;
 }>> {
   const supabase = createClient();
   const { data, error } = await supabase
@@ -53,10 +55,18 @@ export async function fetchLatestRuns(): Promise<QueryResult<{
   }
 
   const runs = (data as ForecastBacktestRun[]) ?? [];
-  const dailyRun = runs.find((r) => getSeriesType(r) === "daily") ?? null;
-  const sma7Run = runs.find((r) => getSeriesType(r) === "sma7") ?? null;
+  const dailyRuns = runs.filter((r) => getSeriesType(r) === "daily");
+  const sma7Runs  = runs.filter((r) => getSeriesType(r) === "sma7");
 
-  return { kind: "ok", data: { dailyRun, sma7Run } };
+  return {
+    kind: "ok",
+    data: {
+      dailyRun:     dailyRuns[0] ?? null,
+      sma7Run:      sma7Runs[0]  ?? null,
+      prevDailyRun: dailyRuns[1] ?? null,
+      prevSma7Run:  sma7Runs[1]  ?? null,
+    },
+  };
 }
 
 /**


### PR DESCRIPTION
## 概要

BacktestComparison テーブルの各 MAE セルに、同 series_type の直前 run との比較バッジを追加する。改善・悪化を一目で判別できるようにする。

## 変更内容

### `src/lib/queries/backtest.ts`
- `fetchLatestRuns()` の戻り値に `prevDailyRun` / `prevSma7Run` を追加
- 同 series_type の runs を配列で保持し、`[0]` を current、`[1]` を prev として返す

### `src/app/forecast-accuracy/page.tsx`
- `prevDailyRun` / `prevSma7Run` の metrics を `Promise.all` で並列フェッチ
- prev run 不在時は `{ kind: "ok", data: [] }` を正常系として扱い、`BacktestComparison` に空配列を渡す

### `src/components/charts/BacktestComparison.tsx`
- `prevDailyMetrics` / `prevSma7Metrics` props を追加（optional、デフォルト `[]`）
- `MaeDeltaBadge` コンポーネントを追加（判定ロジックを一元化）
- prev metrics から `buildMaeMap()` で前回 MAE マップを生成（`all_days` のみ）
- デスクトップテーブルとモバイルの horizon サマリーカードの両方にバッジを追加

## 前回 run / metrics の取得方法

`fetchLatestRuns()` が最新 20 件をフェッチし、series_type ごとに `filter()` で分けた配列の `[0]` / `[1]` を current / prev として返す。新規テーブル・migration 不要。

## バッジ判定ルール

| delta | 表示 | 色 |
|---|---|---|
| < −0.005 | `▼{abs.toFixed(2)}` | 緑 |
| > +0.005 | `▲{abs.toFixed(2)}` | 赤 |
| ±0.005 以内 | `±0` | グレー |
| 前回値なし | なし | — |

閾値 ±0.005 は丸め誤差による表示ノイズを除外するため。比較対象は `eval_policy === "all_days"` のみ。

## デスクトップ / モバイルへの反映

- **デスクトップ**: 各テーブルセルの MAE 値の後にインラインでバッジを表示
- **モバイル**: horizon サマリーカードの最良モデル MAE 行に同一ルールでバッジを表示（モバイルは最良モデルのみ表示なので、最良モデルの前回 MAE と比較）

## 影響範囲

- `BacktestResults`（詳細テーブル）: 変更なし
- `BacktestPolicyComparison`: 変更なし
- `eval_policy: exclude_flagged_plus_recovery` の前回比: 今回対象外
- 前回 run が存在しない場合、バッジが表示されないだけで表示は変わらない

## 確認内容

- `npx tsc --noEmit`: エラーなし
- `npm run build`: ビルド成功

## 補足

`MaeDeltaBadge` はデスクトップ・モバイル共通の判定ロジックを持つ単一コンポーネントとして実装し、条件の重複を排除した。

Closes #433