### PR TITLE
feat: add CSV export verification hint to step import done banner

### DIFF
--- a/src/components/settings/StepImportSection.tsx
+++ b/src/components/settings/StepImportSection.tsx
@@ -279,14 +279,19 @@ export function StepImportSection() {
 
           {/* ── 完了 ── */}
           {phase.kind === "done" && (
-            <div className="flex items-center gap-2 rounded-xl bg-emerald-50 border border-emerald-100 px-4 py-3 text-sm font-medium text-emerald-600 dark:bg-emerald-900/20 dark:border-emerald-700/50 dark:text-emerald-400">
-              <CheckCircle2 size={16} />
-              <span>
-                {phase.saved.toLocaleString()} 日分の歩数を保存しました
-                {phase.skipped > 0 && (
-                  <span className="ml-1 text-amber-600 dark:text-amber-400">（{phase.skipped.toLocaleString()} 件はスキップ）</span>
-                )}
-              </span>
+            <div>
+              <div className="flex items-center gap-2 rounded-xl bg-emerald-50 border border-emerald-100 px-4 py-3 text-sm font-medium text-emerald-600 dark:bg-emerald-900/20 dark:border-emerald-700/50 dark:text-emerald-400">
+                <CheckCircle2 size={16} />
+                <span>
+                  {phase.saved.toLocaleString()} 日分の歩数を保存しました
+                  {phase.skipped > 0 && (
+                    <span className="ml-1 text-amber-600 dark:text-amber-400">（{phase.skipped.toLocaleString()} 件はスキップ）</span>
+                  )}
+                </span>
+              </div>
+              <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+                保存された値は設定画面の CSV エクスポートで step_count 列を確認できます。
+              </p>
             </div>
           )}
 


### PR DESCRIPTION
## 概要
歩数インポート完了バナーの下に「保存値は CSV エクスポートで step_count 列を確認できます」という補足テキストを追加する。

## 原因
現状、インポート後に値が正しく保存されたか確認する UI が存在せず、ユーザーが保存結果を確認する方法が分かりにくかった。

## 変更内容
- `StepImportSection.tsx`: `phase.kind === "done"` 表示ブロックの下に補足テキストを追加
  - 「保存された値は設定画面の CSV エクスポートで step_count 列を確認できます。」

## 方針
- 完了バナーの構造を `<div>` でラップし、バナー直下に小さいテキストを追加
- スタイルは既存の補足テキスト（`text-xs text-slate-500`）に合わせる

## 検証
- TypeScript 型エラーなし
- 既存のインポートフロー（preflight / import / error）への影響なし

## 注意事項
なし

Closes #458