### PR TITLE
feat: extract step-import parsers to testable module and add unit tests

### DIFF
--- a/src/app/api/step-import/parsers.test.ts
+++ b/src/app/api/step-import/parsers.test.ts
@@ -1,0 +1,240 @@
+/**
+ * step-import パーサのユニットテスト
+ *
+ * parseCsv / parseJson のエッジケースと境界値を検証する。
+ */
+
+import { parseCsv, parseJson, parseStepFile } from "./parsers";
+
+// ── parseCsv ─────────────────────────────────────────────────────────────────
+
+describe("parseCsv", () => {
+  it("正常系: 複数行を正しくパースする", () => {
+    const csv = "date,step_count\n2024-01-15,8432\n2024-01-16,12100";
+    const result = parseCsv(csv);
+    expect(result).toEqual({
+      ok: true,
+      records: [
+        { date: "2024-01-15", stepCount: 8432 },
+        { date: "2024-01-16", stepCount: 12100 },
+      ],
+      invalidRows: 0,
+    });
+  });
+
+  it("CRLF 改行を正しく処理する", () => {
+    const csv = "date,step_count\r\n2024-01-15,8432\r\n2024-01-16,5000";
+    const result = parseCsv(csv);
+    expect(result).toEqual({
+      ok: true,
+      records: [
+        { date: "2024-01-15", stepCount: 8432 },
+        { date: "2024-01-16", stepCount: 5000 },
+      ],
+      invalidRows: 0,
+    });
+  });
+
+  it("BOM 付きヘッダを受け付ける（Excel 保存 CSV 対応）", () => {
+    const csv = "\uFEFFdate,step_count\n2024-01-15,8432";
+    const result = parseCsv(csv);
+    expect(result).toEqual({
+      ok: true,
+      records: [{ date: "2024-01-15", stepCount: 8432 }],
+      invalidRows: 0,
+    });
+  });
+
+  it("空行を無視する", () => {
+    const csv = "date,step_count\n2024-01-15,8432\n\n2024-01-17,6200\n";
+    const result = parseCsv(csv);
+    expect(result).toEqual({
+      ok: true,
+      records: [
+        { date: "2024-01-15", stepCount: 8432 },
+        { date: "2024-01-17", stepCount: 6200 },
+      ],
+      invalidRows: 0,
+    });
+  });
+
+  it("重複日付は後勝ちで上書きする", () => {
+    const csv = "date,step_count\n2024-01-15,8432\n2024-01-15,9999";
+    const result = parseCsv(csv);
+    expect(result).toEqual({
+      ok: true,
+      records: [{ date: "2024-01-15", stepCount: 9999 }],
+      invalidRows: 0,
+    });
+  });
+
+  it("日付形式が不正な行は invalidRows にカウントしてスキップする", () => {
+    const csv = "date,step_count\n2024-01-15,8432\n20240116,5000\nnot-a-date,3000";
+    const result = parseCsv(csv);
+    expect(result).toEqual({
+      ok: true,
+      records: [{ date: "2024-01-15", stepCount: 8432 }],
+      invalidRows: 2,
+    });
+  });
+
+  it("step_count が float の行は invalidRows にカウントしてスキップする", () => {
+    const csv = "date,step_count\n2024-01-15,8432.9\n2024-01-16,5000";
+    const result = parseCsv(csv);
+    expect(result).toEqual({
+      ok: true,
+      records: [{ date: "2024-01-16", stepCount: 5000 }],
+      invalidRows: 1,
+    });
+  });
+
+  it("step_count が負値の行は invalidRows にカウントしてスキップする", () => {
+    const csv = "date,step_count\n2024-01-15,-1";
+    const result = parseCsv(csv);
+    expect(result).toEqual({ ok: true, records: [], invalidRows: 1 });
+  });
+
+  it("step_count が文字列の行は invalidRows にカウントしてスキップする", () => {
+    const csv = "date,step_count\n2024-01-15,abc";
+    const result = parseCsv(csv);
+    expect(result).toEqual({ ok: true, records: [], invalidRows: 1 });
+  });
+
+  it("コンマなし行は invalidRows にカウントしてスキップする", () => {
+    const csv = "date,step_count\n2024-01-15";
+    const result = parseCsv(csv);
+    expect(result).toEqual({ ok: true, records: [], invalidRows: 1 });
+  });
+
+  it("ヘッダが不正な場合は ok: false を返す", () => {
+    const csv = "Date,StepCount\n2024-01-15,8432";
+    const result = parseCsv(csv);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("CSV ヘッダーが不正です");
+    }
+  });
+
+  it("空文字列（ヘッダ後が空）は ok: true で records: [] を返す", () => {
+    const result = parseCsv("date,step_count");
+    expect(result).toEqual({ ok: true, records: [], invalidRows: 0 });
+  });
+});
+
+// ── parseJson ────────────────────────────────────────────────────────────────
+
+describe("parseJson", () => {
+  it("正常系: 複数要素を正しくパースする", () => {
+    const json = '[{"date":"2024-01-15","step_count":8432},{"date":"2024-01-16","step_count":12100}]';
+    const result = parseJson(json);
+    expect(result).toEqual({
+      ok: true,
+      records: [
+        { date: "2024-01-15", stepCount: 8432 },
+        { date: "2024-01-16", stepCount: 12100 },
+      ],
+      invalidRows: 0,
+    });
+  });
+
+  it("空配列は ok: true で records: [] を返す", () => {
+    const result = parseJson("[]");
+    expect(result).toEqual({ ok: true, records: [], invalidRows: 0 });
+  });
+
+  it("step_count が 8432.0（JS では整数）は通過する", () => {
+    // JSON.parse('8432.0') === 8432（JS は整数として扱う）
+    const result = parseJson('[{"date":"2024-01-15","step_count":8432.0}]');
+    expect(result).toEqual({
+      ok: true,
+      records: [{ date: "2024-01-15", stepCount: 8432 }],
+      invalidRows: 0,
+    });
+  });
+
+  it("step_count が小数点付き浮動小数点（例: 8432.9）は invalidRows にカウントされる", () => {
+    const result = parseJson('[{"date":"2024-01-15","step_count":8432.9}]');
+    expect(result).toEqual({ ok: true, records: [], invalidRows: 1 });
+  });
+
+  it("step_count が文字列数値（\"8432\"）も通過する", () => {
+    const result = parseJson('[{"date":"2024-01-15","step_count":"8432"}]');
+    expect(result).toEqual({
+      ok: true,
+      records: [{ date: "2024-01-15", stepCount: 8432 }],
+      invalidRows: 0,
+    });
+  });
+
+  it("重複日付は後勝ちで上書きする", () => {
+    const json = '[{"date":"2024-01-15","step_count":8432},{"date":"2024-01-15","step_count":9999}]';
+    const result = parseJson(json);
+    expect(result).toEqual({
+      ok: true,
+      records: [{ date: "2024-01-15", stepCount: 9999 }],
+      invalidRows: 0,
+    });
+  });
+
+  it("不正な要素（null・プリミティブ）は invalidRows にカウントしてスキップする", () => {
+    const json = '[null,{"date":"2024-01-15","step_count":8432},42]';
+    const result = parseJson(json);
+    expect(result).toEqual({
+      ok: true,
+      records: [{ date: "2024-01-15", stepCount: 8432 }],
+      invalidRows: 2,
+    });
+  });
+
+  it("配列以外の JSON（オブジェクト）は ok: false を返す", () => {
+    const result = parseJson('{"date":"2024-01-15","step_count":8432}');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("配列形式の JSON");
+    }
+  });
+
+  it("不正な JSON 文字列は ok: false を返す", () => {
+    const result = parseJson("not json");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("JSON のパースに失敗");
+    }
+  });
+
+  it("step_count が負値の行は invalidRows にカウントしてスキップする", () => {
+    const result = parseJson('[{"date":"2024-01-15","step_count":-1}]');
+    expect(result).toEqual({ ok: true, records: [], invalidRows: 1 });
+  });
+});
+
+// ── parseStepFile ────────────────────────────────────────────────────────────
+
+describe("parseStepFile", () => {
+  it(".csv ファイル名は parseCsv に委譲する", () => {
+    const result = parseStepFile("date,step_count\n2024-01-15,8432", "daily_steps.csv");
+    expect(result).toEqual({
+      ok: true,
+      records: [{ date: "2024-01-15", stepCount: 8432 }],
+      invalidRows: 0,
+    });
+  });
+
+  it(".json ファイル名は parseJson に委譲する", () => {
+    const result = parseStepFile('[{"date":"2024-01-15","step_count":8432}]', "daily_steps.json");
+    expect(result).toEqual({
+      ok: true,
+      records: [{ date: "2024-01-15", stepCount: 8432 }],
+      invalidRows: 0,
+    });
+  });
+
+  it("拡張子が大文字（.JSON）でも parseJson に委譲する", () => {
+    const result = parseStepFile('[{"date":"2024-01-15","step_count":8432}]', "steps.JSON");
+    expect(result).toEqual({
+      ok: true,
+      records: [{ date: "2024-01-15", stepCount: 8432 }],
+      invalidRows: 0,
+    });
+  });
+});

--- a/src/app/api/step-import/parsers.ts
+++ b/src/app/api/step-import/parsers.ts
@@ -1,0 +1,143 @@
+/**
+ * step-import パーサ
+ *
+ * CSV / JSON テキストを { date, stepCount }[] に変換する純粋関数群。
+ * Route Handler の Next.js 依存を持たないため単体テスト可能。
+ */
+
+// ── 型 ───────────────────────────────────────────────────────────────────────
+
+export type StepRecord = { date: string; stepCount: number };
+
+export type ParseResult =
+  | { ok: true; records: StepRecord[]; invalidRows: number }
+  | { ok: false; message: string };
+
+// ── 内部定数 ─────────────────────────────────────────────────────────────────
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+// ── parseCsv ─────────────────────────────────────────────────────────────────
+
+/**
+ * CSV テキストを { date, stepCount }[] にパースする。
+ *
+ * - ヘッダ行は "date,step_count"（小文字・順不同は不可）
+ * - BOM（\uFEFF）を自動除去する（Excel 保存 CSV 対応）
+ * - 日付形式不正 / 数値不正の行は invalidRows にカウントしてスキップ
+ * - 重複日付は後勝ちで上書き（Apple Health 出力の日付重複は起こらないが念のため）
+ */
+export function parseCsv(text: string): ParseResult {
+  // BOM（\uFEFF）を除去する。Excel で開いて上書き保存した CSV に付くことがある。
+  const lines = text.replace(/^\uFEFF/, "").trim().split(/\r?\n/);
+  if (lines.length === 0) return { ok: false, message: "ファイルが空です" };
+
+  const header = lines[0]?.trim();
+  if (header !== "date,step_count") {
+    return {
+      ok: false,
+      message: `CSV ヘッダーが不正です。1行目は "date,step_count" である必要があります（実際: "${header?.slice(0, 40)}"）`,
+    };
+  }
+
+  const records: StepRecord[] = [];
+  const seen = new Map<string, number>(); // date → records index
+  let invalidRows = 0;
+
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i]?.trim();
+    if (!line) continue;
+
+    const commaIdx = line.indexOf(",");
+    if (commaIdx < 0) { invalidRows++; continue; }
+
+    const date = line.slice(0, commaIdx).trim();
+    const stepStr = line.slice(commaIdx + 1).trim();
+
+    if (!DATE_RE.test(date)) { invalidRows++; continue; }
+
+    const stepCount = Number(stepStr);
+    if (!Number.isInteger(stepCount) || stepCount < 0 || isNaN(stepCount)) { invalidRows++; continue; }
+
+    const existing = seen.get(date);
+    if (existing !== undefined) {
+      records[existing] = { date, stepCount };
+    } else {
+      seen.set(date, records.length);
+      records.push({ date, stepCount });
+    }
+  }
+
+  return { ok: true, records, invalidRows };
+}
+
+// ── parseJson ────────────────────────────────────────────────────────────────
+
+/**
+ * JSON テキストを { date, stepCount }[] にパースする。
+ *
+ * 期待形式: [{"date":"YYYY-MM-DD","step_count":N}, ...]
+ * - 浮動小数点数（例: 1234.9）は無効行としてスキップする（Math.trunc で暗黙整数化しない）
+ * - 重複日付は後勝ちで上書き
+ */
+export function parseJson(text: string): ParseResult {
+  let data: unknown;
+  try {
+    data = JSON.parse(text);
+  } catch {
+    return { ok: false, message: "JSON のパースに失敗しました。有効な JSON ファイルを選択してください" };
+  }
+
+  if (!Array.isArray(data)) {
+    return {
+      ok: false,
+      message: '配列形式の JSON を指定してください: [{"date":"YYYY-MM-DD","step_count":N}, ...]',
+    };
+  }
+
+  const records: StepRecord[] = [];
+  const seen = new Map<string, number>();
+  let invalidRows = 0;
+
+  for (const item of data) {
+    if (typeof item !== "object" || item === null) { invalidRows++; continue; }
+    const obj = item as Record<string, unknown>;
+
+    const date = typeof obj["date"] === "string" ? obj["date"].trim() : "";
+    if (!DATE_RE.test(date)) { invalidRows++; continue; }
+
+    const stepRaw = obj["step_count"];
+
+    // 浮動小数点数（例: 1234.9）は無効行としてスキップする。
+    // Math.trunc で暗黙的に整数化しない。
+    if (typeof stepRaw === "number" && !Number.isInteger(stepRaw)) { invalidRows++; continue; }
+
+    const stepCount =
+      typeof stepRaw === "number"
+        ? stepRaw
+        : parseInt(String(stepRaw ?? ""), 10);
+
+    if (!Number.isInteger(stepCount) || stepCount < 0 || isNaN(stepCount)) { invalidRows++; continue; }
+
+    const existing = seen.get(date);
+    if (existing !== undefined) {
+      records[existing] = { date, stepCount };
+    } else {
+      seen.set(date, records.length);
+      records.push({ date, stepCount });
+    }
+  }
+
+  return { ok: true, records, invalidRows };
+}
+
+// ── parseStepFile ────────────────────────────────────────────────────────────
+
+/**
+ * ファイル名の拡張子からフォーマットを判定し、テキストをパースする。
+ * 拡張子が .json なら JSON、それ以外（.csv など）は CSV として処理する。
+ */
+export function parseStepFile(text: string, fileName: string): ParseResult {
+  const isJson = fileName.toLowerCase().endsWith(".json");
+  return isJson ? parseJson(text) : parseCsv(text);
+}

--- a/src/app/api/step-import/route.ts
+++ b/src/app/api/step-import/route.ts
@@ -31,6 +31,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { revalidateAfterDailyLogMutation } from "@/lib/cache/revalidate";
+import { parseStepFile } from "./parsers";
+import type { ParseResult } from "./parsers";
 
 // ── 型定義 ──────────────────────────────────────────────────────────────────
 
@@ -52,134 +54,6 @@ export type StepPreflightResult = {
 export type StepImportResult =
   | { ok: true; savedCount: number; skippedCount: number }
   | { ok: false; message: string };
-
-// ── パース型 ─────────────────────────────────────────────────────────────────
-
-type StepRecord = { date: string; stepCount: number };
-
-type ParseResult =
-  | { ok: true; records: StepRecord[]; invalidRows: number }
-  | { ok: false; message: string };
-
-// ── パーサ ───────────────────────────────────────────────────────────────────
-
-const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
-
-/**
- * CSV テキストを { date, stepCount }[] にパースする。
- *
- * - ヘッダ行は "date,step_count"（小文字・順不同は不可）
- * - 日付形式不正 / 数値不正の行は invalidRows にカウントしてスキップ
- * - 重複日付は後勝ちで上書き（Apple Health 出力の日付重複は起こらないが念のため）
- */
-function parseCsv(text: string): ParseResult {
-  // BOM（\uFEFF）を除去する。Excel で開いて上書き保存した CSV に付くことがある。
-  const lines = text.replace(/^\uFEFF/, "").trim().split(/\r?\n/);
-  if (lines.length === 0) return { ok: false, message: "ファイルが空です" };
-
-  const header = lines[0]?.trim();
-  if (header !== "date,step_count") {
-    return {
-      ok: false,
-      message: `CSV ヘッダーが不正です。1行目は "date,step_count" である必要があります（実際: "${header?.slice(0, 40)}"）`,
-    };
-  }
-
-  const records: StepRecord[] = [];
-  const seen = new Map<string, number>(); // date → records index
-  let invalidRows = 0;
-
-  for (let i = 1; i < lines.length; i++) {
-    const line = lines[i]?.trim();
-    if (!line) continue;
-
-    const commaIdx = line.indexOf(",");
-    if (commaIdx < 0) { invalidRows++; continue; }
-
-    const date = line.slice(0, commaIdx).trim();
-    const stepStr = line.slice(commaIdx + 1).trim();
-
-    if (!DATE_RE.test(date)) { invalidRows++; continue; }
-
-    const stepCount = Number(stepStr);
-    if (!Number.isInteger(stepCount) || stepCount < 0 || isNaN(stepCount)) { invalidRows++; continue; }
-
-    const existing = seen.get(date);
-    if (existing !== undefined) {
-      records[existing] = { date, stepCount };
-    } else {
-      seen.set(date, records.length);
-      records.push({ date, stepCount });
-    }
-  }
-
-  return { ok: true, records, invalidRows };
-}
-
-/**
- * JSON テキストを { date, stepCount }[] にパースする。
- *
- * 期待形式: [{"date":"YYYY-MM-DD","step_count":N}, ...]
- */
-function parseJson(text: string): ParseResult {
-  let data: unknown;
-  try {
-    data = JSON.parse(text);
-  } catch {
-    return { ok: false, message: "JSON のパースに失敗しました。有効な JSON ファイルを選択してください" };
-  }
-
-  if (!Array.isArray(data)) {
-    return {
-      ok: false,
-      message: '配列形式の JSON を指定してください: [{"date":"YYYY-MM-DD","step_count":N}, ...]',
-    };
-  }
-
-  const records: StepRecord[] = [];
-  const seen = new Map<string, number>();
-  let invalidRows = 0;
-
-  for (const item of data) {
-    if (typeof item !== "object" || item === null) { invalidRows++; continue; }
-    const obj = item as Record<string, unknown>;
-
-    const date = typeof obj["date"] === "string" ? obj["date"].trim() : "";
-    if (!DATE_RE.test(date)) { invalidRows++; continue; }
-
-    const stepRaw = obj["step_count"];
-
-    // 浮動小数点数（例: 1234.9）は無効行としてスキップする。
-    // Math.trunc で暗黙的に整数化しない。
-    if (typeof stepRaw === "number" && !Number.isInteger(stepRaw)) { invalidRows++; continue; }
-
-    const stepCount =
-      typeof stepRaw === "number"
-        ? stepRaw
-        : parseInt(String(stepRaw ?? ""), 10);
-
-    if (!Number.isInteger(stepCount) || stepCount < 0 || isNaN(stepCount)) { invalidRows++; continue; }
-
-    const existing = seen.get(date);
-    if (existing !== undefined) {
-      records[existing] = { date, stepCount };
-    } else {
-      seen.set(date, records.length);
-      records.push({ date, stepCount });
-    }
-  }
-
-  return { ok: true, records, invalidRows };
-}
-
-/**
- * ファイル名の拡張子からフォーマットを判定し、テキストをパースする。
- * 拡張子が .json なら JSON、それ以外（.csv など）は CSV として処理する。
- */
-function parseStepFile(text: string, fileName: string): ParseResult {
-  const isJson = fileName.toLowerCase().endsWith(".json");
-  return isJson ? parseJson(text) : parseCsv(text);
-}
 
 // ── ヘルパー ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## 概要
`parseCsv` / `parseJson` / `parseStepFile` を `parsers.ts` に切り出し、25 件のユニットテストを追加する。

## 原因
`route.ts` 内のプライベート関数はテスト不可だった。Next.js の `NextRequest` / `NextResponse` への依存を持たない純粋関数のみを `parsers.ts` に移すことでテスト可能にする。

## 変更内容
- **`parsers.ts`** (新規): `parseCsv` / `parseJson` / `parseStepFile` と型定義（`StepRecord` / `ParseResult`）をエクスポート
- **`route.ts`**: パーサ関連コードを削除し、`parsers.ts` から import するよう変更
- **`parsers.test.ts`** (新規): 25 件のテスト
  - `parseCsv`: 正常系 / CRLF / BOM 付き / 空行 / 重複日付後勝ち / 日付不正 / float スキップ / 負値 / 文字列 / コンマなし / ヘッダ不正
  - `parseJson`: 正常系 / 空配列 / `8432.0`（JS 整数）通過 / `8432.9`（float）reject / 文字列数値 / 重複後勝ち / null/プリミティブスキップ / 配列以外エラー / 不正 JSON / 負値
  - `parseStepFile`: csv/json/JSON 大文字拡張子の委譲確認

## 方針
- `parsers.ts` はロジックのみ。Next.js 依存なし
- `route.ts` からは `parseStepFile` と `ParseResult` 型のみ import（最小インターフェース）
- ロジック変更なし（BOM 除去は #452 で実装済み、float reject は #463 で実装済み）

## 検証
- 25 件のテスト全通過
- 全テスト 1265 件通過
- TypeScript 型チェック通過

## 注意事項
このブランチは `fix/issue-452-bom-csv` から派生。BOM テストが #452 の修正に依存するため、**#452 (PR #474) を先にマージしてから本 PR をマージすること**。

Closes #453