### PR TITLE
fix: strip BOM from CSV in step-import to support Excel-saved files

### DIFF
--- a/src/app/api/step-import/route.ts
+++ b/src/app/api/step-import/route.ts
@@ -73,7 +73,8 @@ const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
  * - 重複日付は後勝ちで上書き（Apple Health 出力の日付重複は起こらないが念のため）
  */
 function parseCsv(text: string): ParseResult {
-  const lines = text.trim().split(/\r?\n/);
+  // BOM（\uFEFF）を除去する。Excel で開いて上書き保存した CSV に付くことがある。
+  const lines = text.replace(/^\uFEFF/, "").trim().split(/\r?\n/);
   if (lines.length === 0) return { ok: false, message: "ファイルが空です" };
 
   const header = lines[0]?.trim();


### PR DESCRIPTION
## 概要
`step-import` の `parseCsv` に BOM 除去処理を追加し、Excel で開いて保存した CSV をインポートできるようにする。

## 原因
`parseCsv` はヘッダ行を `"date,step_count"` と厳密比較している。Excel が UTF-8 BOM 付きで保存すると先頭に `\uFEFF` が付き、`"\uFEFFdate,step_count"` となってヘッダ不一致エラーになっていた。

## 変更内容
- `parseCsv` 関数の先頭行分割前に `text.replace(/^\uFEFF/, "")` で BOM を除去

## 方針
- BOM 除去は `parseCsv` 内の 1 行で対応（最小変更）
- BOM なし CSV の挙動は変わらない
- JSON は対象外（JSON に BOM は付かないのが標準）

## 検証
- TypeScript 型チェック通過
- BOM なし CSV の既存挙動に影響なし

## 注意事項
なし

Closes #452