### PR TITLE
fix: reject float step_count in JSON parser instead of silently coercing

### DIFF
--- a/src/app/api/step-import/route.ts
+++ b/src/app/api/step-import/route.ts
@@ -147,9 +147,14 @@ function parseJson(text: string): ParseResult {
     if (!DATE_RE.test(date)) { invalidRows++; continue; }
 
     const stepRaw = obj["step_count"];
+
+    // 浮動小数点数（例: 1234.9）は無効行としてスキップする。
+    // Math.trunc で暗黙的に整数化しない。
+    if (typeof stepRaw === "number" && !Number.isInteger(stepRaw)) { invalidRows++; continue; }
+
     const stepCount =
       typeof stepRaw === "number"
-        ? Math.trunc(stepRaw)
+        ? stepRaw
         : parseInt(String(stepRaw ?? ""), 10);
 
     if (!Number.isInteger(stepCount) || stepCount < 0 || isNaN(stepCount)) { invalidRows++; continue; }


### PR DESCRIPTION
## 概要
JSON パーサーで `step_count` が浮動小数点数（例: `1234.9`）の場合、`Math.trunc` で暗黙的に整数化するのではなく、無効行としてスキップするよう修正する。

## 原因
```ts
const stepCount = typeof stepRaw === "number"
  ? Math.trunc(stepRaw)  // 1234.9 → 1234 と暗黙変換
  : parseInt(String(stepRaw ?? ""), 10);
if (!Number.isInteger(stepCount) ...) // トランク後は整数なので通過してしまう
```
`Math.trunc` 後の値は `Number.isInteger` を通過するため、`1234.9` が `1234` として無言でインポートされていた。歩数は整数値であるべきで、浮動小数点データは不正形式として扱うのが正しい。

## 変更内容
- `parseJson` 関数: `typeof stepRaw === "number" && !Number.isInteger(stepRaw)` のチェックを `Math.trunc` より先に挿入
- 浮動小数点の場合は `invalidRows++; continue;` でスキップ
- 整数 number の場合は `Math.trunc` を外して `stepRaw` をそのまま使用（既に整数と保証されているため）

## 方針
- CSV パーサー（`parseCsv`）は文字列から `Number()` で変換後 `isInteger` チェックを行っており、同じ問題は発生しない。JSON パーサーのみ修正

## 検証
- TypeScript 型チェック通過
- 既存テスト通過確認

## 注意事項
なし

Closes #463