### PR TITLE
feat: limit daily_logs preflight fetch to CSV date range in ImportSection

### DIFF
--- a/src/components/settings/ImportSection.tsx
+++ b/src/components/settings/ImportSection.tsx
@@ -60,6 +60,10 @@ export function ImportSection() {
   /**
    * DB の既存 log_date を取得して事前集計を計算する。
    * 結果は preflight state に格納し、UI がサマリーを表示できるようにする。
+   *
+   * 全件取得ではなく CSV の日付範囲（minDate〜maxDate）に絞り込んで取得する。
+   * これにより蓄積件数が増えてもクライアント転送量が CSV 件数に比例する範囲に収まる。
+   * step-import の /api/step-import（#448）と同方式。
    */
   async function runPreflight(
     rows: { log_date: string }[],
@@ -68,7 +72,14 @@ export function ImportSection() {
     setPreflightLoading(true);
     try {
       const supabase = createClient();
-      const { data, error } = await supabase.from("daily_logs").select("log_date");
+      const dates = rows.map((r) => r.log_date).sort();
+      const minDate = dates[0]!;
+      const maxDate = dates[dates.length - 1]!;
+      const { data, error } = await supabase
+        .from("daily_logs")
+        .select("log_date")
+        .gte("log_date", minDate)
+        .lte("log_date", maxDate);
       if (error) {
         setErrorMsg("既存データの取得に失敗しました: " + error.message);
         setResult("error");


### PR DESCRIPTION
## 概要
日次ログ CSV インポートの preflight で `daily_logs` を全件取得していた箇所を、CSV の日付範囲（minDate〜maxDate）に絞り込んで取得するよう変更する。

## 原因
`supabase.from("daily_logs").select("log_date")` に件数制限がなく全件取得していた。蓄積件数が増えるほどクライアント転送量・待ち時間が線形に増加する構造だった。

## 変更内容
- `ImportSection.tsx` の `runPreflight` 関数: 全件取得 → CSV の `minDate`〜`maxDate` の範囲取得（`.gte` / `.lte`）
- 范囲内の daily_logs を全件取得し、`existingDates` Set を構築する方式は変わらない
- `computeImportPreflight` の呼び出し・集計ロジックは変更なし

## 方針
step-import の preflight（#448 で修正済み）と同じアプローチ。CSV の日付範囲内だけ取得すれば突合に必要な情報はすべて得られる。

## 検証
- TypeScript 型チェック通過
- preflight の件数サマリー（新規・上書き・スキップ）の計算結果に影響なし

## 注意事項
`rows` は空でない状態でのみ `runPreflight` が呼ばれるため（`deduped.length > 0` のガードあり）、`dates[0]` / `dates[dates.length - 1]` は必ず存在する。

Closes #462