### PR TITLE
feat: Apple Health ZIP から歩数を日次インポートできるようにする (#436)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,10 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  // unzipper と sax は Node.js 専用パッケージ。
+  // Next.js のバンドラーに含めると unzipper が @aws-sdk/client-s3 を解決しようとするため、
+  // serverExternalPackages でランタイム require に委譲する。
+  serverExternalPackages: ["unzipper", "sax"],
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,9 @@
         "react-day-picker": "^9.14.0",
         "react-dom": "19.2.3",
         "recharts": "^3.8.0",
-        "swr": "^2.4.1"
+        "sax": "^1.6.0",
+        "swr": "^2.4.1",
+        "unzipper": "^0.12.3"
       },
       "devDependencies": {
         "@playwright/test": "^1.58.2",
@@ -30,6 +32,8 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/sax": "^1.2.7",
+        "@types/unzipper": "^0.10.11",
         "eslint": "^9",
         "eslint-config-next": "16.1.7",
         "jest": "^30.2.0",
@@ -3167,6 +3171,16 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -3180,6 +3194,16 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/unzipper": {
+      "version": "0.10.11",
+      "resolved": "https://registry.npmjs.org/@types/unzipper/-/unzipper-0.10.11.tgz",
+      "integrity": "sha512-D25im2zjyMCcgL9ag6N46+wbtJBnXIr7SI4zHf9eJD2Dw2tEB5e+p5MYkrxKIVRscs5QV0EhtU9rgXSPx90oJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
@@ -4265,6 +4289,12 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -4636,6 +4666,12 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -5055,6 +5091,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
       }
     },
     "node_modules/eastasianwidth": {
@@ -6015,6 +6060,20 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/fs-extra": {
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -6318,7 +6377,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/handlebars": {
@@ -6627,7 +6685,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/internal-slot": {
@@ -8042,6 +8099,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -8774,7 +8843,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-releases": {
@@ -9382,6 +9450,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -9513,6 +9587,27 @@
           "optional": true
         }
       }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
     },
     "node_modules/recharts": {
       "version": "3.8.0",
@@ -9759,6 +9854,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -9800,6 +9901,15 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -10138,6 +10248,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/string-length": {
@@ -11018,6 +11137,15 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
@@ -11051,6 +11179,19 @@
         "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
         "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
         "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+      }
+    },
+    "node_modules/unzipper": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.3.tgz",
+      "integrity": "sha512-PZ8hTS+AqcGxsaQntl3IRBw65QrBI6lxzqDEL7IAo/XCEqRTKGfOX56Vea5TH9SZczRVxuzk1re04z/YjuYCJA==",
+      "license": "MIT",
+      "dependencies": {
+        "bluebird": "~3.7.2",
+        "duplexer2": "~0.1.4",
+        "fs-extra": "^11.2.0",
+        "graceful-fs": "^4.2.2",
+        "node-int64": "^0.4.0"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -11102,6 +11243,12 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "react-day-picker": "^9.14.0",
     "react-dom": "19.2.3",
     "recharts": "^3.8.0",
-    "swr": "^2.4.1"
+    "sax": "^1.6.0",
+    "swr": "^2.4.1",
+    "unzipper": "^0.12.3"
   },
   "overrides": {
     "flatted": "3.4.2"
@@ -43,6 +45,8 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/sax": "^1.2.7",
+    "@types/unzipper": "^0.10.11",
     "eslint": "^9",
     "eslint-config-next": "16.1.7",
     "jest": "^30.2.0",

--- a/src/app/actions/buildUpdatePayload.ts
+++ b/src/app/actions/buildUpdatePayload.ts
@@ -44,5 +44,8 @@ export function buildUpdatePayload(
   if (input.last_meal_end_time !== undefined) payload.last_meal_end_time = input.last_meal_end_time;
   if (input.weigh_in_time      !== undefined) payload.weigh_in_time      = input.weigh_in_time;
 
+  // #436 追加: 歩数
+  if (input.step_count !== undefined) payload.step_count = input.step_count;
+
   return payload;
 }

--- a/src/app/actions/saveDailyLog.ts
+++ b/src/app/actions/saveDailyLog.ts
@@ -40,6 +40,9 @@ export type SaveDailyLogInput = {
   last_meal_end_time?: string | null;
   /** 体重測定時刻 "HH:MM" 形式。null = 明示クリア */
   weigh_in_time?: string | null;
+  // ── #436 追加 ──
+  /** Apple Health 歩数（日次集計）。null = 明示クリア */
+  step_count?: number | null;
 };
 
 /** DB に渡す更新ペイロード（undefined フィールドを除去したもの）*/
@@ -105,6 +108,12 @@ export async function saveDailyLog(
   if (input.work_mode !== undefined && input.work_mode !== null) {
     if (!isValidWorkMode(input.work_mode)) {
       return { ok: false, message: "work_mode の値が不正です" };
+    }
+  }
+
+  if (input.step_count !== undefined && input.step_count !== null) {
+    if (!Number.isInteger(input.step_count) || input.step_count < 0 || input.step_count > 200000) {
+      return { ok: false, message: "歩数は 0〜200,000 の整数で入力してください" };
     }
   }
 

--- a/src/app/api/apple-health-import/route.ts
+++ b/src/app/api/apple-health-import/route.ts
@@ -1,0 +1,170 @@
+/**
+ * /api/apple-health-import — Apple Health ZIP から歩数をインポートするエンドポイント
+ *
+ * ## エンドポイント
+ *
+ * ### POST /api/apple-health-import?action=preflight
+ *   リクエスト: multipart/form-data, field: "file" (ZIP)
+ *   レスポンス: AppleHealthPreflightResult
+ *   - ZIP を解析して日次歩数を集計し、既存 daily_logs との突合結果を返す
+ *   - DB への書き込みは行わない
+ *
+ * ### POST /api/apple-health-import?action=import
+ *   リクエスト: multipart/form-data, field: "file" (ZIP)
+ *   レスポンス: AppleHealthImportResult
+ *   - ZIP を解析して日次歩数を集計し、既存行のみ step_count を更新する
+ *   - 既存 daily_logs に行がない日付はスキップ（新規行は作らない）
+ *
+ * ## セキュリティ前提
+ * 個人利用専用（認証チェックなし）。CSV エクスポートと同じ前提。
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { parseAppleHealthZip } from "@/lib/utils/appleHealthParser";
+import { revalidateAfterDailyLogMutation } from "@/lib/cache/revalidate";
+
+// ── 型定義 ──────────────────────────────────────────────────────────────────
+
+export type AppleHealthPreflightResult = {
+  /** ZIP から集計された日付総数 */
+  totalDays: number;
+  /** existing daily_logs と一致した日数（weight ログあり） */
+  matchedDays: number;
+  /** matchedDays のうち既に step_count が入っている日数（上書き対象） */
+  overwriteDays: number;
+  /** matchedDays のうち step_count が未入力の日数（新規書き込み対象） */
+  newDays: number;
+  /** daily_logs に対応行がない日数（スキップ対象） */
+  skippedDays: number;
+};
+
+export type AppleHealthImportResult =
+  | { ok: true; savedCount: number; skippedCount: number }
+  | { ok: false; message: string };
+
+// ── ヘルパー ──────────────────────────────────────────────────────────────
+
+/**
+ * multipart/form-data から "file" フィールドを取り出す。
+ * 失敗時は null を返す。
+ */
+async function extractZipBuffer(req: NextRequest): Promise<ArrayBuffer | null> {
+  try {
+    const formData = await req.formData();
+    const file = formData.get("file");
+    if (!file || typeof file === "string") return null;
+    return await (file as File).arrayBuffer();
+  } catch {
+    return null;
+  }
+}
+
+// ── POST ────────────────────────────────────────────────────────────────────
+
+export async function POST(req: NextRequest) {
+  const action = req.nextUrl.searchParams.get("action");
+  if (action !== "preflight" && action !== "import") {
+    return NextResponse.json({ error: "action パラメータが不正です（preflight または import を指定してください）" }, { status: 400 });
+  }
+
+  // ZIP を読み込む
+  const zipBuffer = await extractZipBuffer(req);
+  if (!zipBuffer) {
+    return NextResponse.json({ error: "ZIP ファイルが見つかりません" }, { status: 400 });
+  }
+
+  // ZIP を解析して日次歩数 Map を取得
+  let dailyStepMap;
+  try {
+    dailyStepMap = await parseAppleHealthZip(zipBuffer);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "ZIP 解析に失敗しました";
+    return NextResponse.json({ error: msg }, { status: 400 });
+  }
+
+  if (dailyStepMap.size === 0) {
+    return NextResponse.json({ error: "歩数データが見つかりませんでした" }, { status: 400 });
+  }
+
+  // 解析結果の日付一覧を取得
+  const dates = Array.from(dailyStepMap.keys()).sort();
+
+  // DB から対象日付範囲の daily_logs を取得
+  const supabase = createClient();
+  const { data: existingLogs, error: fetchError } = await supabase
+    .from("daily_logs")
+    .select("log_date, step_count")
+    .in("log_date", dates);
+
+  if (fetchError) {
+    return NextResponse.json({ error: "DB 取得エラー: " + fetchError.message }, { status: 500 });
+  }
+
+  const existingMap = new Map<string, number | null>(
+    (existingLogs ?? []).map((row) => [row.log_date, row.step_count as number | null])
+  );
+
+  // ── preflight ──────────────────────────────────────────────────────────────
+  if (action === "preflight") {
+    let matchedDays  = 0;
+    let overwriteDays = 0;
+    let newDays       = 0;
+    let skippedDays   = 0;
+
+    for (const date of dates) {
+      if (!existingMap.has(date)) {
+        skippedDays++;
+      } else {
+        matchedDays++;
+        if (existingMap.get(date) !== null && existingMap.get(date) !== undefined) {
+          overwriteDays++;
+        } else {
+          newDays++;
+        }
+      }
+    }
+
+    const result: AppleHealthPreflightResult = {
+      totalDays: dates.length,
+      matchedDays,
+      overwriteDays,
+      newDays,
+      skippedDays,
+    };
+    return NextResponse.json(result);
+  }
+
+  // ── import ─────────────────────────────────────────────────────────────────
+  let savedCount   = 0;
+  let skippedCount = 0;
+
+  // 既存 daily_logs がある日付だけ step_count を更新する
+  // 新規行は作らない（仕様: weight ログがない日はインポートしない）
+  for (const [date, steps] of dailyStepMap) {
+    if (!existingMap.has(date)) {
+      skippedCount++;
+      continue;
+    }
+
+    const { error: updateError } = await supabase.rpc("save_daily_log_partial", {
+      p_log_date: date,
+      p_fields:   { step_count: steps },
+    });
+
+    if (updateError) {
+      // 1 件の失敗で全体を止めず、スキップしてカウント
+      console.error("[apple-health-import] rpc error:", date, updateError.message);
+      skippedCount++;
+    } else {
+      savedCount++;
+    }
+  }
+
+  if (savedCount > 0) {
+    revalidateAfterDailyLogMutation();
+  }
+
+  const result: AppleHealthImportResult = { ok: true, savedCount, skippedCount };
+  return NextResponse.json(result);
+}

--- a/src/app/api/export/route.ts
+++ b/src/app/api/export/route.ts
@@ -85,6 +85,7 @@ export async function GET(req: NextRequest) {
       "log_date", "weight", "calories", "protein", "fat", "carbs", "note",
       "is_cheat_day", "is_refeed_day", "is_eating_out", "is_travel_day",
       "sleep_hours", "had_bowel_movement", "training_type", "work_mode", "leg_flag",
+      "last_meal_end_time", "weigh_in_time", "step_count",
     ];
     const csv = toCSV((data ?? []) as Record<string, unknown>[], columns);
     const filename = `bodymake_log_${start || "all"}_${end || "all"}.csv`;

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,6 +1,7 @@
 import { SettingsForm } from "@/components/settings/SettingsForm";
 import { ExportSection } from "@/components/settings/ExportSection";
 import { ImportSection } from "@/components/settings/ImportSection";
+import { AppleHealthImportSection } from "@/components/settings/AppleHealthImportSection";
 import { DataQualityPanel } from "@/components/settings/DataQualityPanel";
 import { ThemeSection } from "@/components/settings/ThemeSection";
 import { calcDataQuality } from "@/lib/utils/calcDataQuality";
@@ -62,6 +63,9 @@ export default async function SettingsPage() {
           <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
             <ExportSection />
             <ImportSection />
+          </div>
+          <div className="mt-6">
+            <AppleHealthImportSection />
           </div>
         </div>
       </div>

--- a/src/components/settings/AppleHealthImportSection.tsx
+++ b/src/components/settings/AppleHealthImportSection.tsx
@@ -1,0 +1,307 @@
+"use client";
+
+import { useState, useRef } from "react";
+import { Upload, FileArchive, CheckCircle2, AlertCircle, Loader2, X, AlertTriangle } from "lucide-react";
+import type { AppleHealthPreflightResult, AppleHealthImportResult } from "@/app/api/apple-health-import/route";
+
+type Phase =
+  | { kind: "idle" }
+  | { kind: "parsing" }
+  | { kind: "preflight"; result: AppleHealthPreflightResult }
+  | { kind: "confirming"; result: AppleHealthPreflightResult }
+  | { kind: "importing" }
+  | { kind: "done"; saved: number; skipped: number }
+  | { kind: "error"; message: string };
+
+export function AppleHealthImportSection() {
+  const fileRef = useRef<HTMLInputElement>(null);
+  const [fileName, setFileName] = useState<string | null>(null);
+  const [file, setFile] = useState<File | null>(null);
+  const [phase, setPhase] = useState<Phase>({ kind: "idle" });
+
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const f = e.target.files?.[0];
+    if (!f) return;
+    if (!f.name.endsWith(".zip")) {
+      setPhase({ kind: "error", message: "ZIP ファイルを選択してください（.zip）" });
+      return;
+    }
+    setFileName(f.name);
+    setFile(f);
+    void runPreflight(f);
+  }
+
+  async function runPreflight(f: File) {
+    setPhase({ kind: "parsing" });
+
+    const formData = new FormData();
+    formData.append("file", f);
+
+    try {
+      const res = await fetch("/api/apple-health-import?action=preflight", {
+        method: "POST",
+        body: formData,
+      });
+      const json: AppleHealthPreflightResult | { error: string } = await res.json();
+      if (!res.ok || "error" in json) {
+        setPhase({ kind: "error", message: "error" in json ? json.error : `HTTP ${res.status}` });
+        return;
+      }
+      setPhase({ kind: "preflight", result: json });
+    } catch (e) {
+      setPhase({ kind: "error", message: e instanceof Error ? e.message : "不明なエラー" });
+    }
+  }
+
+  async function handleImport() {
+    if (!file) return;
+    setPhase({ kind: "importing" });
+
+    const formData = new FormData();
+    formData.append("file", file);
+
+    try {
+      const res = await fetch("/api/apple-health-import?action=import", {
+        method: "POST",
+        body: formData,
+      });
+      const json: AppleHealthImportResult | { error: string } = await res.json();
+      if (!res.ok || "error" in json) {
+        setPhase({ kind: "error", message: "error" in json ? json.error : `HTTP ${res.status}` });
+        return;
+      }
+      if (!json.ok) {
+        setPhase({ kind: "error", message: json.message });
+        return;
+      }
+      setPhase({ kind: "done", saved: json.savedCount, skipped: json.skippedCount });
+    } catch (e) {
+      setPhase({ kind: "error", message: e instanceof Error ? e.message : "不明なエラー" });
+    }
+  }
+
+  function reset() {
+    setFileName(null);
+    setFile(null);
+    setPhase({ kind: "idle" });
+    if (fileRef.current) fileRef.current.value = "";
+  }
+
+  const isIdle = phase.kind === "idle";
+  const isProcessing = phase.kind === "parsing" || phase.kind === "importing";
+  const preflight = phase.kind === "preflight" || phase.kind === "confirming" ? phase.result : null;
+
+  return (
+    <div className="rounded-2xl border border-slate-100 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900 dark:shadow-none">
+      <h2 className="mb-1 text-sm font-semibold text-slate-700 dark:text-slate-200">Apple Health インポート（歩数）</h2>
+      <p className="mb-5 text-xs text-slate-400 dark:text-slate-500">
+        Apple Health からエクスポートした ZIP ファイルを読み込み、歩数（HKQuantityTypeIdentifierStepCount）を日次ログに保存します。
+        体重記録がある日のみ更新し、記録のない日はスキップします。
+      </p>
+
+      {isIdle ? (
+        /* ── ファイル選択エリア ── */
+        <label className="flex cursor-pointer flex-col items-center justify-center gap-3 rounded-xl border-2 border-dashed border-slate-200 bg-slate-50 px-6 py-10 transition-colors hover:border-blue-400 hover:bg-blue-50 dark:border-slate-600 dark:bg-slate-800 dark:hover:border-blue-500 dark:hover:bg-blue-900/20">
+          <FileArchive size={28} className="text-slate-400 dark:text-slate-500" />
+          <div className="text-center">
+            <p className="text-sm font-medium text-slate-600 dark:text-slate-300">Apple Health の ZIP を選択</p>
+            <p className="mt-1 text-xs text-slate-400 dark:text-slate-500">ヘルスケア → プロフィール → データをエクスポート</p>
+          </div>
+          <input
+            ref={fileRef}
+            type="file"
+            accept=".zip,application/zip"
+            className="hidden"
+            onChange={handleFileChange}
+          />
+        </label>
+      ) : (
+        <div className="space-y-4">
+          {/* ── ファイル情報 ── */}
+          <div className="flex items-center justify-between rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 dark:border-slate-700 dark:bg-slate-800">
+            <div className="flex items-center gap-2 min-w-0">
+              <FileArchive size={16} className="flex-shrink-0 text-slate-400 dark:text-slate-500" />
+              <span className="truncate text-sm font-medium text-slate-700 dark:text-slate-200">{fileName}</span>
+            </div>
+            {!isProcessing && (
+              <button onClick={reset} className="ml-3 flex-shrink-0 text-slate-300 hover:text-slate-500 dark:text-slate-600 dark:hover:text-slate-400">
+                <X size={16} />
+              </button>
+            )}
+          </div>
+
+          {/* ── 解析中 ── */}
+          {phase.kind === "parsing" && (
+            <div className="flex items-center gap-2 rounded-xl border border-slate-100 bg-slate-50 px-4 py-3 text-sm text-slate-400 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-500">
+              <Loader2 size={14} className="animate-spin" />
+              <span>ZIP を解析中（数秒〜数十秒かかることがあります）...</span>
+            </div>
+          )}
+
+          {/* ── プレフライト結果 ── */}
+          {preflight && (
+            <div className="rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm dark:border-slate-700 dark:bg-slate-900">
+              <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500">インポート内容</p>
+              <div className="grid grid-cols-3 gap-3 text-center">
+                <div className="rounded-lg bg-emerald-50 px-2 py-2 dark:bg-emerald-900/20">
+                  <p className="text-lg font-bold text-emerald-600 dark:text-emerald-400">{preflight.newDays.toLocaleString()}</p>
+                  <p className="text-xs text-emerald-600 dark:text-emerald-400">新規書き込み</p>
+                </div>
+                <div className={`rounded-lg px-2 py-2 ${preflight.overwriteDays > 0 ? "bg-amber-50 dark:bg-amber-900/20" : "bg-slate-50 dark:bg-slate-800"}`}>
+                  <p className={`text-lg font-bold ${preflight.overwriteDays > 0 ? "text-amber-700 dark:text-amber-400" : "text-slate-400 dark:text-slate-500"}`}>
+                    {preflight.overwriteDays.toLocaleString()}
+                  </p>
+                  <p className={`text-xs ${preflight.overwriteDays > 0 ? "text-amber-600 dark:text-amber-400" : "text-slate-400 dark:text-slate-500"}`}>
+                    上書き
+                  </p>
+                </div>
+                <div className={`rounded-lg px-2 py-2 ${preflight.skippedDays > 0 ? "bg-rose-50 dark:bg-rose-900/20" : "bg-slate-50 dark:bg-slate-800"}`}>
+                  <p className={`text-lg font-bold ${preflight.skippedDays > 0 ? "text-rose-600 dark:text-rose-400" : "text-slate-400 dark:text-slate-500"}`}>
+                    {preflight.skippedDays.toLocaleString()}
+                  </p>
+                  <p className={`text-xs ${preflight.skippedDays > 0 ? "text-rose-500 dark:text-rose-400" : "text-slate-400 dark:text-slate-500"}`}>
+                    スキップ
+                  </p>
+                </div>
+              </div>
+              <p className="mt-2 text-xs text-slate-400 dark:text-slate-500">
+                ZIP 内の歩数: {preflight.totalDays.toLocaleString()} 日分 ／ 体重ログ一致: {preflight.matchedDays.toLocaleString()} 日分
+              </p>
+            </div>
+          )}
+
+          {/* ── 確認パネル ── */}
+          {phase.kind === "confirming" && (
+            <div className={`rounded-xl border px-4 py-4 ${
+              phase.result.overwriteDays > 0
+                ? "border-amber-200 bg-amber-50 dark:border-amber-700/50 dark:bg-amber-900/20"
+                : "border-blue-100 bg-blue-50 dark:border-blue-800/50 dark:bg-blue-900/20"
+            }`}>
+              <div className="flex items-start gap-2">
+                {phase.result.overwriteDays > 0 ? (
+                  <AlertTriangle size={16} className="mt-0.5 flex-shrink-0 text-amber-600 dark:text-amber-400" />
+                ) : (
+                  <Upload size={16} className="mt-0.5 flex-shrink-0 text-blue-500 dark:text-blue-400" />
+                )}
+                <div className="text-sm">
+                  {phase.result.overwriteDays > 0 ? (
+                    <>
+                      <p className="font-semibold text-amber-700 dark:text-amber-400">
+                        {phase.result.overwriteDays.toLocaleString()} 件の歩数が上書きされます
+                      </p>
+                      <p className="mt-0.5 text-xs text-amber-600 dark:text-amber-400">
+                        この操作は取り消せません。新規 {phase.result.newDays} 件の書き込みと合わせて実行します。
+                      </p>
+                    </>
+                  ) : (
+                    <>
+                      <p className="font-semibold text-blue-700 dark:text-blue-400">
+                        {phase.result.newDays.toLocaleString()} 件の歩数を書き込みます
+                      </p>
+                      <p className="mt-0.5 text-xs text-blue-500 dark:text-blue-400">
+                        既存の歩数データへの上書きはありません。
+                      </p>
+                    </>
+                  )}
+                </div>
+              </div>
+              <div className="mt-3 flex justify-end gap-2">
+                <button
+                  onClick={() => setPhase({ kind: "preflight", result: phase.result })}
+                  className="rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm text-slate-500 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-400 dark:hover:bg-slate-700"
+                >
+                  やめる
+                </button>
+                <button
+                  onClick={handleImport}
+                  className={`flex items-center gap-2 rounded-xl px-5 py-2 text-sm font-semibold text-white ${
+                    phase.result.overwriteDays > 0
+                      ? "bg-amber-500 hover:bg-amber-600"
+                      : "bg-blue-600 hover:bg-blue-700"
+                  }`}
+                >
+                  <Upload size={14} />
+                  実行する
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* ── インポート中 ── */}
+          {phase.kind === "importing" && (
+            <div className="flex items-center gap-2 rounded-xl border border-slate-100 bg-slate-50 px-4 py-3 text-sm text-slate-400 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-500">
+              <Loader2 size={14} className="animate-spin" />
+              <span>歩数を保存中...</span>
+            </div>
+          )}
+
+          {/* ── 完了 ── */}
+          {phase.kind === "done" && (
+            <div className="flex items-center gap-2 rounded-xl bg-emerald-50 border border-emerald-100 px-4 py-3 text-sm font-medium text-emerald-600 dark:bg-emerald-900/20 dark:border-emerald-700/50 dark:text-emerald-400">
+              <CheckCircle2 size={16} />
+              <span>
+                {phase.saved.toLocaleString()} 日分の歩数を保存しました
+                {phase.skipped > 0 && (
+                  <span className="ml-1 text-amber-600 dark:text-amber-400">（{phase.skipped.toLocaleString()} 件はスキップ）</span>
+                )}
+              </span>
+            </div>
+          )}
+
+          {/* ── エラー ── */}
+          {phase.kind === "error" && (
+            <div className="flex items-start gap-2 rounded-xl bg-rose-50 border border-rose-100 px-4 py-3 text-sm text-rose-700 dark:bg-rose-900/20 dark:border-rose-700/50 dark:text-rose-400">
+              <AlertCircle size={16} className="flex-shrink-0 mt-0.5" />
+              <div>
+                <p className="font-medium">エラーが発生しました</p>
+                <p className="mt-0.5 text-xs">{phase.message}</p>
+              </div>
+            </div>
+          )}
+
+          {/* ── ボタンエリア ── */}
+          {phase.kind === "preflight" && preflight && (preflight.newDays + preflight.overwriteDays) > 0 && (
+            <div className="flex justify-end gap-3">
+              <button
+                onClick={reset}
+                className="rounded-xl border border-slate-200 px-4 py-2 text-sm text-slate-500 hover:bg-slate-50 dark:border-slate-600 dark:text-slate-400 dark:hover:bg-slate-800"
+              >
+                キャンセル
+              </button>
+              <button
+                onClick={() => setPhase({ kind: "confirming", result: preflight })}
+                className="flex items-center gap-2 rounded-xl bg-blue-600 px-5 py-2 text-sm font-semibold text-white hover:bg-blue-700"
+              >
+                <Upload size={14} />
+                インポートを確認
+              </button>
+            </div>
+          )}
+          {phase.kind === "preflight" && preflight && (preflight.newDays + preflight.overwriteDays) === 0 && (
+            <div className="flex items-center justify-between">
+              <p className="text-sm text-slate-400 dark:text-slate-500">
+                書き込み対象の日付が見つかりませんでした（体重記録がある日が一致しません）。
+              </p>
+              <button
+                onClick={reset}
+                className="ml-4 rounded-xl border border-slate-200 px-4 py-2 text-sm text-slate-500 hover:bg-slate-50 dark:border-slate-600 dark:text-slate-400 dark:hover:bg-slate-800"
+              >
+                閉じる
+              </button>
+            </div>
+          )}
+          {(phase.kind === "done" || phase.kind === "error") && (
+            <div className="flex justify-end">
+              <button
+                onClick={reset}
+                className="rounded-xl border border-slate-200 px-4 py-2 text-sm text-slate-500 hover:bg-slate-50 dark:border-slate-600 dark:text-slate-400 dark:hover:bg-slate-800"
+              >
+                {phase.kind === "done" ? "別のファイルを読み込む" : "やり直す"}
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/queries/dailyLogs.ts
+++ b/src/lib/queries/dailyLogs.ts
@@ -22,7 +22,7 @@
  *
  * | 関数 | 取得列 | 用途 | 戻り値型 |
  * |---|---|---|---|
- * | fetchDashboardDailyLogs()   | 16列（note・leg_flag 除く）  | Dashboard 専用 (#165)                | QueryResult |
+ * | fetchDashboardDailyLogs()   | 19列（note・leg_flag 除く）  | Dashboard 専用 (#165)                | QueryResult |
  * | fetchMacroDailyLogs(days)   | 6列・DESC LIMIT days         | Macro 専用 (#166)                    | QueryResult |
  * | fetchTdeeDailyLogs(limit)   | 3列・DESC LIMIT limit        | TDEE raw fallback 専用 (#166)        | QueryResult |
  * | fetchLatestUpdatedAt()      | updated_at 1行               | stale 判定用（Macro/TDEE共用）       | ベストエフォート |
@@ -37,15 +37,15 @@ import type { DataQualityLog } from "@/lib/utils/calcDataQuality";
 import type { QueryResult } from "./queryResult";
 
 /**
- * Dashboard 専用: daily_logs を 18 列・全期間・日付昇順で取得する。
+ * Dashboard 専用: daily_logs を 19 列・全期間・日付昇順で取得する。
  *
- * ## 取得列と除外列の根拠（#165 棚卸し済み、#435 で時刻列を追加）
+ * ## 取得列と除外列の根拠（#165 棚卸し済み、#435 で時刻列追加、#436 で step_count 追加）
  *
- * 取得列 (18列):
+ * 取得列 (19列):
  *   log_date, weight, calories, protein, fat, carbs,
  *   is_cheat_day, is_refeed_day, is_eating_out, is_travel_day,
  *   sleep_hours, had_bowel_movement, training_type, work_mode, updated_at,
- *   last_meal_end_time, weigh_in_time
+ *   last_meal_end_time, weigh_in_time, step_count
  *
  * 除外列 (2列):
  *   - note     : Dashboard のいずれの関数・コンポーネントでも参照されない
@@ -84,7 +84,7 @@ export async function fetchDashboardDailyLogs(): Promise<QueryResult<DashboardDa
       "log_date, weight, calories, protein, fat, carbs, " +
       "is_cheat_day, is_refeed_day, is_eating_out, is_travel_day, " +
       "sleep_hours, had_bowel_movement, training_type, work_mode, updated_at, " +
-      "last_meal_end_time, weigh_in_time"
+      "last_meal_end_time, weigh_in_time, step_count"
     )
     .order("log_date", { ascending: true });
   if (error) {

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -77,6 +77,7 @@ export type Database = {
           note: string | null
           protein: number | null
           sleep_hours: number | null
+          step_count: number | null
           training_type: string | null
           updated_at: string
           weigh_in_time: string | null
@@ -100,6 +101,7 @@ export type Database = {
           note?: string | null
           protein?: number | null
           sleep_hours?: number | null
+          step_count?: number | null
           training_type?: string | null
           updated_at?: string
           weigh_in_time?: string | null
@@ -123,6 +125,7 @@ export type Database = {
           note?: string | null
           protein?: number | null
           sleep_hours?: number | null
+          step_count?: number | null
           training_type?: string | null
           updated_at?: string
           weigh_in_time?: string | null
@@ -528,7 +531,7 @@ export type DailyLog = Database["public"]["Tables"]["daily_logs"]["Row"];
 
 /**
  * Dashboard 専用の daily_logs projection 型。
- * fetchDashboardDailyLogs() が取得する 18 列に対応する（#435 で last_meal_end_time / weigh_in_time 追加）。
+ * fetchDashboardDailyLogs() が取得する 19 列に対応する（#436 で step_count 追加）。
  *
  * 除外列:
  *   - note     : Dashboard のいずれの関数・コンポーネントでも参照されない

--- a/src/lib/utils/__tests__/calcMonthlyBehaviorStats.test.ts
+++ b/src/lib/utils/__tests__/calcMonthlyBehaviorStats.test.ts
@@ -28,6 +28,7 @@ function makeLog(
     is_travel_day: false,
     last_meal_end_time: null,
     weigh_in_time: null,
+    step_count: null,
     created_at: null,
     updated_at: "2026-01-01T00:00:00Z",
     ...overrides,

--- a/src/lib/utils/appleHealthParser.ts
+++ b/src/lib/utils/appleHealthParser.ts
@@ -1,0 +1,110 @@
+/**
+ * appleHealthParser — Apple Health export.xml から歩数を日次集計する
+ *
+ * ## 入力形式
+ * Apple Health の export.xml（Readable Stream）。
+ * 対象要素: `<Record type="HKQuantityTypeIdentifierStepCount" startDate="YYYY-MM-DD HH:MM:SS +0900" value="N"/>`
+ *
+ * ## 集計ロジック
+ * - startDate の日付部分（YYYY-MM-DD）を JST 日付キーとして使用する
+ * - 同日の全 Record の value を合算する
+ * - 整数以外・負の value は除外する
+ *
+ * ## 注意
+ * export.xml は 200MB+ になりうるため、SAX ストリーミングパーサーで処理する。
+ * DOMParser / XML 全体のバッファリングは行わない。
+ */
+
+import sax from "sax";
+import type { Readable } from "stream";
+
+/** YYYY-MM-DD をキーとする日次歩数マップ */
+export type DailyStepMap = Map<string, number>;
+
+/**
+ * Apple Health export.xml の Readable ストリームを SAX パースし、
+ * 歩数（HKQuantityTypeIdentifierStepCount）を日次集計して返す。
+ *
+ * @param xmlStream - export.xml の Node.js Readable stream
+ * @returns YYYY-MM-DD → 歩数合計 の Map
+ */
+export function parseAppleHealthStepCount(xmlStream: Readable): Promise<DailyStepMap> {
+  return new Promise((resolve, reject) => {
+    const parser = sax.createStream(true, { trim: false, normalize: false });
+    const dailySteps: DailyStepMap = new Map();
+
+    parser.on("opentag", (node) => {
+      if (node.name !== "Record") return;
+      const attrs = node.attributes as Record<string, string>;
+      if (attrs["type"] !== "HKQuantityTypeIdentifierStepCount") return;
+
+      const startDate = attrs["startDate"];
+      const valueStr  = attrs["value"];
+      if (!startDate || !valueStr) return;
+
+      // startDate は "YYYY-MM-DD HH:MM:SS +0900" 形式（JST）
+      // 日付部分を直接スライスする（new Date() は UTC 解釈になるため使用しない）
+      const dateKey = startDate.slice(0, 10);
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(dateKey)) return;
+
+      const value = parseInt(valueStr, 10);
+      if (!Number.isInteger(value) || value < 0) return;
+
+      dailySteps.set(dateKey, (dailySteps.get(dateKey) ?? 0) + value);
+    });
+
+    parser.on("error", (err) => {
+      reject(new Error(`Apple Health XML parse error: ${err.message}`));
+    });
+
+    parser.on("end", () => {
+      resolve(dailySteps);
+    });
+
+    xmlStream.pipe(parser);
+    xmlStream.on("error", (err) => {
+      reject(new Error(`Apple Health XML stream error: ${err.message}`));
+    });
+  });
+}
+
+/**
+ * ZIP の ArrayBuffer から export.xml エントリを抽出し、
+ * 歩数の日次集計 Map を返す。
+ *
+ * @param zipBuffer - ZIP ファイルの ArrayBuffer
+ * @returns YYYY-MM-DD → 歩数合計 の Map
+ * @throws ZIP に export.xml が含まれない場合
+ */
+export async function parseAppleHealthZip(zipBuffer: ArrayBuffer): Promise<DailyStepMap> {
+  const unzipper = await import("unzipper");
+  const { Readable } = await import("stream");
+
+  const nodeBuffer = Buffer.from(zipBuffer);
+  const bufferStream = Readable.from(nodeBuffer);
+
+  return new Promise((resolve, reject) => {
+    let found = false;
+
+    bufferStream
+      .pipe(unzipper.Parse({ forceStream: true }))
+      .on("entry", (entry: { path: string; type: string; autodrain: () => void; pipe: (dest: unknown) => unknown }) => {
+        if (entry.path === "apple_health_export/export.xml" && entry.type === "File") {
+          found = true;
+          parseAppleHealthStepCount(entry as unknown as Readable)
+            .then(resolve)
+            .catch(reject);
+        } else {
+          entry.autodrain();
+        }
+      })
+      .on("finish", () => {
+        if (!found) {
+          reject(new Error("apple_health_export/export.xml が ZIP 内に見つかりません"));
+        }
+      })
+      .on("error", (err: Error) => {
+        reject(new Error(`ZIP 展開エラー: ${err.message}`));
+      });
+  });
+}

--- a/src/lib/utils/calcMacro.test.ts
+++ b/src/lib/utils/calcMacro.test.ts
@@ -24,6 +24,7 @@ function makeLog(log_date: string, overrides: Partial<DailyLog> = {}): DailyLog 
     leg_flag:           null,
     last_meal_end_time: null,
     weigh_in_time:      null,
+    step_count: null,
     updated_at:         "2026-03-01T00:00:00Z",
     ...overrides,
   };

--- a/src/lib/utils/calcReadiness.test.ts
+++ b/src/lib/utils/calcReadiness.test.ts
@@ -48,6 +48,7 @@ function makeDailyLog(
     leg_flag: false,
     last_meal_end_time: null,
     weigh_in_time: null,
+    step_count: null,
     updated_at: "2026-03-01T00:00:00Z",
     ...overrides,
   };

--- a/src/lib/utils/calcWeeklyReview.test.ts
+++ b/src/lib/utils/calcWeeklyReview.test.ts
@@ -27,6 +27,7 @@ function makeLog(
     work_mode: null,
     last_meal_end_time: null,
     weigh_in_time: null,
+    step_count: null,
     ...overrides,
   };
 }

--- a/src/lib/utils/calendarUtils.test.ts
+++ b/src/lib/utils/calendarUtils.test.ts
@@ -32,6 +32,7 @@ function makeLog(overrides: Omit<Partial<DailyLog>, "weight"> & { log_date: stri
     leg_flag:           overrides.leg_flag           ?? null,
     last_meal_end_time: overrides.last_meal_end_time ?? null,
     weigh_in_time:      overrides.weigh_in_time      ?? null,
+    step_count:         overrides.step_count         ?? null,
     updated_at:         overrides.updated_at         ?? "2026-03-01T00:00:00Z",
   };
 }

--- a/supabase/migrations/20260404000001_add_step_count_to_daily_logs.sql
+++ b/supabase/migrations/20260404000001_add_step_count_to_daily_logs.sql
@@ -1,0 +1,135 @@
+-- daily_logs に歩数カラムを追加する
+-- Apple Health の HKQuantityTypeIdentifierStepCount を日次集計して保存する用途。
+
+ALTER TABLE daily_logs
+  ADD COLUMN IF NOT EXISTS step_count INTEGER;
+
+-- save_daily_log_partial RPC に step_count を追加する
+--
+-- 変更内容:
+--   - UPDATE 節に step_count の CASE 句を追加
+--   - INSERT 節に step_count カラムを追加（nullable のため COALESCE 不要）
+--
+-- 部分更新の意味論（既存と同じ）:
+--   - キーなし          : 未更新（既存値を保持）
+--   - キーあり, 値 null : 明示クリア
+--   - キーあり, 値あり  : 上書き
+
+CREATE OR REPLACE FUNCTION save_daily_log_partial(
+  p_log_date DATE,
+  p_fields   JSONB
+) RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  -- ── Step 1: 既存行への partial update を試みる ───────────────────────────
+  UPDATE daily_logs SET
+    weight             = CASE WHEN p_fields ? 'weight'
+                              THEN (p_fields->>'weight')::NUMERIC
+                              ELSE weight             END,
+    calories           = CASE WHEN p_fields ? 'calories'
+                              THEN (p_fields->>'calories')::NUMERIC
+                              ELSE calories           END,
+    protein            = CASE WHEN p_fields ? 'protein'
+                              THEN (p_fields->>'protein')::NUMERIC
+                              ELSE protein            END,
+    fat                = CASE WHEN p_fields ? 'fat'
+                              THEN (p_fields->>'fat')::NUMERIC
+                              ELSE fat                END,
+    carbs              = CASE WHEN p_fields ? 'carbs'
+                              THEN (p_fields->>'carbs')::NUMERIC
+                              ELSE carbs              END,
+    note               = CASE WHEN p_fields ? 'note'
+                              THEN p_fields->>'note'
+                              ELSE note               END,
+    is_cheat_day       = CASE WHEN p_fields ? 'is_cheat_day'
+                              THEN (p_fields->>'is_cheat_day')::BOOLEAN
+                              ELSE is_cheat_day       END,
+    is_refeed_day      = CASE WHEN p_fields ? 'is_refeed_day'
+                              THEN (p_fields->>'is_refeed_day')::BOOLEAN
+                              ELSE is_refeed_day      END,
+    is_eating_out      = CASE WHEN p_fields ? 'is_eating_out'
+                              THEN (p_fields->>'is_eating_out')::BOOLEAN
+                              ELSE is_eating_out      END,
+    is_travel_day      = CASE WHEN p_fields ? 'is_travel_day'
+                              THEN (p_fields->>'is_travel_day')::BOOLEAN
+                              ELSE is_travel_day      END,
+    is_poor_sleep      = CASE WHEN p_fields ? 'is_poor_sleep'
+                              THEN (p_fields->>'is_poor_sleep')::BOOLEAN
+                              ELSE is_poor_sleep      END,
+    sleep_hours        = CASE WHEN p_fields ? 'sleep_hours'
+                              THEN (p_fields->>'sleep_hours')::NUMERIC
+                              ELSE sleep_hours        END,
+    had_bowel_movement = CASE WHEN p_fields ? 'had_bowel_movement'
+                              THEN (p_fields->>'had_bowel_movement')::BOOLEAN
+                              ELSE had_bowel_movement END,
+    training_type      = CASE WHEN p_fields ? 'training_type'
+                              THEN p_fields->>'training_type'
+                              ELSE training_type      END,
+    work_mode          = CASE WHEN p_fields ? 'work_mode'
+                              THEN p_fields->>'work_mode'
+                              ELSE work_mode          END,
+    leg_flag           = CASE WHEN p_fields ? 'leg_flag'
+                              THEN (p_fields->>'leg_flag')::BOOLEAN
+                              ELSE leg_flag           END,
+    last_meal_end_time = CASE WHEN p_fields ? 'last_meal_end_time'
+                              THEN (p_fields->>'last_meal_end_time')::TIME
+                              ELSE last_meal_end_time END,
+    weigh_in_time      = CASE WHEN p_fields ? 'weigh_in_time'
+                              THEN (p_fields->>'weigh_in_time')::TIME
+                              ELSE weigh_in_time      END,
+    step_count         = CASE WHEN p_fields ? 'step_count'
+                              THEN (p_fields->>'step_count')::INTEGER
+                              ELSE step_count         END
+  WHERE log_date = p_log_date;
+
+  -- 既存行が更新できたなら終了（INSERT 側には一切触れない）
+  IF FOUND THEN
+    RETURN;
+  END IF;
+
+  -- ── Step 2: 新規行の場合は weight 必須チェック ───────────────────────────
+  IF NOT (p_fields ? 'weight') OR (p_fields->>'weight') IS NULL THEN
+    RAISE EXCEPTION 'new_log_requires_weight';
+  END IF;
+
+  -- ── Step 3: 新規 INSERT ──────────────────────────────────────────────────
+  INSERT INTO daily_logs (
+    log_date,
+    weight, calories, protein, fat, carbs, note,
+    is_cheat_day, is_refeed_day, is_eating_out, is_travel_day, is_poor_sleep,
+    sleep_hours, had_bowel_movement,
+    training_type, work_mode, leg_flag,
+    last_meal_end_time, weigh_in_time,
+    step_count
+  ) VALUES (
+    p_log_date,
+    (p_fields->>'weight')::NUMERIC,
+    (p_fields->>'calories')::NUMERIC,
+    (p_fields->>'protein')::NUMERIC,
+    (p_fields->>'fat')::NUMERIC,
+    (p_fields->>'carbs')::NUMERIC,
+    p_fields->>'note',
+    COALESCE((p_fields->>'is_cheat_day')::BOOLEAN,   FALSE),
+    COALESCE((p_fields->>'is_refeed_day')::BOOLEAN,  FALSE),
+    COALESCE((p_fields->>'is_eating_out')::BOOLEAN,  FALSE),
+    COALESCE((p_fields->>'is_travel_day')::BOOLEAN,  FALSE),
+    COALESCE((p_fields->>'is_poor_sleep')::BOOLEAN,  FALSE),
+    (p_fields->>'sleep_hours')::NUMERIC,
+    (p_fields->>'had_bowel_movement')::BOOLEAN,
+    p_fields->>'training_type',
+    p_fields->>'work_mode',
+    (p_fields->>'leg_flag')::BOOLEAN,
+    (p_fields->>'last_meal_end_time')::TIME,
+    (p_fields->>'weigh_in_time')::TIME,
+    (p_fields->>'step_count')::INTEGER
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION save_daily_log_partial(DATE, JSONB) IS
+  '日次ログの partial update/insert。
+   既存行: UPDATE のみ実行（INSERT 側の NOT NULL 制約に触れない）。
+   新規行: weight 必須チェック後に INSERT。
+   p_fields の JSONB キー存在で 未更新(キーなし) / 明示クリア(キーあり+null) / 上書き(キーあり+値) を表現。
+   weight なしで新規作成を試みた場合は new_log_requires_weight 例外を発生させる。';


### PR DESCRIPTION
## Summary

- `daily_logs.step_count INTEGER` カラムを追加（migration + `save_daily_log_partial` RPC 更新）
- `appleHealthParser.ts`: ZIP → SAX ストリーミング XML 解析 → 日次歩数集計（241MB XML をメモリに展開しない）
- `/api/apple-health-import` Route Handler: `preflight` / `import` の 2 アクション
  - preflight: ZIP を解析して新規・上書き・スキップ件数を返す（DB 書き込みなし）
  - import: 既存 `daily_logs` がある日付のみ `step_count` を更新（体重記録のない日はスキップ）
- `AppleHealthImportSection.tsx`: ファイル選択 → preflight 表示 → 確認 → 実行の UI（設定画面に配置）
- `SaveDailyLogInput` / `buildUpdatePayload` に `step_count` を追加
- CSV エクスポートに `step_count` / `last_meal_end_time` / `weigh_in_time` を追加
- `serverExternalPackages` に `unzipper` / `sax` を追加（ビルド時の `@aws-sdk` 依存解決エラー回避）

## Test plan

- [ ] テスト: `npx jest --no-coverage` → 1228 passed
- [ ] 型チェック: `npx tsc --noEmit` → エラーなし
- [ ] ビルド: `npm run build` → `/api/apple-health-import` が ƒ (Dynamic) として出力される
- [ ] 実機確認: 設定画面に「Apple Health インポート」セクションが表示される
- [ ] ZIP アップロード → preflight 結果（日数・新規/上書き/スキップ）が表示される
- [ ] 「インポートを確認」→ 確認パネル → 「実行する」→ 歩数が daily_logs に保存される
- [ ] 体重記録がない日付はスキップされる（新規行は作られない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)