### PR TITLE
fix: compute fasting hours from previous day's last_meal_end_time

### DIFF
--- a/src/components/dashboard/RecentLogsCards.tsx
+++ b/src/components/dashboard/RecentLogsCards.tsx
@@ -20,6 +20,7 @@ import { DAY_TAGS, DAY_TAG_LABELS, DAY_TAG_BADGE_COLORS } from "@/lib/utils/dayT
 import { formatConditionSummary } from "@/lib/utils/trainingType";
 import { computeWeightDelta, buildRecentLogArrays } from "@/lib/utils/recentLogsUtils";
 import { calcFastingHours } from "@/lib/utils/calendarUtils";
+import { addDaysStr } from "@/lib/utils/date";
 
 interface RecentLogsCardsProps {
   logs: DashboardDailyLog[];
@@ -29,6 +30,8 @@ interface RecentLogsCardsProps {
 
 export function RecentLogsCards({ logs, seasonMap, currentSeason }: RecentLogsCardsProps) {
   const { sorted, ascending } = buildRecentLogArrays(logs);
+  // 断食時間算出用: 日付 → ログ の高速参照テーブル（前日 D-1 の last_meal_end_time を参照するため）
+  const logByDate = new Map(ascending.map((l) => [l.log_date, l]));
 
   if (sorted.length === 0) {
     return (
@@ -74,20 +77,23 @@ export function RecentLogsCards({ logs, seasonMap, currentSeason }: RecentLogsCa
                   </span>
                 ))}
               </div>
-              {(conditionSummary || log.sleep_hours !== null || calcFastingHours(log.last_meal_end_time, log.weigh_in_time) !== null) && (
-                <div className="mt-0.5 text-[10px] leading-snug text-slate-400 dark:text-slate-500">
-                  {(() => {
-                    const fastingHours = calcFastingHours(log.last_meal_end_time, log.weigh_in_time);
-                    return [
+              {(() => {
+                const prevDate    = addDaysStr(log.log_date, -1);
+                const prevDayLog  = prevDate ? (logByDate.get(prevDate) ?? null) : null;
+                const fastingHours = calcFastingHours(prevDayLog?.last_meal_end_time, log.weigh_in_time);
+                if (!conditionSummary && log.sleep_hours === null && fastingHours === null) return null;
+                return (
+                  <div className="mt-0.5 text-[10px] leading-snug text-slate-400 dark:text-slate-500">
+                    {[
                       conditionSummary,
                       log.sleep_hours !== null ? `睡眠${log.sleep_hours}h` : null,
                       fastingHours !== null ? `断食${fastingHours % 1 === 0 ? fastingHours.toFixed(0) : fastingHours.toFixed(1)}h` : null,
                     ]
                       .filter(Boolean)
-                      .join(" / ");
-                  })()}
-                </div>
-              )}
+                      .join(" / ")}
+                  </div>
+                );
+              })()}
             </div>
 
             {/* 右: 体重 + カロリー */}

--- a/src/components/dashboard/RecentLogsTable.tsx
+++ b/src/components/dashboard/RecentLogsTable.tsx
@@ -6,6 +6,7 @@ import { DAY_TAGS, DAY_TAG_LABELS, DAY_TAG_BADGE_COLORS } from "@/lib/utils/dayT
 import { formatConditionSummary } from "@/lib/utils/trainingType";
 import { computeWeightDelta, buildRecentLogArrays } from "@/lib/utils/recentLogsUtils";
 import { calcFastingHours } from "@/lib/utils/calendarUtils";
+import { addDaysStr } from "@/lib/utils/date";
 
 interface RecentLogsTableProps {
   logs: DashboardDailyLog[];
@@ -16,6 +17,8 @@ interface RecentLogsTableProps {
 
 export function RecentLogsTable({ logs, embedded = false, seasonMap, currentSeason }: RecentLogsTableProps) {
   const { sorted, ascending } = buildRecentLogArrays(logs);
+  // 断食時間算出用: 日付 → ログ の高速参照テーブル（前日 D-1 の last_meal_end_time を参照するため）
+  const logByDate = new Map(ascending.map((l) => [l.log_date, l]));
 
   /** 直前ログとのカロリー差分。calories / 前回 calories いずれかが null なら null */
   function getCalDelta(log: DashboardDailyLog): number | null {
@@ -71,20 +74,23 @@ export function RecentLogsTable({ logs, embedded = false, seasonMap, currentSeas
                       </span>
                     ))}
                   </div>
-                  {(conditionSummary || log.sleep_hours !== null || calcFastingHours(log.last_meal_end_time, log.weigh_in_time) !== null) && (
-                    <div className="mt-1 text-xs leading-snug text-slate-500 dark:text-slate-400">
-                      {(() => {
-                        const fastingHours = calcFastingHours(log.last_meal_end_time, log.weigh_in_time);
-                        return [
+                  {(() => {
+                    const prevDate    = addDaysStr(log.log_date, -1);
+                    const prevDayLog  = prevDate ? (logByDate.get(prevDate) ?? null) : null;
+                    const fastingHours = calcFastingHours(prevDayLog?.last_meal_end_time, log.weigh_in_time);
+                    if (!conditionSummary && log.sleep_hours === null && fastingHours === null) return null;
+                    return (
+                      <div className="mt-1 text-xs leading-snug text-slate-500 dark:text-slate-400">
+                        {[
                           conditionSummary,
                           log.sleep_hours !== null ? `睡眠${log.sleep_hours}h` : null,
                           fastingHours !== null ? `断食${fastingHours % 1 === 0 ? fastingHours.toFixed(0) : fastingHours.toFixed(1)}h` : null,
                         ]
                           .filter(Boolean)
-                          .join(" / ");
-                      })()}
-                    </div>
-                  )}
+                          .join(" / ")}
+                      </div>
+                    );
+                  })()}
                 </td>
                 <td className="py-2 pr-4 text-right font-semibold text-slate-800 dark:text-slate-200">
                   {log.weight?.toFixed(1)}

--- a/src/lib/utils/calendarUtils.test.ts
+++ b/src/lib/utils/calendarUtils.test.ts
@@ -293,6 +293,82 @@ describe("buildConditionTags", () => {
   });
 });
 
+// ── buildCalendarDayMap — fasting_hours (前日参照仕様) ─────────────────────────
+
+describe("buildCalendarDayMap — fasting_hours", () => {
+  it("前日 last_meal_end_time と当日 weigh_in_time から算出する", () => {
+    // 前日 22:30 → 当日 07:00 = 8.5h
+    const logs = [
+      makeLog({ log_date: "2026-03-09", weight: 70, last_meal_end_time: "22:30:00" }),
+      makeLog({ log_date: "2026-03-10", weight: 70, weigh_in_time: "07:00:00" }),
+    ];
+    const map = buildCalendarDayMap(logs);
+    expect(map.get("2026-03-10")!.fasting_hours).toBe(8.5);
+  });
+
+  it("前日ログがない場合は null", () => {
+    // 2026-03-11 の前日 (2026-03-10) はログなし
+    const logs = [
+      makeLog({ log_date: "2026-03-09", weight: 70, last_meal_end_time: "22:30:00" }),
+      makeLog({ log_date: "2026-03-11", weight: 70, weigh_in_time: "07:00:00" }),
+    ];
+    const map = buildCalendarDayMap(logs);
+    // 2026-03-10 のログが存在しないので 2026-03-11 は null
+    expect(map.get("2026-03-11")!.fasting_hours).toBeNull();
+  });
+
+  it("前日 last_meal_end_time がない場合は null", () => {
+    const logs = [
+      makeLog({ log_date: "2026-03-09", weight: 70, last_meal_end_time: null }),
+      makeLog({ log_date: "2026-03-10", weight: 70, weigh_in_time: "07:00:00" }),
+    ];
+    const map = buildCalendarDayMap(logs);
+    expect(map.get("2026-03-10")!.fasting_hours).toBeNull();
+  });
+
+  it("当日 weigh_in_time がない場合は null", () => {
+    const logs = [
+      makeLog({ log_date: "2026-03-09", weight: 70, last_meal_end_time: "22:30:00" }),
+      makeLog({ log_date: "2026-03-10", weight: 70, weigh_in_time: null }),
+    ];
+    const map = buildCalendarDayMap(logs);
+    expect(map.get("2026-03-10")!.fasting_hours).toBeNull();
+  });
+
+  it("当日の same-day last_meal_end_time は断食時間に使われない", () => {
+    // 当日 D に last_meal_end_time があっても、前日がなければ null
+    const logs = [
+      makeLog({ log_date: "2026-03-10", weight: 70, last_meal_end_time: "22:30:00", weigh_in_time: "07:00:00" }),
+    ];
+    const map = buildCalendarDayMap(logs);
+    // 前日ログがないので null（旧仕様では 8.5h だった）
+    expect(map.get("2026-03-10")!.fasting_hours).toBeNull();
+  });
+
+  it("ログが1件のみ（前日参照不能）の場合は null", () => {
+    const logs = [
+      makeLog({ log_date: "2026-03-10", weight: 70, last_meal_end_time: "22:30:00", weigh_in_time: "07:00:00" }),
+    ];
+    const map = buildCalendarDayMap(logs);
+    expect(map.get("2026-03-10")!.fasting_hours).toBeNull();
+  });
+
+  it("連続ログが複数ある場合、各日は正しく前日を参照する", () => {
+    const logs = [
+      makeLog({ log_date: "2026-03-08", weight: 70, last_meal_end_time: "21:00:00" }),
+      makeLog({ log_date: "2026-03-09", weight: 70, last_meal_end_time: "22:30:00", weigh_in_time: "06:00:00" }),
+      makeLog({ log_date: "2026-03-10", weight: 70, weigh_in_time: "07:00:00" }),
+    ];
+    const map = buildCalendarDayMap(logs);
+    // 2026-03-09: 前日(08) 21:00 → 当日(09) 06:00 = 9h
+    expect(map.get("2026-03-09")!.fasting_hours).toBe(9);
+    // 2026-03-10: 前日(09) 22:30 → 当日(10) 07:00 = 8.5h
+    expect(map.get("2026-03-10")!.fasting_hours).toBe(8.5);
+    // 2026-03-08: 前日ログなし → null
+    expect(map.get("2026-03-08")!.fasting_hours).toBeNull();
+  });
+});
+
 // ── calcFastingHours ─────────────────────────────────────────────────────────
 
 describe("calcFastingHours", () => {

--- a/src/lib/utils/calendarUtils.ts
+++ b/src/lib/utils/calendarUtils.ts
@@ -13,6 +13,7 @@
 import type { DashboardDailyLog } from "@/lib/supabase/types";
 import { DAY_TAGS, DAY_TAG_LABELS, DAY_TAG_BADGE_COLORS } from "./dayTags";
 import { formatConditionSummary, isValidTrainingType, isValidWorkMode, TRAINING_TYPE_LABELS, WORK_MODE_LABELS } from "./trainingType";
+import { addDaysStr } from "./date";
 
 // ── 型定義 ──────────────────────────────────────────────────────────────────
 
@@ -45,20 +46,25 @@ export interface CalendarDayData {
    */
   conditionTags: CalendarDayTagInfo[];
   /**
-   * 空腹時間（時間単位、小数点1桁）。
-   * last_meal_end_time と weigh_in_time の両方が記録されている場合のみ算出。
-   * 日をまたぐ場合（例: 22:30→07:00）も正しく計算する。
+   * 断食時間（時間単位、小数点1桁）。
+   * 表示日 D の断食時間 = 前日 D-1 の last_meal_end_time と 当日 D の weigh_in_time の差分。
+   * 前日ログなし・前日に last_meal_end_time なし・当日に weigh_in_time なし のいずれかで null。
    */
   fasting_hours: number | null;
 }
 
 /**
- * 最終食事終了時刻と体重測定時刻から空腹時間（h）を算出する。
+ * 2つの時刻文字列から断食時間（h）を算出する低レベルユーティリティ。
  *
  * - 両方の時刻が存在する場合のみ計算する。
- * - 日をまたぐ場合（weigh_in_time < last_meal_end_time）は +24h で補正する。
- * - タイムゾーン情報なし・当日内の時刻として扱う。
+ * - 日をまたぐ場合（weighInTime < lastMealEndTime）は +24h で補正する。
+ * - タイムゾーン情報なし・時刻のみを扱う。
  * - 入力は "HH:MM" または "HH:MM:SS" 形式を許容する（PostgreSQL TIME 型は "HH:MM:SS" で返す）。
+ *
+ * 呼び出し側の責務:
+ *   - lastMealEndTime には「前日 D-1 の last_meal_end_time」を渡すこと
+ *   - weighInTime には「当日 D の weigh_in_time」を渡すこと
+ *   - 前日ログが存在しない場合は null を渡し、呼び出し側でハンドリングすること
  */
 export function calcFastingHours(
   lastMealEndTime: string | null | undefined,
@@ -174,6 +180,9 @@ export function buildCalendarDayMap(logs: DashboardDailyLog[]): Map<string, Cale
   const withWeight = sorted.filter((d) => d.weight !== null);
   const withCals   = sorted.filter((d) => d.calories !== null);
 
+  // 断食時間算出用: 日付 → ログ の高速参照テーブル
+  const logByDate = new Map(sorted.map((l) => [l.log_date, l]));
+
   const map = new Map<string, CalendarDayData>();
 
   for (const log of sorted) {
@@ -218,7 +227,11 @@ export function buildCalendarDayMap(logs: DashboardDailyLog[]): Map<string, Cale
       work_mode:          log.work_mode,
     });
 
-    const fasting_hours = calcFastingHours(log.last_meal_end_time, log.weigh_in_time);
+    // 断食時間: 前日 D-1 の last_meal_end_time → 当日 D の weigh_in_time
+    // 前日ログなし・前日 last_meal_end_time なし・当日 weigh_in_time なし → null
+    const prevDateKey = addDaysStr(log.log_date, -1);
+    const prevDayLog  = prevDateKey ? (logByDate.get(prevDateKey) ?? null) : null;
+    const fasting_hours = calcFastingHours(prevDayLog?.last_meal_end_time, log.weigh_in_time);
 
     map.set(log.log_date, {
       log, weightDelta, calDelta, dayTags, conditionSummary, conditionTags, fasting_hours,


### PR DESCRIPTION
## 旧仕様と新仕様の差分

| | 旧仕様 | 新仕様 |
|---|---|---|
| 断食時間の算出 | D の `last_meal_end_time` → D の `weigh_in_time`（同日内差分） | D-1 の `last_meal_end_time` → D の `weigh_in_time`（前日参照） |
| `last_meal_end_time` の意味 | 当日の最後の食事終了時刻（変更なし） | 当日の最後の食事終了時刻（変更なし） |
| 前日ログなし時 | 同日フォールバック | null（表示しない） |
| 前日に `last_meal_end_time` なし | n/a | null（表示しない） |
| 当日に `weigh_in_time` なし | null | null（変更なし） |

## 前日参照ロジックをどこで実装したか

**`calendarUtils.ts` — `buildCalendarDayMap`:**
- `sorted` から `logByDate = new Map(sorted.map(l => [l.log_date, l]))` を構築
- `addDaysStr(log.log_date, -1)` で前日の日付キーを計算
- `logByDate.get(prevDateKey)` で前日ログを取得
- `calcFastingHours(prevDayLog?.last_meal_end_time, log.weigh_in_time)` を呼ぶ

**`RecentLogsTable.tsx` / `RecentLogsCards.tsx`:**
- `ascending`（全ログ昇順）から同様の `logByDate` Map を構築
- 各行のレンダリング時に前日ログを参照して `calcFastingHours` を呼ぶ

`calcFastingHours` 関数自体はシグネチャ・実装ともに変更なし（純粋な時刻差分計算）。

## 前日値欠損時の扱い

以下のいずれかに該当する場合、断食時間を `null` として表示しない:
- 前日 (D-1) のログが存在しない（欠損日を跨ぐケースを含む）
- 前日ログに `last_meal_end_time` が記録されていない
- 当日ログに `weigh_in_time` が記録されていない

## 変更ファイル一覧

- `src/lib/utils/calendarUtils.ts` — `buildCalendarDayMap` の fasting 算出を前日参照に変更、JSDoc 更新
- `src/components/dashboard/RecentLogsTable.tsx` — 同じ前日参照ロジックを適用
- `src/components/dashboard/RecentLogsCards.tsx` — 同上
- `src/lib/utils/calendarUtils.test.ts` — `buildCalendarDayMap` の fasting_hours 新仕様テスト 7件追加

## テスト追加内容

`describe("buildCalendarDayMap — fasting_hours")` として 7件追加:

| テストケース | 期待値 |
|---|---|
| 前日 22:30 → 当日 07:00 | 8.5h |
| 前日ログなし（欠損日あり） | null |
| 前日 `last_meal_end_time` なし | null |
| 当日 `weigh_in_time` なし | null |
| 当日のみ `last_meal_end_time` あり（旧仕様で通っていたケース） | null（新仕様では使われない） |
| ログ1件のみ | null |
| 3日連続の各日が正しく前日を参照する | 各日 9h / 8.5h / null |

全テスト: 1235 passed（+7件）、型チェック・ビルド正常。

🤖 Generated with [Claude Code](https://claude.com/claude-code)