### PR TITLE
fix: correct TDEE error banner text to match actual fallback behavior

### DIFF
--- a/src/app/tdee/page.tsx
+++ b/src/app/tdee/page.tsx
@@ -200,7 +200,7 @@ export default async function TdeePage() {
       {rawLogsResult.kind === "error" && (
         <StatusNotice status="error" className="mb-5">
           ログデータの取得中にエラーが発生しました。ページを再読み込みしてください。
-          グラフ・表は取得エラー前のデータを表示しています。
+          グラフ・表のデータを表示できません。
         </StatusNotice>
       )}
       {settingsResult.kind === "error" && (


### PR DESCRIPTION
## 概要
TDEE ページでログ取得エラーが発生した際のバナー文言を、実装の実際の挙動（空配列フォールバック）と一致させる。

## 原因
エラー時は `rawLogs = []`（空配列）にフォールバックするため、グラフ・表は空白になる。「グラフ・表は取得エラー前のデータを表示しています」という文言は誤りで、ユーザーに「一部データが残っている」という誤解を与えていた。

## 変更内容
- `src/app/tdee/page.tsx` L203: 「グラフ・表は取得エラー前のデータを表示しています。」→「グラフ・表のデータを表示できません。」

## 方針
文言のみ修正。ロジックは変更なし。他ページ（dashboard / macro / settings）に同様の文言がないことを確認済み。

## 検証
- TypeScript 型チェック通過（文言変更のみ）

## 注意事項
なし

Closes #460