### PR TITLE
refactor: add Apple Health import-only comment to step_count fields

### DIFF
--- a/src/app/actions/buildUpdatePayload.ts
+++ b/src/app/actions/buildUpdatePayload.ts
@@ -44,7 +44,7 @@ export function buildUpdatePayload(
   if (input.last_meal_end_time !== undefined) payload.last_meal_end_time = input.last_meal_end_time;
   if (input.weigh_in_time      !== undefined) payload.weigh_in_time      = input.weigh_in_time;
 
-  // #436 追加: 歩数
+  // #436 追加: 歩数（Apple Health インポート専用。MealLogger からは渡されない）
   if (input.step_count !== undefined) payload.step_count = input.step_count;
 
   return payload;

--- a/src/app/actions/saveDailyLog.ts
+++ b/src/app/actions/saveDailyLog.ts
@@ -111,6 +111,8 @@ export async function saveDailyLog(
     }
   }
 
+  // step_count は Apple Health インポート専用。MealLogger からは渡されないが、
+  // 万一渡された場合に不正値で上書きされないようバリデーションを維持する。
   if (input.step_count !== undefined && input.step_count !== null) {
     if (!Number.isInteger(input.step_count) || input.step_count < 0 || input.step_count > 200000) {
       return { ok: false, message: "歩数は 0〜200,000 の整数で入力してください" };


### PR DESCRIPTION
## 概要
`buildUpdatePayload.ts` と `saveDailyLog.ts` の `step_count` 処理に「Apple Health インポート専用・MealLogger からは渡されない」旨のコメントを追加する。

## 原因
`step_count` が Apple Health インポート専用フィールドであることがコードから読み取りにくく、将来的に MealLogger から誤って渡す実装が入るリスクがあった。

## 変更内容
- `buildUpdatePayload.ts` L47: `// #436 追加: 歩数` → Apple Health インポート専用である旨を追記
- `saveDailyLog.ts` L114: バリデーションブロック直前に Apple Health インポート専用であることと、万一渡された場合のガード目的のコメントを追加

## 方針
コメントのみの変更。ロジックは変更なし。

## 検証
- 既存テスト通過確認（ロジック変更なし）

## 注意事項
なし

Closes #456