### PR TITLE
feat: add LIMIT 200 to useDailyLogs query to cap transfer size

### DIFF
--- a/src/lib/hooks/useDailyLogs.ts
+++ b/src/lib/hooks/useDailyLogs.ts
@@ -8,6 +8,8 @@
  *   - 理由: MealLogger はフォーム hydration に既存ログの全フィールドが必要
  *   - front 側の Server Component ページは `src/lib/queries/dailyLogs.ts` の projection query を使うこと
  * - 保存後は `mutate()` でキャッシュを更新する（revalidatePath ではなく SWR 側で即時反映）
+ * - 件数上限: 直近 200 件（降順）。MealLogger の hydration 用途では十分な範囲。
+ *   年単位でデータが蓄積された場合のメモリ・転送量増加を防ぐ。
  *
  * ## full read が許容される理由
  * Client Component がブラウザから直接フォームを操作するため、
@@ -24,7 +26,8 @@ async function fetchDailyLogs(): Promise<DailyLog[]> {
   const { data, error } = await supabase
     .from("daily_logs")
     .select("*")
-    .order("log_date", { ascending: false });
+    .order("log_date", { ascending: false })
+    .limit(200);
 
   if (error) throw error;
   return (data as DailyLog[]) ?? [];


### PR DESCRIPTION
## 概要
`useDailyLogs` フックの `daily_logs` 取得に `.limit(200)` を追加し、蓄積件数が増えた場合のクライアント転送量の線形増加を防ぐ。

## 原因
現状は件数・期間の制限なく全件取得しており、年単位のデータが蓄積された場合にメモリ・通信量のボトルネックになりうる。MealLogger の hydration 用途では直近の数十〜百件があれば十分。

## 変更内容
- `useDailyLogs.ts`: クエリに `.limit(200)` を追加（降順なので直近 200 件が取得される）
- JSDoc に件数上限の説明・理由を追記

## 方針
- `select("*")` と `order("log_date", { ascending: false })` は変更しない
- `.limit(200)` のみ追加（最小変更）

## 検証
- TypeScript 型チェック通過
- MealLogger の hydration（選択日のログ値を入力欄に表示）は直近 200 件で十分カバーされる

## 注意事項
200 件を超える古い日付のログを MealLogger で参照しようとした場合、その日付のデータが hydration されない。ただし実用上このシナリオは発生しにくく、その場合でも「新規入力」として扱われる（空フォームになる）だけで保存には影響しない。

Closes #464