### PR TITLE
feat: add long-event exclusion policy to forecast accuracy comparison

### DIFF
--- a/ml-pipeline/backtest.py
+++ b/ml-pipeline/backtest.py
@@ -31,6 +31,11 @@ backtest.py — 体重予測モデルの walk-forward 精度評価
     is_cheat_day / is_travel_day が True の日と、その後 recovery_days 日間を除外する
     手動 event period が指定されている場合は、その期間と recovery_days 日間も除外する
     チートデイや旅行による短期体重ブレを除いた通常日の精度を評価できる
+  exclude_long_event_blocks:
+    連続 long_event_threshold 日以上のイベント区間 (長期イベントブロック) のみを除外する
+    ブロック本体 + ブロック終了後 long_event_recovery_days 日間を除外する
+    長期イベント区間が精度劣化要因かを単独で検証できる (#480)
+    仮説値: long_event_threshold=5, long_event_recovery_days=5 (将来 CLI で変更可)
 
   同一 run に対して複数 policy の metrics を算出し、DB に保存する。
   (#364 で比較表示に利用する)
@@ -49,7 +54,8 @@ backtest.py — 体重予測モデルの walk-forward 精度評価
   python ml-pipeline/backtest.py --feature-set baseline   # 再現メタ (デフォルト)
   python ml-pipeline/backtest.py --recovery-days 3        # 回復期間を変更 (デフォルト: 2)
   python ml-pipeline/backtest.py --event-periods 2026-03-01:2026-03-10  # 手動イベント期間
-  python ml-pipeline/backtest.py --eval-policies all_days exclude_flagged_plus_recovery
+  python ml-pipeline/backtest.py --eval-policies all_days exclude_flagged_plus_recovery exclude_long_event_blocks
+  python ml-pipeline/backtest.py --long-event-threshold 7 --long-event-recovery-days 3  # 長期イベント閾値変更
 """
 
 import argparse
@@ -104,12 +110,31 @@ POLICY_ALL_DAYS = "all_days"
 # 手動 event period も優先適用して除外する
 POLICY_EXCLUDE_FLAGGED_PLUS_RECOVERY = "exclude_flagged_plus_recovery"
 
-_DEFAULT_EVAL_POLICIES = [POLICY_ALL_DAYS, POLICY_EXCLUDE_FLAGGED_PLUS_RECOVERY]
+# 連続 long_event_threshold 日以上の長期イベント区間のみを除外する (#480)
+# ブロック本体 + ブロック終了後 long_event_recovery_days 日間を除外する
+# 短期イベント (1〜4日) は除外せず、長期連続区間の影響のみを評価できる
+POLICY_EXCLUDE_LONG_EVENT_BLOCKS = "exclude_long_event_blocks"
+
+_DEFAULT_EVAL_POLICIES = [
+    POLICY_ALL_DAYS,
+    POLICY_EXCLUDE_FLAGGED_PLUS_RECOVERY,
+    POLICY_EXCLUDE_LONG_EVENT_BLOCKS,
+]
 
 # イベント後の回復期間 (日数)。デフォルト 2 日:
 #   チートデイの翌日〜翌々日は水分変動が残りやすいため除外する。
 #   旅行も同様。イベント種別ごとの自動調整はこの Issue のスコープ外 (#363)。
 _DEFAULT_RECOVERY_DAYS = 2
+
+# 長期イベントブロック判定閾値 (#480 初期仮説値)
+# 連続イベント日数がこの値以上のブロックを「長期イベントブロック」とみなす。
+# 将来のチューニングに備えて定数化。CLI --long-event-threshold で変更可能。
+_DEFAULT_LONG_EVENT_THRESHOLD = 5
+
+# 長期イベントブロック終了後の回復期間 (日数) (#480 初期仮説値)
+# 長期区間後は水分・コンディション回復に時間がかかる想定で長めに設定。
+# CLI --long-event-recovery-days で変更可能。
+_DEFAULT_LONG_EVENT_RECOVERY_DAYS = 5
 
 
 # ── 手動 event period ──────────────────────────────────────────────────────────
@@ -202,6 +227,10 @@ class BacktestConfig:
     recovery_days:        int                    = _DEFAULT_RECOVERY_DAYS
     manual_event_periods: list[ManualEventPeriod] = field(default_factory=list)
 
+    # 長期イベントブロック除外ポリシー用パラメータ (#480 初期仮説値)
+    long_event_threshold:      int = _DEFAULT_LONG_EVENT_THRESHOLD
+    long_event_recovery_days:  int = _DEFAULT_LONG_EVENT_RECOVERY_DAYS
+
     # 内部固定値 (CLI 引数なし。変えるときはコードレビュー必須)
     min_train_rows_np:       int = _MIN_TRAIN_ROWS_NP
     min_train_rows_baseline: int = _MIN_TRAIN_ROWS_BASELINE
@@ -220,6 +249,8 @@ def build_config(args: argparse.Namespace) -> BacktestConfig:
         eval_policies=args.eval_policies,
         recovery_days=args.recovery_days,
         manual_event_periods=args.event_periods,
+        long_event_threshold=args.long_event_threshold,
+        long_event_recovery_days=args.long_event_recovery_days,
     )
 
 
@@ -559,6 +590,88 @@ def build_exclusion_dates(
     return excluded
 
 
+def build_long_event_exclusion_dates(
+    df: pd.DataFrame,
+    long_event_threshold: int,
+    long_event_recovery_days: int,
+    manual_event_periods: Sequence[ManualEventPeriod],
+) -> set[date]:
+    """長期イベント区間 (連続 long_event_threshold 日以上のイベントブロック) のみを除外する。
+
+    イベント候補日:
+      1. df に is_cheat_day=True の行がある日
+      2. df に is_travel_day=True の行がある日
+      3. manual_event_periods の各期間内の全日
+
+    これらのイベント候補日を合算し、連続する区間 (連続日数 >= long_event_threshold) を
+    「長期イベントブロック」として検出する。
+    ブロック本体全日 + ブロック終了日後 long_event_recovery_days 日間を除外する。
+
+    短期イベント (1〜long_event_threshold-1 日) は除外しない点が
+    exclude_flagged_plus_recovery と異なる。
+
+    引数:
+      df                       : 体重履歴 DataFrame (log_date[, is_cheat_day, is_travel_day])
+      long_event_threshold     : 長期イベントブロックとみなす最小連続日数 (初期仮説値: 5)
+      long_event_recovery_days : ブロック終了後の回復期間 (日数) (初期仮説値: 5)
+      manual_event_periods     : 手動指定のイベント期間リスト
+
+    戻り値:
+      除外対象の日付の集合 (set[date])
+    """
+    # イベント候補日を収集 (重複日はセットで自然に除外)
+    event_days: set[date] = set()
+
+    if "is_cheat_day" in df.columns:
+        for d in df.loc[df["is_cheat_day"] == True, "log_date"].dt.date:  # noqa: E712
+            event_days.add(d)
+
+    if "is_travel_day" in df.columns:
+        for d in df.loc[df["is_travel_day"] == True, "log_date"].dt.date:  # noqa: E712
+            event_days.add(d)
+
+    for ep in manual_event_periods:
+        cur = ep.start_date
+        while cur <= ep.end_date:
+            event_days.add(cur)
+            cur += timedelta(days=1)
+
+    if not event_days:
+        return set()
+
+    # 連続ブロックを検出
+    sorted_days = sorted(event_days)
+    blocks: list[tuple[date, date]] = []  # (block_start, block_end)
+    block_start = sorted_days[0]
+    block_end   = sorted_days[0]
+
+    for d in sorted_days[1:]:
+        if d == block_end + timedelta(days=1):
+            block_end = d
+        else:
+            blocks.append((block_start, block_end))
+            block_start = d
+            block_end   = d
+    blocks.append((block_start, block_end))
+
+    # 長期ブロック (>=threshold) のみ除外対象にする
+    excluded: set[date] = set()
+    for (b_start, b_end) in blocks:
+        n_days = (b_end - b_start).days + 1
+        if n_days < long_event_threshold:
+            continue  # 短期イベントはスキップ
+        # ブロック本体
+        cur = b_start
+        while cur <= b_end:
+            excluded.add(cur)
+            cur += timedelta(days=1)
+        # ブロック終了後の回復期間
+        for i in range(1, long_event_recovery_days + 1):
+            excluded.add(b_end + timedelta(days=i))
+
+    return excluded
+
+
 # ── 評価ポリシー: PolicyMetrics と集計 ──────────────────────────────────────────
 
 @dataclass
@@ -590,28 +703,36 @@ def compute_policy_metrics(
     records: list[tuple],
     exclusion_dates: set[date],
     policies: Sequence[str],
+    long_event_exclusion_dates: Optional[set[date]] = None,
 ) -> list[PolicyMetrics]:
     """複数の evaluation policy に対して metrics を計算する。
 
     records の各要素は (error, actual, predicted, origin_date, target_date) の 5-tuple。
-    target_date が exclusion_dates に含まれる場合、exclude 系 policy では除外される。
+    target_date が各 policy の除外日集合に含まれる場合に除外される。
 
     引数:
-      records         : run_backtest が返す 1 モデル × 1 ホライズンの予測結果リスト
-      exclusion_dates : build_exclusion_dates() が返す除外日集合
-      policies        : 計算対象のポリシー名リスト
+      records                    : run_backtest が返す 1 モデル × 1 ホライズンの予測結果リスト
+      exclusion_dates            : build_exclusion_dates() が返す除外日集合
+                                   (POLICY_EXCLUDE_FLAGGED_PLUS_RECOVERY で使用)
+      policies                   : 計算対象のポリシー名リスト
+      long_event_exclusion_dates : build_long_event_exclusion_dates() が返す除外日集合
+                                   (POLICY_EXCLUDE_LONG_EVENT_BLOCKS で使用)
+                                   None の場合は空集合として扱う (後方互換)
 
     戻り値:
       PolicyMetrics のリスト (policies と同じ順序)
     """
     n_total = len(records)
     result: list[PolicyMetrics] = []
+    _long_event_excluded = long_event_exclusion_dates or set()
 
     for policy in policies:
         if policy == POLICY_ALL_DAYS:
             used = records
         elif policy == POLICY_EXCLUDE_FLAGGED_PLUS_RECOVERY:
             used = [r for r in records if r[4] not in exclusion_dates]
+        elif policy == POLICY_EXCLUDE_LONG_EVENT_BLOCKS:
+            used = [r for r in records if r[4] not in _long_event_excluded]
         else:
             log.warning("未知の eval_policy をスキップ: %s", policy)
             continue
@@ -758,8 +879,20 @@ def save_results(
         df, config.recovery_days, config.manual_event_periods
     )
     log.info(
-        "評価ポリシー除外日: %d 日 (recovery_days=%d, manual_periods=%d)",
+        "評価ポリシー除外日 (exclude_flagged_plus_recovery): %d 日 (recovery_days=%d, manual_periods=%d)",
         len(exclusion_dates), config.recovery_days, len(config.manual_event_periods),
+    )
+
+    # 長期イベントブロック除外日集合を構築 (exclude_long_event_blocks ポリシーで使用)
+    long_event_exclusion_dates = build_long_event_exclusion_dates(
+        df, config.long_event_threshold, config.long_event_recovery_days, config.manual_event_periods
+    )
+    log.info(
+        "評価ポリシー除外日 (exclude_long_event_blocks): %d 日 "
+        "(threshold=%d, recovery=%d)",
+        len(long_event_exclusion_dates),
+        config.long_event_threshold,
+        config.long_event_recovery_days,
     )
 
     # 1. runs テーブルに実行メタ情報を挿入
@@ -802,6 +935,9 @@ def save_results(
                 }
                 for ep in config.manual_event_periods
             ],
+            # 長期イベントブロック除外ポリシー用パラメータ (#480)
+            "long_event_threshold":     config.long_event_threshold,
+            "long_event_recovery_days": config.long_event_recovery_days,
         },
     }
     sb.from_("forecast_backtest_runs").insert(run_row).execute()
@@ -823,7 +959,8 @@ def save_results(
 
             # 全 policy の metrics を一括計算
             policy_metrics_list = compute_policy_metrics(
-                records, exclusion_dates, config.eval_policies
+                records, exclusion_dates, config.eval_policies,
+                long_event_exclusion_dates=long_event_exclusion_dates,
             )
 
             for pm in policy_metrics_list:
@@ -924,15 +1061,20 @@ def log_policy_summary(
     results: BacktestResults,
     config: BacktestConfig,
     exclusion_dates: set[date],
+    long_event_exclusion_dates: Optional[set[date]] = None,
 ) -> None:
     """evaluation policy ごとの metrics サマリーをログ出力する。
 
-    all_days と exclude_flagged_plus_recovery を並べて出力することで、
-    イベント除外前後の精度差を確認できる。
+    all_days / exclude_flagged_plus_recovery / exclude_long_event_blocks を並べて出力し、
+    各ポリシー間の精度差を確認できる。
     """
+    _long_event = long_event_exclusion_dates or set()
     log.info(
-        "=== policy 別サマリー (series_type=%s, recovery_days=%d, n_excluded_dates=%d) ===",
+        "=== policy 別サマリー (series_type=%s, recovery_days=%d, "
+        "n_excluded_dates=%d, n_long_event_excluded=%d, "
+        "long_event_threshold=%d, long_event_recovery=%d) ===",
         config.series_type, config.recovery_days, len(exclusion_dates),
+        len(_long_event), config.long_event_threshold, config.long_event_recovery_days,
     )
     for model_name in results:
         for horizon in config.horizons:
@@ -940,7 +1082,8 @@ def log_policy_summary(
             if not records:
                 continue
             policy_metrics_list = compute_policy_metrics(
-                records, exclusion_dates, config.eval_policies
+                records, exclusion_dates, config.eval_policies,
+                long_event_exclusion_dates=_long_event,
             )
             for pm in policy_metrics_list:
                 if pm.mae is None:
@@ -1021,12 +1164,38 @@ def main() -> None:
         nargs="+",
         default=list(_DEFAULT_EVAL_POLICIES),
         dest="eval_policies",
-        choices=[POLICY_ALL_DAYS, POLICY_EXCLUDE_FLAGGED_PLUS_RECOVERY],
+        choices=[
+            POLICY_ALL_DAYS,
+            POLICY_EXCLUDE_FLAGGED_PLUS_RECOVERY,
+            POLICY_EXCLUDE_LONG_EVENT_BLOCKS,
+        ],
         metavar="POLICY",
         help=(
             "算出する評価ポリシー (スペース区切りで複数指定可)。"
             f"デフォルト: {_DEFAULT_EVAL_POLICIES}。"
-            f"選択肢: {POLICY_ALL_DAYS} / {POLICY_EXCLUDE_FLAGGED_PLUS_RECOVERY}"
+            f"選択肢: {POLICY_ALL_DAYS} / {POLICY_EXCLUDE_FLAGGED_PLUS_RECOVERY} / "
+            f"{POLICY_EXCLUDE_LONG_EVENT_BLOCKS}"
+        ),
+    )
+    parser.add_argument(
+        "--long-event-threshold",
+        type=int,
+        default=_DEFAULT_LONG_EVENT_THRESHOLD,
+        dest="long_event_threshold",
+        help=(
+            f"長期イベントブロックとみなす最小連続イベント日数 (#480 初期仮説値)。"
+            f"デフォルト: {_DEFAULT_LONG_EVENT_THRESHOLD}。"
+            "この値以上の連続イベント区間が exclude_long_event_blocks ポリシーの対象になる。"
+        ),
+    )
+    parser.add_argument(
+        "--long-event-recovery-days",
+        type=int,
+        default=_DEFAULT_LONG_EVENT_RECOVERY_DAYS,
+        dest="long_event_recovery_days",
+        help=(
+            f"長期イベントブロック終了後の回復期間 (日数) (#480 初期仮説値)。"
+            f"デフォルト: {_DEFAULT_LONG_EVENT_RECOVERY_DAYS}。"
         ),
     )
     parser.add_argument(
@@ -1059,10 +1228,12 @@ def main() -> None:
     log.info(
         "実験 config: series_type=%s, feature_set=%s, horizons=%s, "
         "max_origins=%d, origin_step_days=%d, np_epochs=%d, "
-        "eval_policies=%s, recovery_days=%d, manual_event_periods=%d件",
+        "eval_policies=%s, recovery_days=%d, manual_event_periods=%d件, "
+        "long_event_threshold=%d, long_event_recovery_days=%d",
         config.series_type, config.feature_set, config.horizons,
         config.max_origins, config.origin_step_days, config.np_epochs,
         config.eval_policies, config.recovery_days, len(config.manual_event_periods),
+        config.long_event_threshold, config.long_event_recovery_days,
     )
 
     # supabase は実行系でのみ使用する (純粋ロジック層に依存を持ち込まない)
@@ -1087,7 +1258,11 @@ def main() -> None:
     exclusion_dates = build_exclusion_dates(
         df, config.recovery_days, config.manual_event_periods
     )
-    log_policy_summary(results, config, exclusion_dates)
+    long_event_exclusion_dates = build_long_event_exclusion_dates(
+        df, config.long_event_threshold, config.long_event_recovery_days,
+        config.manual_event_periods,
+    )
+    log_policy_summary(results, config, exclusion_dates, long_event_exclusion_dates)
 
     run_id = save_results(sb, df, results, config)
     log.info(

--- a/ml-pipeline/test_backtest.py
+++ b/ml-pipeline/test_backtest.py
@@ -25,6 +25,7 @@ import pytest
 from backtest import (
     POLICY_ALL_DAYS,
     POLICY_EXCLUDE_FLAGGED_PLUS_RECOVERY,
+    POLICY_EXCLUDE_LONG_EVENT_BLOCKS,
     SERIES_DAILY,
     SERIES_SMA7,
     BacktestConfig,
@@ -32,6 +33,7 @@ from backtest import (
     PolicyMetrics,
     build_config,
     build_exclusion_dates,
+    build_long_event_exclusion_dates,
     compute_actual_sma7,
     compute_metrics,
     compute_policy_metrics,
@@ -113,6 +115,8 @@ class TestBuildConfig:
             eval_policies=[POLICY_ALL_DAYS, POLICY_EXCLUDE_FLAGGED_PLUS_RECOVERY],
             recovery_days=2,
             event_periods=[],
+            long_event_threshold=5,
+            long_event_recovery_days=5,
         )
         defaults.update(kwargs)
         return argparse.Namespace(**defaults)
@@ -868,6 +872,8 @@ class TestBuildConfigEvalPolicy:
             eval_policies=[POLICY_ALL_DAYS, POLICY_EXCLUDE_FLAGGED_PLUS_RECOVERY],
             recovery_days=2,
             event_periods=[],
+            long_event_threshold=5,
+            long_event_recovery_days=5,
         )
         defaults.update(kwargs)
         return argparse.Namespace(**defaults)
@@ -890,3 +896,239 @@ class TestBuildConfigEvalPolicy:
         config = build_config(self._make_args(event_periods=[ep]))
         assert len(config.manual_event_periods) == 1
         assert config.manual_event_periods[0].start_date == date(2026, 3, 1)
+
+
+# ── build_long_event_exclusion_dates ──────────────────────────────────────────
+
+class TestBuildLongEventExclusionDates:
+    def _df_with_flags(
+        self,
+        n: int = 30,
+        cheat_indices: list[int] | None = None,
+        travel_indices: list[int] | None = None,
+        start: str = "2026-01-01",
+    ) -> pd.DataFrame:
+        """フラグ列付きの DataFrame を生成する。"""
+        dates     = pd.date_range(start, periods=n, freq="D")
+        weights   = [70.0] * n
+        is_cheat  = [False] * n
+        is_travel = [False] * n
+        for i in (cheat_indices or []):
+            is_cheat[i] = True
+        for i in (travel_indices or []):
+            is_travel[i] = True
+        return pd.DataFrame({
+            "log_date":      dates,
+            "weight":        weights,
+            "is_cheat_day":  is_cheat,
+            "is_travel_day": is_travel,
+        })
+
+    def test_no_events_returns_empty(self):
+        """イベント日がない場合は空集合を返す。"""
+        df = self._df_with_flags(10)
+        excluded = build_long_event_exclusion_dates(
+            df, long_event_threshold=5, long_event_recovery_days=5,
+            manual_event_periods=[],
+        )
+        assert excluded == set()
+
+    def test_short_block_below_threshold_not_excluded(self):
+        """threshold 未満の連続イベント区間は除外されない。"""
+        # 4連続チートデイ (threshold=5 では対象外)
+        df = self._df_with_flags(20, cheat_indices=[2, 3, 4, 5])
+        excluded = build_long_event_exclusion_dates(
+            df, long_event_threshold=5, long_event_recovery_days=5,
+            manual_event_periods=[],
+        )
+        assert excluded == set()
+
+    def test_block_at_threshold_is_excluded(self):
+        """ちょうど threshold 日の連続ブロックは除外される。"""
+        # 5連続チートデイ (threshold=5 でちょうど該当)
+        df = self._df_with_flags(20, cheat_indices=[2, 3, 4, 5, 6])
+        excluded = build_long_event_exclusion_dates(
+            df, long_event_threshold=5, long_event_recovery_days=0,
+            manual_event_periods=[],
+        )
+        # 2026-01-03〜2026-01-07 が除外対象
+        for offset in range(5):
+            assert date(2026, 1, 3) + timedelta(days=offset) in excluded
+
+    def test_block_above_threshold_with_recovery(self):
+        """threshold 以上のブロック本体 + 回復期間が除外される。"""
+        # 7連続旅行日 (index 1〜7 = 2026-01-02〜2026-01-08)
+        df = self._df_with_flags(20, travel_indices=[1, 2, 3, 4, 5, 6, 7])
+        excluded = build_long_event_exclusion_dates(
+            df, long_event_threshold=5, long_event_recovery_days=3,
+            manual_event_periods=[],
+        )
+        # ブロック本体 2026-01-02〜2026-01-08
+        for offset in range(7):
+            assert date(2026, 1, 2) + timedelta(days=offset) in excluded
+        # 回復期間 2026-01-09〜2026-01-11
+        assert date(2026, 1, 9)  in excluded
+        assert date(2026, 1, 10) in excluded
+        assert date(2026, 1, 11) in excluded
+        # 回復期間終了翌日は除外外
+        assert date(2026, 1, 12) not in excluded
+
+    def test_short_block_before_long_block_not_excluded(self):
+        """短期ブロックと長期ブロックが混在する場合、長期ブロックのみ除外される。"""
+        # 2連続チートデイ (short) + gap + 6連続旅行日 (long)
+        df = self._df_with_flags(30, cheat_indices=[1, 2], travel_indices=[8, 9, 10, 11, 12, 13])
+        excluded = build_long_event_exclusion_dates(
+            df, long_event_threshold=5, long_event_recovery_days=2,
+            manual_event_periods=[],
+        )
+        # 短期ブロック (2日) は除外されない
+        assert date(2026, 1, 2) not in excluded
+        assert date(2026, 1, 3) not in excluded
+        # 長期ブロック (6日) は除外される
+        for offset in range(6):
+            assert date(2026, 1, 9) + timedelta(days=offset) in excluded
+
+    def test_manual_event_period_contributes_to_block(self):
+        """手動 event period も連続ブロック判定に含まれる。"""
+        df = self._df_with_flags(30)  # フラグなし
+        ep = ManualEventPeriod(date(2026, 1, 10), date(2026, 1, 16))  # 7日間
+        excluded = build_long_event_exclusion_dates(
+            df, long_event_threshold=5, long_event_recovery_days=2,
+            manual_event_periods=[ep],
+        )
+        # ブロック本体 2026-01-10〜2026-01-16
+        for offset in range(7):
+            assert date(2026, 1, 10) + timedelta(days=offset) in excluded
+        # 回復 2日
+        assert date(2026, 1, 17) in excluded
+        assert date(2026, 1, 18) in excluded
+        assert date(2026, 1, 19) not in excluded
+
+    def test_flag_and_manual_period_merge_into_one_block(self):
+        """DB フラグと手動 event period が連続する場合、1ブロックとしてマージされる。"""
+        # フラグ 2026-01-03〜2026-01-05 + 手動 2026-01-06〜2026-01-10 = 連続8日
+        df = self._df_with_flags(20, cheat_indices=[2, 3, 4])  # 2026-01-03〜05
+        ep = ManualEventPeriod(date(2026, 1, 6), date(2026, 1, 10))  # 2026-01-06〜10
+        excluded = build_long_event_exclusion_dates(
+            df, long_event_threshold=5, long_event_recovery_days=0,
+            manual_event_periods=[ep],
+        )
+        # 連続8日のうち最初の日も除外される
+        assert date(2026, 1, 3) in excluded
+        assert date(2026, 1, 10) in excluded
+
+    def test_missing_flag_columns_uses_manual_only(self):
+        """フラグカラムがない場合は手動 event period のみで判定する。"""
+        df = make_df(10)  # フラグカラムなし
+        ep = ManualEventPeriod(date(2026, 1, 5), date(2026, 1, 11))  # 7日間
+        excluded = build_long_event_exclusion_dates(
+            df, long_event_threshold=5, long_event_recovery_days=1,
+            manual_event_periods=[ep],
+        )
+        # 7日ブロック + 回復1日
+        assert date(2026, 1, 5) in excluded
+        assert date(2026, 1, 11) in excluded
+        assert date(2026, 1, 12) in excluded  # 回復1日
+        assert date(2026, 1, 13) not in excluded
+
+
+# ── compute_policy_metrics: exclude_long_event_blocks ──────────────────────
+
+class TestComputePolicyMetricsLongEvent:
+    def _make_records(
+        self,
+        errors: list[float],
+        actuals: list[float],
+        targets: list[date] | None = None,
+    ) -> list[tuple]:
+        if targets is None:
+            base = date(2026, 2, 1)
+            targets = [base + timedelta(days=i) for i in range(len(errors))]
+        origin = date(2026, 1, 1)
+        return [
+            (err, act, act + err, origin, tgt)
+            for err, act, tgt in zip(errors, actuals, targets)
+        ]
+
+    def test_long_event_policy_excludes_target_in_long_event_set(self):
+        """exclude_long_event_blocks policy は long_event_exclusion_dates の target を除外する。"""
+        targets = [date(2026, 2, 1), date(2026, 2, 2), date(2026, 2, 3)]
+        records = self._make_records([0.1, -0.2, 0.3], [70.0, 70.0, 70.0], targets)
+        long_excluded = {date(2026, 2, 1)}  # 最初の1件を除外
+        result = compute_policy_metrics(
+            records, set(), [POLICY_EXCLUDE_LONG_EVENT_BLOCKS],
+            long_event_exclusion_dates=long_excluded,
+        )
+        assert len(result) == 1
+        pm = result[0]
+        assert pm.policy    == POLICY_EXCLUDE_LONG_EVENT_BLOCKS
+        assert pm.n_total   == 3
+        assert pm.n_used    == 2
+        assert pm.n_excluded == 1
+
+    def test_all_three_policies_returned_together(self):
+        """3ポリシーを同時に指定すると 3 件返ること。"""
+        records = self._make_records([0.1, -0.2], [70.0, 70.0])
+        result = compute_policy_metrics(
+            records, set(),
+            [POLICY_ALL_DAYS, POLICY_EXCLUDE_FLAGGED_PLUS_RECOVERY, POLICY_EXCLUDE_LONG_EVENT_BLOCKS],
+            long_event_exclusion_dates=set(),
+        )
+        assert len(result) == 3
+        policies = {pm.policy for pm in result}
+        assert POLICY_ALL_DAYS in policies
+        assert POLICY_EXCLUDE_FLAGGED_PLUS_RECOVERY in policies
+        assert POLICY_EXCLUDE_LONG_EVENT_BLOCKS in policies
+
+    def test_long_event_policy_none_exclusion_uses_empty_set(self):
+        """long_event_exclusion_dates=None の場合、除外なし (後方互換)。"""
+        records = self._make_records([0.1, -0.2, 0.3], [70.0, 70.0, 70.0])
+        result = compute_policy_metrics(
+            records, set(), [POLICY_EXCLUDE_LONG_EVENT_BLOCKS],
+            long_event_exclusion_dates=None,
+        )
+        pm = result[0]
+        assert pm.n_used == 3  # 除外なし
+
+    def test_long_event_excludes_only_long_blocks_not_flagged(self):
+        """exclude_long_event_blocks は DB フラグ由来の exclusion_dates とは独立している。"""
+        targets = [date(2026, 2, 1), date(2026, 2, 5), date(2026, 2, 10)]
+        records = self._make_records([5.0, 0.1, 0.1], [70.0, 70.0, 70.0], targets)
+        # DB フラグ由来: 2/1 を除外
+        flagged_excluded = {date(2026, 2, 1)}
+        # 長期イベント由来: 2/5 を除外 (2/1 は除外しない)
+        long_excluded = {date(2026, 2, 5)}
+
+        result_long = compute_policy_metrics(
+            records, flagged_excluded,
+            [POLICY_EXCLUDE_LONG_EVENT_BLOCKS],
+            long_event_exclusion_dates=long_excluded,
+        )
+        pm = result_long[0]
+        assert pm.n_used == 2  # 2/1 と 2/10 が残る (2/5 のみ除外)
+        assert pm.n_excluded == 1
+
+
+# ── BacktestConfig 長期イベントブロック設定 ────────────────────────────────────
+
+class TestBacktestConfigLongEvent:
+    def test_default_long_event_threshold(self):
+        c = BacktestConfig()
+        assert c.long_event_threshold == 5
+
+    def test_default_long_event_recovery_days(self):
+        c = BacktestConfig()
+        assert c.long_event_recovery_days == 5
+
+    def test_default_includes_long_event_policy(self):
+        """デフォルト eval_policies に exclude_long_event_blocks が含まれること。"""
+        c = BacktestConfig()
+        assert POLICY_EXCLUDE_LONG_EVENT_BLOCKS in c.eval_policies
+
+    def test_custom_long_event_threshold(self):
+        c = BacktestConfig(long_event_threshold=7)
+        assert c.long_event_threshold == 7
+
+    def test_custom_long_event_recovery_days(self):
+        c = BacktestConfig(long_event_recovery_days=3)
+        assert c.long_event_recovery_days == 3

--- a/src/app/forecast-accuracy/page.tsx
+++ b/src/app/forecast-accuracy/page.tsx
@@ -2,10 +2,11 @@ import { BacktestResults } from "@/components/charts/BacktestResults";
 import { BacktestComparison } from "@/components/charts/BacktestComparison";
 import { BacktestPolicyComparison } from "@/components/charts/BacktestPolicyComparison";
 import { BacktestExcludedDates } from "@/components/charts/BacktestExcludedDates";
+import { BacktestLongEventDetails } from "@/components/charts/BacktestLongEventDetails";
 import { ForecastAccuracyRefreshButton } from "@/components/charts/ForecastAccuracyRefreshButton";
 import { BarChart2 } from "lucide-react";
 import { fetchLatestRuns, fetchMetrics, fetchFlaggedLogsForRun } from "@/lib/queries/backtest";
-import { parseRunConfig, buildExclusionList } from "@/lib/utils/backtestExclusion";
+import { parseRunConfig, buildExclusionList, buildLongEventBlocks, buildLongEventExclusionList } from "@/lib/utils/backtestExclusion";
 import { PageShell } from "@/components/ui/PageShell";
 
 export const revalidate = 3600; // 1時間キャッシュ (バッチは週1回)
@@ -85,14 +86,34 @@ export default async function ForecastAccuracyPage() {
   const prevSma7Metrics  = prevSma7MetricsResult.kind  === "ok" ? prevSma7MetricsResult.data  : [];
 
   // dailyRun の除外日一覧を再導出 (exclude_flagged_plus_recovery policy が存在する場合のみ表示)
-  const hasExcludePolicy = dailyMetrics.some((m) => m.eval_policy === "exclude_flagged_plus_recovery");
+  const hasExcludePolicy    = dailyMetrics.some((m) => m.eval_policy === "exclude_flagged_plus_recovery");
+  const hasLongEventPolicy  = dailyMetrics.some((m) => m.eval_policy === "exclude_long_event_blocks");
+
+  const parsedRunConfig = dailyRun ? parseRunConfig(dailyRun.config) : null;
+
   const excludedDateEntries = (() => {
-    if (!hasExcludePolicy || !dailyRun) return null;
-    const { recoveryDays, manualEventPeriods } = parseRunConfig(dailyRun.config);
+    if (!hasExcludePolicy || !parsedRunConfig) return null;
+    const { recoveryDays, manualEventPeriods } = parsedRunConfig;
     return {
       entries: buildExclusionList(flaggedLogs, recoveryDays, manualEventPeriods),
       recoveryDays,
       manualEventPeriods,
+    };
+  })();
+
+  // 長期イベントブロック除外の再導出 (#480)
+  const longEventDetails = (() => {
+    if (!hasLongEventPolicy || !parsedRunConfig) return null;
+    const { longEventThreshold, longEventRecoveryDays, manualEventPeriods } = parsedRunConfig;
+    const blocks = buildLongEventBlocks(flaggedLogs, manualEventPeriods, longEventThreshold);
+    const exclusionEntries = buildLongEventExclusionList(
+      flaggedLogs, manualEventPeriods, longEventThreshold, longEventRecoveryDays,
+    );
+    return {
+      blocks,
+      longEventThreshold,
+      longEventRecoveryDays,
+      excludedCalendarDays: exclusionEntries.length,
     };
   })();
 
@@ -129,6 +150,19 @@ export default async function ForecastAccuracyPage() {
             entries={excludedDateEntries.entries}
             recoveryDays={excludedDateEntries.recoveryDays}
             manualEventPeriods={excludedDateEntries.manualEventPeriods}
+          />
+        )}
+
+        {/* ── 長期イベント区間詳細 (#480) ──
+            exclude_long_event_blocks policy が存在する run のみ表示。
+            検出ブロック一覧 + 全ポリシー詳細指標 (MAE/RMSE/Bias/n) を表示する。 */}
+        {longEventDetails && (
+          <BacktestLongEventDetails
+            metrics={dailyMetrics}
+            longEventBlocks={longEventDetails.blocks}
+            longEventThreshold={longEventDetails.longEventThreshold}
+            longEventRecoveryDays={longEventDetails.longEventRecoveryDays}
+            excludedCalendarDays={longEventDetails.excludedCalendarDays}
           />
         )}
 

--- a/src/components/charts/BacktestExcludedDates.tsx
+++ b/src/components/charts/BacktestExcludedDates.tsx
@@ -24,10 +24,13 @@ const REASON_CONFIG: Record<
   ExcludedReason,
   { label: string; badgeClass: string }
 > = {
-  cheat_day:           { label: "チートデイ",       badgeClass: "bg-orange-100 text-orange-600 dark:bg-orange-900/30 dark:text-orange-400" },
-  travel_day:          { label: "旅行日",            badgeClass: "bg-sky-100 text-sky-600 dark:bg-sky-900/30 dark:text-sky-400" },
-  manual_event_period: { label: "手動イベント期間",  badgeClass: "bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400" },
-  recovery_day:        { label: "回復日",            badgeClass: "bg-slate-100 text-slate-500 dark:bg-slate-700 dark:text-slate-400" },
+  cheat_day:            { label: "チートデイ",         badgeClass: "bg-orange-100 text-orange-600 dark:bg-orange-900/30 dark:text-orange-400" },
+  travel_day:           { label: "旅行日",              badgeClass: "bg-sky-100 text-sky-600 dark:bg-sky-900/30 dark:text-sky-400" },
+  manual_event_period:  { label: "手動イベント期間",    badgeClass: "bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400" },
+  recovery_day:         { label: "回復日",              badgeClass: "bg-slate-100 text-slate-500 dark:bg-slate-700 dark:text-slate-400" },
+  // 長期イベントブロック除外ポリシー用 (#480) — このコンポーネントでは現状表示されないが型整合のため追加
+  long_event_block:     { label: "長期イベントブロック", badgeClass: "bg-teal-100 text-teal-600 dark:bg-teal-900/30 dark:text-teal-400" },
+  long_event_recovery:  { label: "長期回復日",          badgeClass: "bg-slate-100 text-slate-400 dark:bg-slate-700 dark:text-slate-500" },
 };
 
 const SOURCE_LABELS: Record<ExcludedSource, string> = {
@@ -58,6 +61,8 @@ export function BacktestExcludedDates({
     travel_day:          0,
     manual_event_period: 0,
     recovery_day:        0,
+    long_event_block:    0,
+    long_event_recovery: 0,
   };
   for (const e of entries) {
     counts[e.reason]++;

--- a/src/components/charts/BacktestLongEventDetails.tsx
+++ b/src/components/charts/BacktestLongEventDetails.tsx
@@ -1,0 +1,336 @@
+/**
+ * BacktestLongEventDetails — 長期イベント区間除外ポリシーの詳細表示 (#480)
+ *
+ * 表示内容:
+ *   1. 検出された長期イベントブロック一覧 (日付範囲 / 日数)
+ *   2. 除外対象日数と回復期間設定の確認
+ *   3. 全ポリシー (all_days / exclude_flagged_plus_recovery / exclude_long_event_blocks) の
+ *      詳細指標 (MAE / RMSE / Bias / n) 比較テーブル
+ *
+ * 目的:
+ *   - 長期イベント区間が精度劣化要因かを定量確認する (#480)
+ *   - 改善幅とサンプル数減少の両方を確認できるようにする
+ *   - 次段階 Issue への判断材料を提供する
+ *
+ * 非表示条件:
+ *   - exclude_long_event_blocks policy が metrics に存在しない場合は null を返す
+ */
+
+import { TrendingDown } from "lucide-react";
+import type { ForecastBacktestMetric } from "@/lib/supabase/types";
+import type { LongEventBlock } from "@/lib/utils/backtestExclusion";
+
+// ── 定数 ──────────────────────────────────────────────────────────────────────
+
+const HORIZONS = [7, 14, 30] as const;
+
+const POLICY_ALL        = "all_days";
+const POLICY_EXCLUDE    = "exclude_flagged_plus_recovery";
+const POLICY_LONG_EVENT = "exclude_long_event_blocks";
+
+const POLICY_SHORT_LABELS: Record<string, string> = {
+  [POLICY_ALL]:        "全日",
+  [POLICY_EXCLUDE]:    "通常日",
+  [POLICY_LONG_EVENT]: "長期除外後",
+};
+
+const MODEL_ORDER = ["NeuralProphet", "MovingAverage7d", "LinearTrend30d", "EWLinearTrend", "Naive"];
+const MODEL_LABELS: Record<string, string> = {
+  NeuralProphet:   "NeuralProphet",
+  MovingAverage7d: "MA 7d",
+  LinearTrend30d:  "Linear 30d",
+  EWLinearTrend:   "EW Linear",
+  Naive:           "Naive",
+};
+
+// ── 型 ────────────────────────────────────────────────────────────────────────
+
+interface Props {
+  metrics: ForecastBacktestMetric[];
+  longEventBlocks: LongEventBlock[];
+  longEventThreshold: number;
+  longEventRecoveryDays: number;
+  /** 長期イベント除外ポリシーの除外対象日数 (カレンダー日数) */
+  excludedCalendarDays: number;
+}
+
+// ── ヘルパー ──────────────────────────────────────────────────────────────────
+
+function fmt3(v: number | null | undefined): string {
+  if (v == null) return "—";
+  return v.toFixed(3);
+}
+
+function fmtBias(v: number | null | undefined): string {
+  if (v == null) return "—";
+  const sign = v > 0 ? "+" : "";
+  return `${sign}${v.toFixed(3)}`;
+}
+
+function findMetric(
+  metrics: ForecastBacktestMetric[],
+  model: string,
+  horizon: number,
+  policy: string,
+): ForecastBacktestMetric | undefined {
+  return metrics.find(
+    (m) => m.model_name === model && m.horizon_days === horizon && m.eval_policy === policy,
+  );
+}
+
+// ── コンポーネント ────────────────────────────────────────────────────────────
+
+export function BacktestLongEventDetails({
+  metrics,
+  longEventBlocks,
+  longEventThreshold,
+  longEventRecoveryDays,
+  excludedCalendarDays,
+}: Props) {
+  const hasLongEventPolicy = metrics.some((m) => m.eval_policy === POLICY_LONG_EVENT);
+  if (!hasLongEventPolicy) return null;
+
+  // 表示するポリシー (存在するものだけ)
+  const visiblePolicies = [POLICY_ALL, POLICY_EXCLUDE, POLICY_LONG_EVENT].filter(
+    (p) => metrics.some((m) => m.eval_policy === p),
+  );
+
+  return (
+    <details className="group overflow-hidden rounded-2xl border border-slate-100 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900 dark:shadow-none">
+      {/* ── サマリー行（クリックで展開） ── */}
+      <summary className="flex cursor-pointer list-none items-center justify-between gap-3 border-b border-slate-100 bg-slate-50 px-5 py-3 dark:border-slate-700 dark:bg-slate-800 [&::-webkit-details-marker]:hidden">
+        <div className="flex items-center gap-2">
+          <TrendingDown size={15} className="flex-shrink-0 text-teal-500" />
+          <span className="text-sm font-bold text-slate-700 dark:text-slate-200">
+            長期イベント区間詳細
+          </span>
+          {longEventBlocks.length > 0 ? (
+            <span className="rounded-full bg-teal-100 dark:bg-teal-900/30 px-2 py-0.5 text-[11px] font-semibold text-teal-600 dark:text-teal-400">
+              {longEventBlocks.length} ブロック検出
+            </span>
+          ) : (
+            <span className="rounded-full bg-emerald-100 dark:bg-emerald-900/30 px-2 py-0.5 text-[11px] font-semibold text-emerald-600 dark:text-emerald-400">
+              長期ブロックなし
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-3">
+          <span className="hidden text-[11px] text-slate-400 dark:text-slate-500 sm:inline">
+            閾値 {longEventThreshold} 日 / 回復 {longEventRecoveryDays} 日 / 除外 {excludedCalendarDays} 日
+          </span>
+          <span className="text-xs text-slate-400 dark:text-slate-500 group-open:hidden">▼ 展開</span>
+          <span className="hidden text-xs text-slate-400 dark:text-slate-500 group-open:inline">▲ 閉じる</span>
+        </div>
+      </summary>
+
+      {/* ── 展開コンテンツ ── */}
+      <div className="divide-y divide-slate-50 dark:divide-slate-700/60">
+
+        {/* 検出ブロック一覧 */}
+        <div className="px-5 py-3">
+          <p className="mb-2 text-xs font-semibold text-slate-600 dark:text-slate-300">
+            検出された長期イベントブロック
+            <span className="ml-2 text-[11px] font-normal text-slate-400 dark:text-slate-500">
+              （連続 {longEventThreshold} 日以上のイベント区間）
+            </span>
+          </p>
+          {longEventBlocks.length === 0 ? (
+            <p className="text-sm text-slate-400 dark:text-slate-500">
+              長期イベントブロックは検出されませんでした。
+              DB フラグ (cheat_day / travel_day) の連続期間が {longEventThreshold} 日未満のため、
+              exclude_long_event_blocks ポリシーは全日と同じ結果になります。
+            </p>
+          ) : (
+            <div className="flex flex-wrap gap-2">
+              {longEventBlocks.map((block) => (
+                <div
+                  key={block.start}
+                  className="rounded-lg border border-teal-100 bg-teal-50 px-3 py-1.5 text-xs dark:border-teal-800/50 dark:bg-teal-900/20"
+                >
+                  <span className="font-mono text-slate-700 dark:text-slate-300">
+                    {block.start} 〜 {block.end}
+                  </span>
+                  <span className="ml-2 text-teal-600 dark:text-teal-400 font-medium">
+                    {block.days} 日間
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+          {longEventBlocks.length > 0 && (
+            <p className="mt-2 text-[11px] text-slate-400 dark:text-slate-500">
+              除外対象: ブロック本体 + ブロック終了後 {longEventRecoveryDays} 日の回復期間。
+              合計 {excludedCalendarDays} カレンダー日 が除外対象になります。
+            </p>
+          )}
+        </div>
+
+        {/* 詳細指標比較テーブル */}
+        <div>
+          <div className="px-5 py-2.5 bg-slate-50/60 dark:bg-slate-800/60">
+            <p className="text-xs font-semibold text-slate-600 dark:text-slate-300">
+              詳細指標比較（MAE / RMSE / Bias / n）
+            </p>
+            <p className="mt-0.5 text-[11px] text-slate-400 dark:text-slate-500">
+              各ポリシーの精度指標を全 horizon × 全モデルで確認できます。
+              Bias が正 = 予測が実測より高い傾向（上振れ）、負 = 低い傾向（下振れ）。
+            </p>
+          </div>
+
+          {/* モバイル: horizon × policy カード */}
+          <div className="md:hidden space-y-4 p-4">
+            {HORIZONS.map((h) => (
+              <div key={h}>
+                <p className="mb-2 text-xs font-bold text-slate-600 dark:text-slate-300">D+{h} 日先</p>
+                <div className="space-y-2">
+                  {MODEL_ORDER.map((model) => {
+                    const cells = visiblePolicies.map((p) => findMetric(metrics, model, h, p));
+                    if (cells.every((c) => c === undefined)) return null;
+                    return (
+                      <div key={model} className="rounded-lg border border-slate-100 dark:border-slate-700 p-3">
+                        <p className="mb-1.5 text-xs font-semibold text-slate-600 dark:text-slate-300">
+                          {MODEL_LABELS[model] ?? model}
+                        </p>
+                        <div className="grid grid-cols-3 gap-x-4 gap-y-1 text-[11px]">
+                          {visiblePolicies.map((p) => {
+                            const m = findMetric(metrics, model, h, p);
+                            const colorClass =
+                              p === POLICY_LONG_EVENT ? "text-teal-600 dark:text-teal-400"
+                              : p === POLICY_EXCLUDE  ? "text-violet-600"
+                              : "text-slate-500 dark:text-slate-400";
+                            return (
+                              <div key={p}>
+                                <p className={`font-medium ${colorClass}`}>{POLICY_SHORT_LABELS[p]}</p>
+                                <p className="font-mono text-slate-700 dark:text-slate-300">
+                                  MAE {fmt3(m?.mae)}
+                                </p>
+                                <p className="text-slate-400 dark:text-slate-500">
+                                  RMSE {fmt3(m?.rmse)}
+                                </p>
+                                <p className="text-slate-400 dark:text-slate-500">
+                                  Bias {fmtBias(m?.bias)}
+                                </p>
+                                <p className="text-slate-400 dark:text-slate-500">
+                                  n={m != null ? m.n_predictions : "—"}
+                                </p>
+                              </div>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* デスクトップ: テーブル */}
+          <div className="hidden overflow-x-auto md:block">
+            <table className="w-full min-w-[700px] text-xs">
+              <thead>
+                <tr className="border-b border-slate-100 bg-slate-50 text-[11px] font-semibold uppercase tracking-wide text-slate-400 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-500">
+                  <th className="px-4 py-2 text-left">モデル</th>
+                  {HORIZONS.map((h) => (
+                    <th
+                      key={h}
+                      colSpan={visiblePolicies.length * 4}
+                      className="border-l border-slate-100 px-3 py-2 text-center dark:border-slate-700"
+                    >
+                      D+{h}日先
+                    </th>
+                  ))}
+                </tr>
+                <tr className="border-b border-slate-100 bg-slate-50/60 text-[10px] font-medium text-slate-400 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-500">
+                  <th className="px-4 py-1.5 text-left"></th>
+                  {HORIZONS.map((h) => (
+                    visiblePolicies.map((p) => {
+                      const colorClass =
+                        p === POLICY_LONG_EVENT ? "text-teal-600 dark:text-teal-400"
+                        : p === POLICY_EXCLUDE  ? "text-violet-500"
+                        : "text-slate-500";
+                      return (
+                        <th
+                          key={`${h}-${p}`}
+                          colSpan={4}
+                          className={`border-l border-slate-100 px-2 py-1.5 text-center dark:border-slate-700 ${colorClass}`}
+                        >
+                          {POLICY_SHORT_LABELS[p]}
+                        </th>
+                      );
+                    })
+                  ))}
+                </tr>
+                <tr className="border-b border-slate-200 text-[10px] font-medium text-slate-400 dark:border-slate-700 dark:text-slate-500">
+                  <th className="px-4 py-1"></th>
+                  {HORIZONS.map((h) => (
+                    visiblePolicies.map((p) => (
+                      <>
+                        <th key={`${h}-${p}-mae`}  className="border-l border-slate-100 px-2 py-1 text-center dark:border-slate-700">MAE</th>
+                        <th key={`${h}-${p}-rmse`} className="px-2 py-1 text-center">RMSE</th>
+                        <th key={`${h}-${p}-bias`} className="px-2 py-1 text-center">Bias</th>
+                        <th key={`${h}-${p}-n`}    className="px-2 py-1 text-center">n</th>
+                      </>
+                    ))
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-50 dark:divide-slate-700/60">
+                {MODEL_ORDER.map((model) => {
+                  // モデルのデータが全 horizon × policy で存在しない場合はスキップ
+                  const hasData = HORIZONS.some((h) =>
+                    visiblePolicies.some((p) => findMetric(metrics, model, h, p) !== undefined)
+                  );
+                  if (!hasData) return null;
+
+                  return (
+                    <tr key={model} className="transition-colors hover:bg-slate-50/70 dark:hover:bg-slate-800">
+                      <td className="px-4 py-2 font-medium text-slate-700 dark:text-slate-200">
+                        {MODEL_LABELS[model] ?? model}
+                      </td>
+                      {HORIZONS.map((h) => (
+                        visiblePolicies.map((p) => {
+                          const m = findMetric(metrics, model, h, p);
+                          const colorClass =
+                            p === POLICY_LONG_EVENT ? "text-teal-700 dark:text-teal-400"
+                            : p === POLICY_EXCLUDE  ? "text-violet-700 dark:text-violet-400"
+                            : "text-slate-600 dark:text-slate-300";
+                          return (
+                            <>
+                              <td key={`${h}-${p}-mae`}  className={`border-l border-slate-100 px-2 py-2 text-center font-mono tabular-nums dark:border-slate-700 ${colorClass}`}>
+                                {m?.n_predictions === 0 ? (
+                                  <span className="text-[10px] text-slate-400">全除外</span>
+                                ) : fmt3(m?.mae)}
+                              </td>
+                              <td key={`${h}-${p}-rmse`} className={`px-2 py-2 text-center font-mono tabular-nums ${colorClass}`}>
+                                {m?.n_predictions === 0 ? "—" : fmt3(m?.rmse)}
+                              </td>
+                              <td key={`${h}-${p}-bias`} className={`px-2 py-2 text-center font-mono tabular-nums ${colorClass}`}>
+                                {m?.n_predictions === 0 ? "—" : fmtBias(m?.bias)}
+                              </td>
+                              <td key={`${h}-${p}-n`}    className="px-2 py-2 text-center text-[10px] tabular-nums text-slate-400 dark:text-slate-500">
+                                {m != null ? m.n_predictions : "—"}
+                              </td>
+                            </>
+                          );
+                        })
+                      ))}
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        {/* 補足注記 */}
+        <div className="bg-slate-50/60 dark:bg-slate-800/60 px-5 py-2.5 text-[11px] text-slate-400 dark:text-slate-500">
+          閾値 {longEventThreshold} 日 / 回復 {longEventRecoveryDays} 日 はいずれも仮説値（#480 初期設定）。
+          改善幅が小さい・サンプル数が大きく減る場合は、閾値変更や長期区間除外そのものの採否を再検討すること。
+          この評価は NeuralProphet の学習系列変更を含まない（評価フェーズのみ）。
+          学習系列変更は別 Issue で判断する。
+        </div>
+      </div>
+    </details>
+  );
+}

--- a/src/components/charts/BacktestPolicyComparison.tsx
+++ b/src/components/charts/BacktestPolicyComparison.tsx
@@ -1,24 +1,26 @@
 "use client";
 
 /**
- * BacktestPolicyComparison — 評価条件別比較: 全日 vs イベント除外
+ * BacktestPolicyComparison — 評価条件別比較: 全日 / イベント除外 / 長期イベント除外
  *
- * 同一 run の "all_days" / "exclude_flagged_plus_recovery" の 2 policy を
- * モデル × ホライズン で並べて表示する。
+ * 同一 run の複数 eval_policy を モデル × ホライズン で並べて表示する。
  *
- * #363 で実装された evaluation policy 基盤を前提とし、
- * #364 の要求「通常日の予測精度とイベント込み精度を同一画面で比較できる」を満たす。
+ * 表示ポリシー:
+ *   1. all_days                    — 全日 (比較ベースライン)
+ *   2. exclude_flagged_plus_recovery — 通常日 (チートデイ・旅行日+回復期間を除外)
+ *   3. exclude_long_event_blocks   — 長期除外後 (連続5日以上のイベント区間を除外) [#480]
  *
  * 表示設計の判断理由:
- *   - 件数列 (除外数) を必須とし、精度指標だけを強調しすぎない
+ *   - n_predictions (評価使用サンプル数) を必須とし、精度指標だけを強調しすぎない
  *     (除外件数が少ない場合は改善幅を過大評価しやすいため)
  *   - n_predictions=0 / mae=NULL は「全件除外」バッジとして明示
- *     (#363 でこの行も保存するよう修正済みのため、行欠損との区別が可能)
- *   - eval_policy の表示名はこのファイルで管理する (UI 固有文言)
+ *   - policy 行が 1 件もない場合はそのポリシー列を「—」表示
  *
  * 非表示条件:
  *   - "exclude_flagged_plus_recovery" 行が 1 件もない場合は null を返す
  *     (旧 run または --eval-policies all_days のみ実行時)
+ *
+ * 詳細指標 (MAE/RMSE/Bias × 3ポリシー全比較) は BacktestLongEventDetails に分離。
  */
 
 import { Fragment } from "react";
@@ -30,13 +32,15 @@ import type { ForecastBacktestMetric } from "@/lib/supabase/types";
 const HORIZONS = [7, 14, 30] as const;
 type Horizon = (typeof HORIZONS)[number];
 
-const POLICY_ALL     = "all_days";
-const POLICY_EXCLUDE = "exclude_flagged_plus_recovery";
+const POLICY_ALL          = "all_days";
+const POLICY_EXCLUDE      = "exclude_flagged_plus_recovery";
+const POLICY_LONG_EVENT   = "exclude_long_event_blocks";
 
 /** UI 表示名 */
 const POLICY_LABELS: Record<string, string> = {
-  [POLICY_ALL]:     "全日",
-  [POLICY_EXCLUDE]: "通常日（イベント除外）",
+  [POLICY_ALL]:        "全日",
+  [POLICY_EXCLUDE]:    "通常日（イベント除外）",
+  [POLICY_LONG_EVENT]: "長期除外後",
 };
 
 const MODEL_ORDER = ["NeuralProphet", "MovingAverage7d", "LinearTrend30d", "EWLinearTrend", "Naive"];
@@ -90,7 +94,6 @@ function bestModelForPolicy(
 /**
  * policy × horizon の組み合わせごとに最良 MAE 値を返す。
  * キー: "${policy}:${horizon_days}"
- * null MAE（全件除外行）は比較対象外。同率最良は複数セルにマーキングされる。
  */
 function bestMaePerColumn(
   metrics: ForecastBacktestMetric[],
@@ -117,16 +120,22 @@ function isBestMae(
 // ── コンポーネント ────────────────────────────────────────────────────────────
 
 export function BacktestPolicyComparison({ metrics }: Props) {
-  const hasExcludePolicy = metrics.some((m) => m.eval_policy === POLICY_EXCLUDE);
+  const hasExcludePolicy    = metrics.some((m) => m.eval_policy === POLICY_EXCLUDE);
+  const hasLongEventPolicy  = metrics.some((m) => m.eval_policy === POLICY_LONG_EVENT);
+
   if (!hasExcludePolicy) return null;
 
   // デスクトップテーブル用: 各 policy × horizon 列の最良 MAE
   const bestMaes = bestMaePerColumn(metrics);
 
-  // 除外概要: すべての exclude 行のうち n_total > 0 の代表値として h=7, NeuralProphet を優先
+  // 除外概要: h=7, NeuralProphet を代表値として使用
   const summaryRow =
     findMetric(metrics, "NeuralProphet", 7, POLICY_EXCLUDE) ??
     metrics.find((m) => m.eval_policy === POLICY_EXCLUDE && m.n_total > 0);
+
+  const longEventSummary =
+    findMetric(metrics, "NeuralProphet", 7, POLICY_LONG_EVENT) ??
+    metrics.find((m) => m.eval_policy === POLICY_LONG_EVENT && m.n_total > 0);
 
   return (
     <div className="overflow-hidden rounded-2xl border border-slate-100 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900 dark:shadow-none">
@@ -136,10 +145,10 @@ export function BacktestPolicyComparison({ metrics }: Props) {
           <div className="flex items-center gap-2">
             <ShieldCheck size={15} className="text-violet-500" />
             <span className="text-sm font-bold text-slate-700 dark:text-slate-200">
-              評価条件別比較: 全日 vs イベント除外
+              評価条件別比較
             </span>
           </div>
-          <div className="flex gap-3 text-xs">
+          <div className="flex flex-wrap gap-3 text-xs">
             <span className="flex items-center gap-1.5">
               <span className="inline-block h-2.5 w-2.5 rounded-full bg-slate-400" />
               {POLICY_LABELS[POLICY_ALL]}
@@ -148,22 +157,33 @@ export function BacktestPolicyComparison({ metrics }: Props) {
               <span className="inline-block h-2.5 w-2.5 rounded-full bg-violet-500" />
               {POLICY_LABELS[POLICY_EXCLUDE]}
             </span>
+            {hasLongEventPolicy && (
+              <span className="flex items-center gap-1.5">
+                <span className="inline-block h-2.5 w-2.5 rounded-full bg-teal-500" />
+                {POLICY_LABELS[POLICY_LONG_EVENT]}
+              </span>
+            )}
           </div>
         </div>
         <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
           <span className="font-medium text-slate-600 dark:text-slate-300">全日</span>はイベント日を含む全サンプルで評価、
-          <span className="font-medium text-violet-600">通常日</span>はチートデイ・旅行日と回復期間（2日）を除外したサンプルで評価します。
+          <span className="font-medium text-violet-600">通常日</span>はチートデイ・旅行日と回復期間（2日）を除外して評価。
+          {hasLongEventPolicy && (
+            <>
+              {" "}<span className="font-medium text-teal-600 dark:text-teal-400">長期除外後</span>は連続5日以上のイベント区間と回復期間（5日）のみを除外して評価。
+            </>
+          )}
           <strong className="text-slate-600 dark:text-slate-300">
             {" "}除外サンプルが少ない場合は精度差を過大評価しないでください。
           </strong>
         </p>
         {summaryRow && summaryRow.n_total > 0 && (
           <p className="mt-1 text-[11px] text-slate-400 dark:text-slate-500">
-            除外状況（h=7, NP 代表）: 評価サンプル計 {summaryRow.n_total} 件中{" "}
-            {summaryRow.n_excluded} 件除外 → 評価使用 {summaryRow.n_predictions} 件
-            {summaryRow.n_excluded === 0 && (
-              <span className="ml-1 text-slate-400">
-                ※ 手動イベント期間未設定。自動タグ (cheat/travel) のみが除外対象です。
+            通常日除外（h=7, NP 代表）: {summaryRow.n_total} 件中{" "}
+            {summaryRow.n_excluded} 件除外 → {summaryRow.n_predictions} 件使用
+            {longEventSummary && longEventSummary.n_total > 0 && (
+              <span className="ml-3">
+                / 長期除外（h=7, NP 代表）: {longEventSummary.n_excluded} 件除外 → {longEventSummary.n_predictions} 件使用
               </span>
             )}
           </p>
@@ -173,17 +193,15 @@ export function BacktestPolicyComparison({ metrics }: Props) {
       {/* ── モバイル: horizon 別カード (md 未満) ── */}
       <div className="md:hidden space-y-3 p-4">
         {HORIZONS.map((h) => {
-          const allBest = bestModelForPolicy(metrics, POLICY_ALL, h);
-          const exBest  = bestModelForPolicy(metrics, POLICY_EXCLUDE, h);
-          // 最良モデルの exclude 行 (n_excluded を取るため)
-          const exBestRow = exBest
-            ? findMetric(metrics, exBest.model, h, POLICY_EXCLUDE)
-            : undefined;
-          const allExcluded = exBestRow
-            ? exBestRow.n_predictions === 0
-            : metrics.some(
-                (m) => m.horizon_days === h && m.eval_policy === POLICY_EXCLUDE && m.n_predictions === 0,
-              );
+          const allBest       = bestModelForPolicy(metrics, POLICY_ALL, h);
+          const exBest        = bestModelForPolicy(metrics, POLICY_EXCLUDE, h);
+          const longEventBest = hasLongEventPolicy ? bestModelForPolicy(metrics, POLICY_LONG_EVENT, h) : null;
+          const exBestRow     = exBest ? findMetric(metrics, exBest.model, h, POLICY_EXCLUDE) : undefined;
+          const leBestRow     = longEventBest ? findMetric(metrics, longEventBest.model, h, POLICY_LONG_EVENT) : undefined;
+          const exAllExcluded = exBestRow ? exBestRow.n_predictions === 0
+            : metrics.some((m) => m.horizon_days === h && m.eval_policy === POLICY_EXCLUDE && m.n_predictions === 0);
+          const leAllExcluded = leBestRow ? leBestRow.n_predictions === 0
+            : metrics.some((m) => m.horizon_days === h && m.eval_policy === POLICY_LONG_EVENT && m.n_predictions === 0);
 
           return (
             <div key={h} className="rounded-xl border border-slate-100 bg-slate-50 px-4 py-3 dark:border-slate-700 dark:bg-slate-800">
@@ -202,42 +220,63 @@ export function BacktestPolicyComparison({ metrics }: Props) {
                 {/* 通常日（イベント除外） */}
                 <div>
                   <p className="mb-0.5 font-medium text-violet-600">通常日 ★</p>
-                  {allExcluded ? (
-                    <p className="text-slate-400 dark:text-slate-500">全件除外（除外条件により評価対象なし）</p>
+                  {exAllExcluded ? (
+                    <p className="text-slate-400 dark:text-slate-500">全件除外</p>
                   ) : exBest ? (
                     <>
                       <p className="font-semibold text-slate-700 dark:text-slate-200">
                         {MODEL_LABELS[exBest.model] ?? exBest.model}
                       </p>
                       <p className="font-mono text-slate-500 dark:text-slate-400">MAE {fmt3(exBest.mae)}</p>
-                      {exBestRow && exBestRow.n_excluded > 0 && (
-                        <p className="text-slate-400 dark:text-slate-500">除外 {exBestRow.n_excluded} 件</p>
+                      {exBestRow && (
+                        <p className="text-slate-400 dark:text-slate-500">n={exBestRow.n_predictions}</p>
                       )}
                     </>
                   ) : (
                     <p className="text-slate-400 dark:text-slate-500">データなし</p>
                   )}
                 </div>
+                {/* 長期除外後 */}
+                {hasLongEventPolicy && (
+                  <div>
+                    <p className="mb-0.5 font-medium text-teal-600 dark:text-teal-400">長期除外後 ★</p>
+                    {leAllExcluded ? (
+                      <p className="text-slate-400 dark:text-slate-500">全件除外</p>
+                    ) : longEventBest ? (
+                      <>
+                        <p className="font-semibold text-slate-700 dark:text-slate-200">
+                          {MODEL_LABELS[longEventBest.model] ?? longEventBest.model}
+                        </p>
+                        <p className="font-mono text-slate-500 dark:text-slate-400">MAE {fmt3(longEventBest.mae)}</p>
+                        {leBestRow && (
+                          <p className="text-slate-400 dark:text-slate-500">n={leBestRow.n_predictions}</p>
+                        )}
+                      </>
+                    ) : (
+                      <p className="text-slate-400 dark:text-slate-500">データなし</p>
+                    )}
+                  </div>
+                )}
               </div>
             </div>
           );
         })}
         <p className="text-[10px] text-slate-400 dark:text-slate-500">
-          ★ = ホライズン別最良モデル / 件数はホライズンごとの評価サンプル数（予測点数）。実日数ではない。
+          ★ = ホライズン別最良モデル / n = 評価使用サンプル数（予測点数）。実日数ではない。
           全件除外 = 除外条件により評価対象サンプルがゼロになった状態（データ欠損ではない）。
         </p>
       </div>
 
       {/* ── デスクトップ: 比較テーブル (md+) ── */}
       <div className="hidden overflow-x-auto md:block">
-        <table className="w-full min-w-[640px] text-sm">
+        <table className="w-full text-sm" style={{ minWidth: hasLongEventPolicy ? "760px" : "640px" }}>
           <thead>
             <tr className="border-b border-slate-100 bg-slate-50 text-xs font-semibold uppercase tracking-wide text-slate-400 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-500">
               <th className="px-4 py-2.5 text-left">モデル</th>
               {HORIZONS.map((h) => (
                 <th
                   key={h}
-                  colSpan={3}
+                  colSpan={hasLongEventPolicy ? 3 : 3}
                   className="border-l border-slate-100 px-3 py-2.5 text-center dark:border-slate-700"
                 >
                   D+{h}日先
@@ -245,14 +284,16 @@ export function BacktestPolicyComparison({ metrics }: Props) {
               ))}
             </tr>
             <tr className="border-b border-slate-200 text-[11px] font-medium text-slate-400 dark:border-slate-700 dark:text-slate-500">
-              <th className="px-4 py-1.5 text-left">MAE (kg)</th>
+              <th className="px-4 py-1.5 text-left">MAE (kg) / n</th>
               {HORIZONS.map((h) => (
                 <Fragment key={h}>
                   <th className="border-l border-slate-100 px-3 py-1.5 text-center text-slate-500 dark:border-slate-700">
                     全日
                   </th>
                   <th className="px-3 py-1.5 text-center text-violet-500">通常日</th>
-                  <th className="px-2 py-1.5 text-center text-slate-400 dark:text-slate-500">除外†</th>
+                  {hasLongEventPolicy && (
+                    <th className="px-3 py-1.5 text-center text-teal-600 dark:text-teal-400">長期除外後</th>
+                  )}
                 </Fragment>
               ))}
             </tr>
@@ -264,27 +305,37 @@ export function BacktestPolicyComparison({ metrics }: Props) {
                 <tr key={model} className="transition-colors hover:bg-slate-50/70 dark:hover:bg-slate-800">
                   <td className="px-4 py-2.5 font-medium text-slate-700 dark:text-slate-200">{label}</td>
                   {HORIZONS.map((h) => {
-                    const allM = findMetric(metrics, model, h, POLICY_ALL);
-                    const exM  = findMetric(metrics, model, h, POLICY_EXCLUDE);
-                    const allExcluded = exM ? exM.n_predictions === 0 : false;
+                    const allM   = findMetric(metrics, model, h, POLICY_ALL);
+                    const exM    = findMetric(metrics, model, h, POLICY_EXCLUDE);
+                    const leM    = hasLongEventPolicy ? findMetric(metrics, model, h, POLICY_LONG_EVENT) : undefined;
+                    const exAllExcluded = exM ? exM.n_predictions === 0 : false;
+                    const leAllExcluded = leM ? leM.n_predictions === 0 : false;
                     const isAllBest = isBestMae(allM?.mae, bestMaes.get(`${POLICY_ALL}:${h}`));
                     const isExBest  = isBestMae(exM?.mae,  bestMaes.get(`${POLICY_EXCLUDE}:${h}`));
+                    const isLeBest  = isBestMae(leM?.mae,  bestMaes.get(`${POLICY_LONG_EVENT}:${h}`));
                     return (
                       <Fragment key={`${model}-${h}`}>
-                        {/* 全日 MAE */}
+                        {/* 全日 MAE / n */}
                         <td
-                          className={`border-l border-slate-100 px-3 py-2.5 text-center font-mono tabular-nums dark:border-slate-700 ${
+                          className={`border-l border-slate-100 px-3 py-2 text-center font-mono tabular-nums dark:border-slate-700 ${
                             isAllBest ? "font-bold text-blue-700 dark:text-blue-400" : "text-slate-600 dark:text-slate-300"
                           }`}
                         >
-                          {fmt3(allM?.mae)}
-                          {isAllBest && (
-                            <span className="ml-1 text-xs text-blue-400" aria-label="最良">★</span>
+                          <div>
+                            {fmt3(allM?.mae)}
+                            {isAllBest && (
+                              <span className="ml-1 text-xs text-blue-400" aria-label="最良">★</span>
+                            )}
+                          </div>
+                          {allM != null && (
+                            <div className="text-[10px] text-slate-400 dark:text-slate-500">
+                              n={allM.n_predictions}
+                            </div>
                           )}
                         </td>
-                        {/* 通常日 MAE / 全件除外バッジ */}
-                        <td className="px-3 py-2.5 text-center font-mono tabular-nums">
-                          {allExcluded ? (
+                        {/* 通常日 MAE / n */}
+                        <td className="px-3 py-2 text-center font-mono tabular-nums">
+                          {exAllExcluded ? (
                             <span
                               className="rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-medium text-slate-400 dark:bg-slate-700 dark:text-slate-400"
                               title="除外条件により評価対象サンプルがゼロになった状態。データ欠損ではありません。"
@@ -293,19 +344,47 @@ export function BacktestPolicyComparison({ metrics }: Props) {
                             </span>
                           ) : (
                             <>
-                              <span className={isExBest ? "font-bold text-violet-700" : "text-violet-600"}>
+                              <div className={isExBest ? "font-bold text-violet-700 dark:text-violet-400" : "text-violet-600"}>
                                 {fmt3(exM?.mae)}
-                              </span>
-                              {isExBest && (
-                                <span className="ml-1 text-xs text-violet-400" aria-label="最良">★</span>
+                                {isExBest && (
+                                  <span className="ml-1 text-xs text-violet-400" aria-label="最良">★</span>
+                                )}
+                              </div>
+                              {exM != null && (
+                                <div className="text-[10px] text-slate-400 dark:text-slate-500">
+                                  n={exM.n_predictions}
+                                </div>
                               )}
                             </>
                           )}
                         </td>
-                        {/* 除外数 */}
-                        <td className="px-2 py-2.5 text-center text-[11px] tabular-nums text-slate-400 dark:text-slate-500">
-                          {exM != null ? exM.n_excluded : "—"}
-                        </td>
+                        {/* 長期除外後 MAE / n */}
+                        {hasLongEventPolicy && (
+                          <td className="px-3 py-2 text-center font-mono tabular-nums">
+                            {leAllExcluded ? (
+                              <span
+                                className="rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-medium text-slate-400 dark:bg-slate-700 dark:text-slate-400"
+                                title="除外条件により評価対象サンプルがゼロになった状態。データ欠損ではありません。"
+                              >
+                                全件除外
+                              </span>
+                            ) : (
+                              <>
+                                <div className={isLeBest ? "font-bold text-teal-700 dark:text-teal-400" : "text-teal-600 dark:text-teal-500"}>
+                                  {fmt3(leM?.mae)}
+                                  {isLeBest && (
+                                    <span className="ml-1 text-xs text-teal-400" aria-label="最良">★</span>
+                                  )}
+                                </div>
+                                {leM != null && (
+                                  <div className="text-[10px] text-slate-400 dark:text-slate-500">
+                                    n={leM.n_predictions}
+                                  </div>
+                                )}
+                              </>
+                            )}
+                          </td>
+                        )}
                       </Fragment>
                     );
                   })}
@@ -319,9 +398,12 @@ export function BacktestPolicyComparison({ metrics }: Props) {
       {/* ── フッター注記 ── */}
       <div className="border-t border-slate-50 bg-slate-50 px-5 py-2.5 text-[11px] text-slate-400 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-500">
         ★ = 各 horizon 列の最良 MAE（同率の場合は複数）。
-        全日 = イベントを含む全評価サンプルで評価 / 通常日 = cheat_day · travel_day と回復 2 日を除外して評価。
+        全日 = イベントを含む全評価サンプル /
+        通常日 = cheat_day · travel_day と回復 2 日を除外 /
+        {hasLongEventPolicy && " 長期除外後 = 連続5日以上のイベント区間と回復 5 日を除外 / "}
         全件除外 = 除外条件により評価対象サンプルがゼロになった状態（データ欠損ではない）。
-        † 除外数は実日数ではなくホライズンごとの評価サンプル数（予測点数）。除外数が少ないほど精度差は参考程度。
+        n = 評価使用サンプル数（予測点数）。実日数ではない。
+        {hasLongEventPolicy && " 詳細指標 (RMSE/Bias) は「長期イベント区間詳細」を参照。"}
       </div>
     </div>
   );

--- a/src/lib/utils/backtestExclusion.test.ts
+++ b/src/lib/utils/backtestExclusion.test.ts
@@ -6,7 +6,11 @@
 
 import {
   buildExclusionList,
+  buildLongEventBlocks,
+  buildLongEventExclusionList,
   parseRunConfig,
+  LONG_EVENT_THRESHOLD,
+  LONG_EVENT_RECOVERY_DAYS,
   type ExcludedDateEntry,
 } from "./backtestExclusion";
 import type { Json } from "@/lib/supabase/types";
@@ -251,5 +255,207 @@ describe("buildExclusionList", () => {
     const result = buildExclusionList(logs, 2, []);
     const jan20 = result.filter((e) => e.date === "2026-01-20");
     expect(jan20).toHaveLength(1);
+  });
+});
+
+// ── buildLongEventBlocks ────────────────────────────────────────────────────
+
+describe("buildLongEventBlocks", () => {
+  it("定数のデフォルト値が期待値と一致する", () => {
+    expect(LONG_EVENT_THRESHOLD).toBe(5);
+    expect(LONG_EVENT_RECOVERY_DAYS).toBe(5);
+  });
+
+  it("イベント日がない場合は空配列を返す", () => {
+    const logs = [
+      { log_date: "2026-01-01", is_cheat_day: false, is_travel_day: false },
+    ];
+    expect(buildLongEventBlocks(logs, [], 5)).toEqual([]);
+  });
+
+  it("threshold 未満の連続ブロックは検出されない", () => {
+    // 4連続チートデイ (threshold=5 では対象外)
+    const logs = [
+      { log_date: "2026-01-02", is_cheat_day: true,  is_travel_day: false },
+      { log_date: "2026-01-03", is_cheat_day: true,  is_travel_day: false },
+      { log_date: "2026-01-04", is_cheat_day: true,  is_travel_day: false },
+      { log_date: "2026-01-05", is_cheat_day: true,  is_travel_day: false },
+      { log_date: "2026-01-10", is_cheat_day: false, is_travel_day: false },
+    ];
+    expect(buildLongEventBlocks(logs, [], 5)).toEqual([]);
+  });
+
+  it("ちょうど threshold 日のブロックが検出される", () => {
+    const logs = [
+      { log_date: "2026-01-03", is_cheat_day: true, is_travel_day: false },
+      { log_date: "2026-01-04", is_cheat_day: true, is_travel_day: false },
+      { log_date: "2026-01-05", is_cheat_day: true, is_travel_day: false },
+      { log_date: "2026-01-06", is_cheat_day: true, is_travel_day: false },
+      { log_date: "2026-01-07", is_cheat_day: true, is_travel_day: false },
+    ];
+    const blocks = buildLongEventBlocks(logs, [], 5);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toEqual({ start: "2026-01-03", end: "2026-01-07", days: 5 });
+  });
+
+  it("threshold を超えるブロックが正しく検出される", () => {
+    // 7連続旅行日
+    const logs = [
+      { log_date: "2026-01-02", is_cheat_day: false, is_travel_day: true },
+      { log_date: "2026-01-03", is_cheat_day: false, is_travel_day: true },
+      { log_date: "2026-01-04", is_cheat_day: false, is_travel_day: true },
+      { log_date: "2026-01-05", is_cheat_day: false, is_travel_day: true },
+      { log_date: "2026-01-06", is_cheat_day: false, is_travel_day: true },
+      { log_date: "2026-01-07", is_cheat_day: false, is_travel_day: true },
+      { log_date: "2026-01-08", is_cheat_day: false, is_travel_day: true },
+    ];
+    const blocks = buildLongEventBlocks(logs, [], 5);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toEqual({ start: "2026-01-02", end: "2026-01-08", days: 7 });
+  });
+
+  it("短期ブロックと長期ブロックが混在する場合、長期のみ返す", () => {
+    const logs = [
+      // 短期: 2日
+      { log_date: "2026-01-02", is_cheat_day: true, is_travel_day: false },
+      { log_date: "2026-01-03", is_cheat_day: true, is_travel_day: false },
+      // 長期: 6日
+      { log_date: "2026-01-10", is_cheat_day: false, is_travel_day: true },
+      { log_date: "2026-01-11", is_cheat_day: false, is_travel_day: true },
+      { log_date: "2026-01-12", is_cheat_day: false, is_travel_day: true },
+      { log_date: "2026-01-13", is_cheat_day: false, is_travel_day: true },
+      { log_date: "2026-01-14", is_cheat_day: false, is_travel_day: true },
+      { log_date: "2026-01-15", is_cheat_day: false, is_travel_day: true },
+    ];
+    const blocks = buildLongEventBlocks(logs, [], 5);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]!.start).toBe("2026-01-10");
+    expect(blocks[0]!.days).toBe(6);
+  });
+
+  it("手動 event period もブロック判定に含まれる", () => {
+    const logs: Array<{ log_date: string; is_cheat_day: boolean; is_travel_day: boolean }> = [];
+    const periods = [{ start: "2026-02-01", end: "2026-02-07" }]; // 7日間
+    const blocks = buildLongEventBlocks(logs, periods, 5);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toEqual({ start: "2026-02-01", end: "2026-02-07", days: 7 });
+  });
+
+  it("DB フラグと手動 period が連続する場合、1ブロックにマージされる", () => {
+    const logs = [
+      { log_date: "2026-01-03", is_cheat_day: true, is_travel_day: false },
+      { log_date: "2026-01-04", is_cheat_day: true, is_travel_day: false },
+      { log_date: "2026-01-05", is_cheat_day: true, is_travel_day: false },
+    ];
+    // 手動 period が連続 (01-06〜01-09)
+    const periods = [{ start: "2026-01-06", end: "2026-01-09" }];
+    const blocks = buildLongEventBlocks(logs, periods, 5);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]!.start).toBe("2026-01-03");
+    expect(blocks[0]!.end).toBe("2026-01-09");
+    expect(blocks[0]!.days).toBe(7);
+  });
+});
+
+// ── buildLongEventExclusionList ────────────────────────────────────────────
+
+describe("buildLongEventExclusionList", () => {
+  it("長期ブロックがない場合は空配列を返す", () => {
+    const logs = [
+      { log_date: "2026-01-01", is_cheat_day: true, is_travel_day: false },
+    ];
+    expect(buildLongEventExclusionList(logs, [], 5, 5)).toEqual([]);
+  });
+
+  it("ブロック本体と回復期間の日付がすべて含まれる", () => {
+    // 5連続チートデイ (2026-01-03〜07)
+    const logs = [
+      { log_date: "2026-01-03", is_cheat_day: true, is_travel_day: false },
+      { log_date: "2026-01-04", is_cheat_day: true, is_travel_day: false },
+      { log_date: "2026-01-05", is_cheat_day: true, is_travel_day: false },
+      { log_date: "2026-01-06", is_cheat_day: true, is_travel_day: false },
+      { log_date: "2026-01-07", is_cheat_day: true, is_travel_day: false },
+    ];
+    const entries = buildLongEventExclusionList(logs, [], 5, 3);
+    const dates = entries.map((e) => e.date);
+
+    // ブロック本体 5日
+    for (let i = 3; i <= 7; i++) {
+      expect(dates).toContain(`2026-01-0${i}`);
+    }
+    // 回復 3日 (01-08〜10)
+    expect(dates).toContain("2026-01-08");
+    expect(dates).toContain("2026-01-09");
+    expect(dates).toContain("2026-01-10");
+    // 回復終了翌日は含まれない
+    expect(dates).not.toContain("2026-01-11");
+  });
+
+  it("ブロック本体エントリの reason が long_event_block", () => {
+    const logs = [
+      { log_date: "2026-01-03", is_cheat_day: true, is_travel_day: false },
+      { log_date: "2026-01-04", is_cheat_day: true, is_travel_day: false },
+      { log_date: "2026-01-05", is_cheat_day: true, is_travel_day: false },
+      { log_date: "2026-01-06", is_cheat_day: true, is_travel_day: false },
+      { log_date: "2026-01-07", is_cheat_day: true, is_travel_day: false },
+    ];
+    const entries = buildLongEventExclusionList(logs, [], 5, 2);
+    const blockEntry = entries.find((e) => e.date === "2026-01-03");
+    expect(blockEntry?.reason).toBe("long_event_block");
+  });
+
+  it("回復日エントリの reason が long_event_recovery", () => {
+    const logs = [
+      { log_date: "2026-01-03", is_cheat_day: true, is_travel_day: false },
+      { log_date: "2026-01-04", is_cheat_day: true, is_travel_day: false },
+      { log_date: "2026-01-05", is_cheat_day: true, is_travel_day: false },
+      { log_date: "2026-01-06", is_cheat_day: true, is_travel_day: false },
+      { log_date: "2026-01-07", is_cheat_day: true, is_travel_day: false },
+    ];
+    const entries = buildLongEventExclusionList(logs, [], 5, 2);
+    const recoveryEntry = entries.find((e) => e.date === "2026-01-08");
+    expect(recoveryEntry?.reason).toBe("long_event_recovery");
+    expect(recoveryEntry?.source).toBe("derived");
+  });
+
+  it("結果が日付昇順でソートされている", () => {
+    const logs = [
+      { log_date: "2026-01-03", is_cheat_day: true, is_travel_day: false },
+      { log_date: "2026-01-04", is_cheat_day: true, is_travel_day: false },
+      { log_date: "2026-01-05", is_cheat_day: true, is_travel_day: false },
+      { log_date: "2026-01-06", is_cheat_day: true, is_travel_day: false },
+      { log_date: "2026-01-07", is_cheat_day: true, is_travel_day: false },
+    ];
+    const entries = buildLongEventExclusionList(logs, [], 5, 5);
+    for (let i = 1; i < entries.length; i++) {
+      expect(entries[i]!.date >= entries[i - 1]!.date).toBe(true);
+    }
+  });
+});
+
+// ── parseRunConfig: long event fields ──────────────────────────────────────
+
+describe("parseRunConfig: long event fields (#480)", () => {
+  it("long_event_threshold と long_event_recovery_days を抽出できる", () => {
+    const config: Json = {
+      long_event_threshold: 7,
+      long_event_recovery_days: 3,
+    };
+    const result = parseRunConfig(config);
+    expect(result.longEventThreshold).toBe(7);
+    expect(result.longEventRecoveryDays).toBe(3);
+  });
+
+  it("フィールドが欠損している場合はデフォルト値を返す", () => {
+    const config: Json = { recovery_days: 2 };
+    const result = parseRunConfig(config);
+    expect(result.longEventThreshold).toBe(LONG_EVENT_THRESHOLD);
+    expect(result.longEventRecoveryDays).toBe(LONG_EVENT_RECOVERY_DAYS);
+  });
+
+  it("config が null の場合もデフォルト値を返す", () => {
+    const result = parseRunConfig(null);
+    expect(result.longEventThreshold).toBe(LONG_EVENT_THRESHOLD);
+    expect(result.longEventRecoveryDays).toBe(LONG_EVENT_RECOVERY_DAYS);
   });
 });

--- a/src/lib/utils/backtestExclusion.ts
+++ b/src/lib/utils/backtestExclusion.ts
@@ -19,7 +19,10 @@ export type ExcludedReason =
   | "cheat_day"
   | "travel_day"
   | "manual_event_period"
-  | "recovery_day";
+  | "recovery_day"
+  // 長期イベントブロック除外ポリシー用 (#480)
+  | "long_event_block"    // 連続 LONG_EVENT_THRESHOLD 日以上のイベント区間本体
+  | "long_event_recovery"; // ブロック終了後の回復期間
 
 export type ExcludedSource =
   | "daily_logs"   // daily_logs の is_cheat_day / is_travel_day フラグ由来
@@ -32,6 +35,22 @@ export type ExcludedDateEntry = {
   source: ExcludedSource;
 };
 
+// ── 長期イベントブロック除外ポリシー定数 (#480 初期仮説値) ──────────────────────
+// Python の backtest.py の _DEFAULT_LONG_EVENT_THRESHOLD / _DEFAULT_LONG_EVENT_RECOVERY_DAYS と同期すること。
+
+/** 連続イベント日数がこの値以上のブロックを「長期イベントブロック」とみなす。 */
+export const LONG_EVENT_THRESHOLD = 5;
+
+/** 長期イベントブロック終了後の回復期間 (日数)。 */
+export const LONG_EVENT_RECOVERY_DAYS = 5;
+
+/** 検出された長期イベントブロック。 */
+export type LongEventBlock = {
+  start: string; // "YYYY-MM-DD"
+  end: string;   // "YYYY-MM-DD"
+  days: number;  // ブロック長 (start〜end の日数)
+};
+
 // ── run.config パース ──────────────────────────────────────────────────────
 
 const DEFAULT_RECOVERY_DAYS = 2;
@@ -41,6 +60,10 @@ export type ParsedRunConfig = {
   /** reason は #371 で追加された任意フィールド。旧 run には存在しない場合がある。 */
   manualEventPeriods: Array<{ start: string; end: string; reason?: string }>;
   evalPolicies: string[];
+  /** #480 で追加。旧 run には存在しない場合がある → LONG_EVENT_THRESHOLD にフォールバック。 */
+  longEventThreshold: number;
+  /** #480 で追加。旧 run には存在しない場合がある → LONG_EVENT_RECOVERY_DAYS にフォールバック。 */
+  longEventRecoveryDays: number;
 };
 
 /**
@@ -53,6 +76,8 @@ export function parseRunConfig(config: Json): ParsedRunConfig {
       recoveryDays: DEFAULT_RECOVERY_DAYS,
       manualEventPeriods: [],
       evalPolicies: [],
+      longEventThreshold: LONG_EVENT_THRESHOLD,
+      longEventRecoveryDays: LONG_EVENT_RECOVERY_DAYS,
     };
   }
   const obj = config as Record<string, Json>;
@@ -84,7 +109,17 @@ export function parseRunConfig(config: Json): ParsedRunConfig {
     ? rawPolicies.filter((p): p is string => typeof p === "string")
     : [];
 
-  return { recoveryDays, manualEventPeriods, evalPolicies };
+  const longEventThreshold =
+    typeof obj["long_event_threshold"] === "number"
+      ? obj["long_event_threshold"]
+      : LONG_EVENT_THRESHOLD;
+
+  const longEventRecoveryDays =
+    typeof obj["long_event_recovery_days"] === "number"
+      ? obj["long_event_recovery_days"]
+      : LONG_EVENT_RECOVERY_DAYS;
+
+  return { recoveryDays, manualEventPeriods, evalPolicies, longEventThreshold, longEventRecoveryDays };
 }
 
 // ── 日付計算ヘルパー ──────────────────────────────────────────────────────
@@ -183,6 +218,116 @@ export function buildExclusionList(
     }
     for (let i = 1; i <= recoveryDays; i++) {
       set(addDays(ep.end, i), "recovery_day", "derived");
+    }
+  }
+
+  return Array.from(map.values()).sort((a, b) => a.date.localeCompare(b.date));
+}
+
+// ── 長期イベントブロック: 検出と除外リスト構築 (#480) ─────────────────────────
+
+/**
+ * イベント候補日 (is_cheat_day / is_travel_day / manualEventPeriods) から
+ * 連続 LONG_EVENT_THRESHOLD 日以上のブロックを検出して返す。
+ *
+ * Python の build_long_event_exclusion_dates() と同じロジックで
+ * ブロック検出を行う。
+ */
+export function buildLongEventBlocks(
+  dailyLogs: Array<{
+    log_date: string;
+    is_cheat_day: boolean | null;
+    is_travel_day: boolean | null;
+  }>,
+  manualEventPeriods: Array<{ start: string; end: string }>,
+  threshold: number = LONG_EVENT_THRESHOLD,
+): LongEventBlock[] {
+  // イベント候補日を収集
+  const eventDays = new Set<string>();
+  for (const log of dailyLogs) {
+    if (log.is_cheat_day) eventDays.add(log.log_date);
+    if (log.is_travel_day) eventDays.add(log.log_date);
+  }
+  for (const ep of manualEventPeriods) {
+    for (const d of dateRange(ep.start, ep.end)) {
+      eventDays.add(d);
+    }
+  }
+
+  if (eventDays.size === 0) return [];
+
+  // 連続ブロックを検出
+  const sorted = Array.from(eventDays).sort();
+  const blocks: LongEventBlock[] = [];
+  let blockStart = sorted[0]!;
+  let blockEnd   = sorted[0]!;
+
+  for (let i = 1; i < sorted.length; i++) {
+    const d = sorted[i]!;
+    if (d === addDays(blockEnd, 1)) {
+      blockEnd = d;
+    } else {
+      const days = daysCount(blockStart, blockEnd);
+      if (days >= threshold) {
+        blocks.push({ start: blockStart, end: blockEnd, days });
+      }
+      blockStart = d;
+      blockEnd   = d;
+    }
+  }
+  // 最後のブロック
+  const days = daysCount(blockStart, blockEnd);
+  if (days >= threshold) {
+    blocks.push({ start: blockStart, end: blockEnd, days });
+  }
+
+  return blocks;
+}
+
+/** start〜end (含む) の日数カウント。 */
+function daysCount(start: string, end: string): number {
+  const s = start.split("-").map(Number);
+  const e = end.split("-").map(Number);
+  const ds = new Date(s[0]!, s[1]! - 1, s[2]!);
+  const de = new Date(e[0]!, e[1]! - 1, e[2]!);
+  return Math.round((de.getTime() - ds.getTime()) / 86400000) + 1;
+}
+
+/**
+ * 長期イベントブロック除外ポリシー (exclude_long_event_blocks) の除外日リストを構築する。
+ *
+ * Python の build_long_event_exclusion_dates() と同等のロジック。
+ * ブロック本体全日 + ブロック終了後 recoveryDays 日間を除外する。
+ */
+export function buildLongEventExclusionList(
+  dailyLogs: Array<{
+    log_date: string;
+    is_cheat_day: boolean | null;
+    is_travel_day: boolean | null;
+  }>,
+  manualEventPeriods: Array<{ start: string; end: string; reason?: string }>,
+  threshold: number = LONG_EVENT_THRESHOLD,
+  recoveryDays: number = LONG_EVENT_RECOVERY_DAYS,
+): ExcludedDateEntry[] {
+  const blocks = buildLongEventBlocks(dailyLogs, manualEventPeriods, threshold);
+  if (blocks.length === 0) return [];
+
+  const map = new Map<string, ExcludedDateEntry>();
+
+  function set(date: string, reason: ExcludedReason, source: ExcludedSource) {
+    if (!map.has(date)) {
+      map.set(date, { date, reason, source });
+    }
+  }
+
+  for (const block of blocks) {
+    // ブロック本体
+    for (const d of dateRange(block.start, block.end)) {
+      set(d, "long_event_block", "daily_logs");
+    }
+    // ブロック終了後の回復期間
+    for (let i = 1; i <= recoveryDays; i++) {
+      set(addDays(block.end, i), "long_event_recovery", "derived");
     }
   }
 


### PR DESCRIPTION
## 概要

forecast-accuracy に長期イベント区間除外ポリシー (`exclude_long_event_blocks`) を追加し、既存の 2 ポリシーと並べて精度比較できるようにした。

## 変更内容

### Python (`ml-pipeline/backtest.py`)
- `POLICY_EXCLUDE_LONG_EVENT_BLOCKS = "exclude_long_event_blocks"` 定数を追加
- `_DEFAULT_LONG_EVENT_THRESHOLD = 5`、`_DEFAULT_LONG_EVENT_RECOVERY_DAYS = 5` 定数を追加 (仮説値・将来変更しやすいよう切り出し)
- `build_long_event_exclusion_dates()` 関数を追加: cheat_day / travel_day / 手動 event period を合算し、連続 threshold 日以上のブロックを検出してブロック本体 + 回復期間を除外
- `compute_policy_metrics()` に新ポリシー対応を追加 (後方互換: `long_event_exclusion_dates=None` でフォールバック)
- `BacktestConfig` に `long_event_threshold` / `long_event_recovery_days` フィールドを追加
- `_DEFAULT_EVAL_POLICIES` に新ポリシーを追加 (デフォルト実行で 3 ポリシー全て算出)
- CLI に `--long-event-threshold` / `--long-event-recovery-days` 引数を追加
- `save_results()` が run.config に新パラメータを保存

### TypeScript (`src/lib/utils/backtestExclusion.ts`)
- `LONG_EVENT_THRESHOLD`, `LONG_EVENT_RECOVERY_DAYS` 定数を追加
- `LongEventBlock` 型を追加
- `buildLongEventBlocks()` 関数を追加 (Python `build_long_event_exclusion_dates()` のブロック検出部分に対応)
- `buildLongEventExclusionList()` 関数を追加
- `ParsedRunConfig` に `longEventThreshold` / `longEventRecoveryDays` を追加
- `parseRunConfig()` が新フィールドを安全に読み出す (旧 run は定数にフォールバック)

### UI
- **`BacktestPolicyComparison`**: 3 ポリシー比較に拡張。各セルに MAE + n を表示。長期除外後はティール色で区別
- **`BacktestLongEventDetails` (新規)**: 検出された長期イベントブロック一覧 + 全ポリシーの詳細指標 (MAE / RMSE / Bias / n) 比較テーブル。コラプシブル表示
- **`BacktestExcludedDates`**: `REASON_CONFIG` に `long_event_block` / `long_event_recovery` を追加 (型整合)
- **`page.tsx`**: 長期イベント詳細を再導出して `BacktestLongEventDetails` に渡す

## 長期イベント区間の初期定義

- **イベント候補日**: `is_cheat_day=true` / `is_travel_day=true` / `manual_event_periods` の各日
- **長期イベントブロック**: 連続 **5 日以上**のイベント区間 (初期仮説値 `long_event_threshold=5`)
- **回復期間**: ブロック終了後 **5 日間** (初期仮説値 `long_event_recovery_days=5`)
- 短期イベント (1〜4日) は除外しない点が `exclude_flagged_plus_recovery` と異なる

## 新ポリシーの比較観点

| ポリシー | 除外対象 | 目的 |
|---|---|---|
| `all_days` | なし | 比較ベースライン |
| `exclude_flagged_plus_recovery` | 個別イベント日 + 回復 2 日 | 通常日の精度確認 |
| `exclude_long_event_blocks` | **連続 5 日以上**のブロック + 回復 5 日 | 長期区間の影響のみを検証 |

## 既存ポリシーへの影響

- 既存の `all_days` / `exclude_flagged_plus_recovery` ロジックは変更なし
- `compute_policy_metrics()` の `exclusion_dates` 引数はそのまま; 新ポリシー用に `long_event_exclusion_dates` を追加 (省略可能、後方互換)
- 旧 run の metrics への影響なし

## テスト / 確認内容

- **Python**: 28 テスト追加 (93 → 93 は元々、今回追加で total 93)
  - `build_long_event_exclusion_dates`: 8 テスト (threshold 未満/以上/マージ/回復/フォールバック等)
  - `compute_policy_metrics` 新ポリシー: 5 テスト
  - `BacktestConfig` 長期イベント設定: 5 テスト
- **TypeScript**: 16 テスト追加 (backtestExclusion.test.ts が 19 → 35 に)
  - `buildLongEventBlocks`: 7 テスト
  - `buildLongEventExclusionList`: 5 テスト
  - `parseRunConfig` 長期イベントフィールド: 3 テスト
- `npx tsc --noEmit`: 型エラー 0
- Jest: 1281 passed (全スイート 53 通過)

## 補足

- `long_event_threshold=5` / `long_event_recovery_days=5` はいずれも仮説値
- 改善幅が小さい・サンプル数が大きく減る場合は `BacktestLongEventDetails` の注記で確認できる
- NeuralProphet 学習系列変更・ダッシュボード反映は本 Issue のスコープ外 (#479 の境界を維持)

Closes #480