### PR TITLE
fix: avoid Bad Request in step-import preflight for large date sets

### DIFF
--- a/src/app/api/step-import/route.ts
+++ b/src/app/api/step-import/route.ts
@@ -220,22 +220,34 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  // 解析結果の日付一覧を取得
+  // 解析結果の日付一覧を取得（昇順ソート��み）
   const dates = parsed.records.map((r) => r.date).sort();
+  const datesSet = new Set(dates);
+  const minDate = dates[0]!;
+  const maxDate = dates[dates.length - 1]!;
 
   // DB から対象日付範囲の daily_logs を取得
+  //
+  // `.in("log_date", dates)` は PostgREST により URL クエリパラメータに展開されるため、
+  // 日付件数が多い（数百〜数千件）と URL 長制限を超���て 400 Bad Request になる。
+  // 代わりに minDate〜maxDate の範囲取得を使い、アプリ側で datesSet との突合を行う。
+  // 範囲内に import 対象外の日付が含まれる場合があるが、datesSet フィルタで除外する。
   const supabase = createClient();
   const { data: existingLogs, error: fetchError } = await supabase
     .from("daily_logs")
     .select("log_date, step_count")
-    .in("log_date", dates);
+    .gte("log_date", minDate)
+    .lte("log_date", maxDate);
 
   if (fetchError) {
     return NextResponse.json({ error: "DB 取得エラー: " + fetchError.message }, { status: 500 });
   }
 
+  // 範囲取得結果のうち import 対象日だけを Map に収録する
   const existingMap = new Map<string, number | null>(
-    (existingLogs ?? []).map((row) => [row.log_date, row.step_count as number | null]),
+    (existingLogs ?? [])
+      .filter((row) => datesSet.has(row.log_date))
+      .map((row) => [row.log_date, row.step_count as number | null]),
   );
 
   // ── preflight ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## 概要

大��日付の CSV/JSON をイ���ポートしようとすると preflight（および import）で `DB 取得エラー: Bad Request` になる問題を修正する。

## 原因

PostgREST の `.in("log_date", dates)` はリクエスト URL のクエリパラメータとして展開される。

```
GET /daily_logs?select=log_date,step_count&log_date=in.(2024-01-01,2024-01-02,...,2026-04-01)
```

日付が数百〜数千件になると URL が 8KB 前後の制限を超え、`400 Bad Request` が返る。  
Apple Health の実データは数年分（1000 件超）になるケースがあり、確実に再現する。

## 変更内容

`src/app/api/step-import/route.ts` の 1 か所のみ。

**変更前**
```ts
const { data: existingLogs } = await supabase
  .from("daily_logs")
  .select("log_date, step_count")
  .in("log_date", dates);          // ← URL 長爆発
```

**変更後**
```ts
const { data: existingLogs } = await supabase
  .from("daily_logs")
  .select("log_date, step_count")
  .gte("log_date", minDate)        // ← 範囲取得
  .lte("log_date", maxDate);

// 範囲内の余分な行は datesSet でフィルタ
const existingMap = new Map(
  (existingLogs ?? [])
    .filter((row) => datesSet.has(row.log_date))
    .map((row) => [row.log_date, row.step_count])
);
```

## 採用した対策

**日付範囲取得 + ���プリ側 Set 突合**

- `minDate〜maxDate` の範囲で `daily_logs` を 1 クエリ取得（URL 長は定数）
- 取得結果を `datesSet` でフィルタし、import 対象外日を除外
- `daily_logs` は個人利用の日次ログなので範囲内の行数は最大でも数千行程度

## preflight / import への影響

- **preflight の件数サマリー計算ロジック**: 変更なし
- **import の保存ルール**��`daily_logs` がある日のみ更新）: 変更なし
- **preflight と import で共用の DB 取得処理を 1 か所修正**: 両方に効く

## 確認内容

- `npx tsc --noEmit` エラーなし
- `npx jest --no-coverage` 1235 件�����過

## 補足

チャンク分割方式も検討したが、範囲取得方式の方がクエリ数が 1 回で済み実装も単純なため採用した。

Closes #448