### PR TITLE
feat: guard invalid previous-run comparisons in backtest UI

### DIFF
--- a/src/app/forecast-accuracy/page.tsx
+++ b/src/app/forecast-accuracy/page.tsx
@@ -38,7 +38,7 @@ export default async function ForecastAccuracyPage() {
     );
   }
 
-  const { dailyRun, sma7Run, prevDailyRun, prevSma7Run } = runsResult.data;
+  const { dailyRun, sma7Run, prevDailyRun, prevSma7Run, prevDailyRunComparable, prevSma7RunComparable } = runsResult.data;
 
   // 両方ともデータなし
   if (!dailyRun && !sma7Run) {
@@ -133,6 +133,8 @@ export default async function ForecastAccuracyPage() {
           sma7Metrics={sma7Metrics}
           prevDailyMetrics={prevDailyMetrics}
           prevSma7Metrics={prevSma7Metrics}
+          prevDailyComparable={prevDailyRunComparable}
+          prevSma7Comparable={prevSma7RunComparable}
         />
 
         {/* ── 全日 vs イベント除外 評価条件別比較 (#364) ──

--- a/src/components/charts/BacktestComparison.tsx
+++ b/src/components/charts/BacktestComparison.tsx
@@ -29,6 +29,15 @@ interface BacktestComparisonProps {
   sma7Metrics: ForecastBacktestMetric[];
   prevDailyMetrics?: ForecastBacktestMetric[];
   prevSma7Metrics?: ForecastBacktestMetric[];
+  /**
+   * false のとき: 前回 daily run と実行条件 (horizons / feature_set / origin_step_days) が異なるため
+   * 前回比バッジを表示しない。デフォルト true。
+   */
+  prevDailyComparable?: boolean;
+  /**
+   * false のとき: 前回 sma7 run と実行条件が異なるため前回比バッジを表示しない。デフォルト true。
+   */
+  prevSma7Comparable?: boolean;
 }
 
 const HORIZONS = [7, 14, 30] as const;
@@ -116,8 +125,10 @@ function noiseReductionColor(pct: number | null): string {
 export function BacktestComparison({
   dailyMetrics,
   sma7Metrics,
-  prevDailyMetrics = [],
-  prevSma7Metrics  = [],
+  prevDailyMetrics   = [],
+  prevSma7Metrics    = [],
+  prevDailyComparable = true,
+  prevSma7Comparable  = true,
 }: BacktestComparisonProps) {
   // #363 以降の run は複数 policy の行を含む。
   // BacktestComparison は評価軸（単日 vs 7日均）の比較が目的のため、
@@ -134,8 +145,18 @@ export function BacktestComparison({
   const sma7Map  = buildMaeMap(sma7All);
 
   // 前回比バッジ用 MAE マップ (all_days のみ)
-  const prevDailyMap = buildMaeMap(prevDailyMetrics.filter((m) => m.eval_policy === "all_days"));
-  const prevSma7Map  = buildMaeMap(prevSma7Metrics.filter((m) => m.eval_policy === "all_days"));
+  // 条件不一致の場合は空 Map にして全バッジを抑止する
+  const prevDailyMap = prevDailyComparable
+    ? buildMaeMap(prevDailyMetrics.filter((m) => m.eval_policy === "all_days"))
+    : new Map<string, number>();
+  const prevSma7Map = prevSma7Comparable
+    ? buildMaeMap(prevSma7Metrics.filter((m) => m.eval_policy === "all_days"))
+    : new Map<string, number>();
+
+  // 条件不一致注記を表示するか (前回 run が存在する場合のみ注記が意味を持つ)
+  const showDailyConditionNote  = !prevDailyComparable && prevDailyMetrics.length  > 0;
+  const showSma7ConditionNote   = !prevSma7Comparable  && prevSma7Metrics.length   > 0;
+  const showAnyConditionNote    = showDailyConditionNote || showSma7ConditionNote;
 
   // ホライズン別ベスト MAE (ノイズ除去率計算用)
   const dailyBest: Record<Horizon, { model: string; mae: number } | null> = {
@@ -231,8 +252,13 @@ export function BacktestComparison({
           );
         })}
         <p className="text-[10px] text-slate-400 dark:text-slate-500">
-          ★ = ホライズン別最良モデル / ノイズ除去率 = (1 − 7日均MAE ÷ 単日MAE) × 100%
+          ★ = ホライズン別最良モデル / ▲▼ = 今回のホライズン別最良モデルの自己前回比 / ノイズ除去率 = (1 − 7日均MAE ÷ 単日MAE) × 100%
         </p>
+        {showAnyConditionNote && (
+          <p className="text-[10px] text-amber-600 dark:text-amber-400">
+            ※ 前回と実行条件 (horizons / feature_set / origin_step_days) が異なるため前回比は表示していません。
+          </p>
+        )}
       </div>
 
       {/* ── デスクトップ: 比較テーブル (md+) ── */}
@@ -353,11 +379,16 @@ export function BacktestComparison({
       {/* ── フッター注記（デスクトップのみ）── */}
       <div className="hidden md:block border-t border-slate-50 bg-slate-50 px-5 py-2.5 text-[11px] text-slate-400 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-500">
         <span>
-          ★ = ホライズン別最良モデル / MAE: 平均絶対誤差 (kg) / ノイズ除去率 = (1 − 7日均MAE ÷ 単日MAE) × 100%
+          ★ = ホライズン別最良モデル / ▲▼ = モデル別自己前回比 / MAE: 平均絶対誤差 (kg) / ノイズ除去率 = (1 − 7日均MAE ÷ 単日MAE) × 100%
         </span>
         <span className="ml-3 text-slate-300 dark:text-slate-600">
           リークなし保証: horizon ≥ 7 のため SMA7 評価ウィンドウは訓練期間と重複しない
         </span>
+        {showAnyConditionNote && (
+          <span className="ml-3 text-amber-500 dark:text-amber-400">
+            ※ 前回と実行条件が異なるため▲▼は非表示
+          </span>
+        )}
       </div>
     </div>
   );

--- a/src/lib/queries/backtest.ts
+++ b/src/lib/queries/backtest.ts
@@ -26,6 +26,56 @@ function getSeriesType(run: ForecastBacktestRun): string {
   return "daily";
 }
 
+/** config JSON から文字列フィールドを安全に読み出す。存在しない場合は null。 */
+function cfgStr(run: ForecastBacktestRun, key: string): string | null {
+  const cfg = run.config;
+  if (cfg && typeof cfg === "object" && !Array.isArray(cfg)) {
+    const v = (cfg as Record<string, Json>)[key];
+    if (typeof v === "string") return v;
+  }
+  return null;
+}
+
+/** config JSON から数値フィールドを安全に読み出す。存在しない場合は null。 */
+function cfgNum(run: ForecastBacktestRun, key: string): number | null {
+  const cfg = run.config;
+  if (cfg && typeof cfg === "object" && !Array.isArray(cfg)) {
+    const v = (cfg as Record<string, Json>)[key];
+    if (typeof v === "number") return v;
+  }
+  return null;
+}
+
+/**
+ * prev run の実行条件が current run と比較可能か判定する。
+ *
+ * 判定フィールド:
+ *   - horizons         : 評価ホライズンセットが異なると同じホライズンの MAE を比較できない
+ *   - feature_set      : 使用特徴量セットが異なると別実験とみなす
+ *   - origin_step_days : 評価ウィンドウのサンプリング間隔が異なると評価精度の分母が変わる
+ *
+ * フィールドが旧 run に存在しない場合は比較可能とみなす (graceful fallback)。
+ * eval_policies は BacktestComparison が all_days のみ参照するため判定不要。
+ */
+function isRunComparable(current: ForecastBacktestRun, prev: ForecastBacktestRun): boolean {
+  // horizons: top-level number[] カラムで比較 (順序不同)
+  const curH = [...(current.horizons ?? [])].sort((a, b) => a - b);
+  const preH = [...(prev.horizons    ?? [])].sort((a, b) => a - b);
+  if (curH.length !== preH.length || curH.some((v, i) => v !== preH[i])) return false;
+
+  // feature_set: config JSON フィールド (どちらかが読めない場合はスキップ)
+  const curFs = cfgStr(current, "feature_set");
+  const preFs = cfgStr(prev,    "feature_set");
+  if (curFs !== null && preFs !== null && curFs !== preFs) return false;
+
+  // origin_step_days: config JSON フィールド (どちらかが読めない場合はスキップ)
+  const curStep = cfgNum(current, "origin_step_days");
+  const preStep = cfgNum(prev,    "origin_step_days");
+  if (curStep !== null && preStep !== null && curStep !== preStep) return false;
+
+  return true;
+}
+
 /**
  * 最新 20 件の run を取得し、daily / sma7 それぞれの最新 run と直前 run を返す。
  * 旧来の run (config.series_type なし) は daily として扱う。
@@ -41,6 +91,10 @@ export async function fetchLatestRuns(): Promise<QueryResult<{
   sma7Run: ForecastBacktestRun | null;
   prevDailyRun: ForecastBacktestRun | null;
   prevSma7Run: ForecastBacktestRun | null;
+  /** true = 前回 daily run と実行条件が一致し、前回比として比較可能。false = 条件が異なり比較不可。 */
+  prevDailyRunComparable: boolean;
+  /** true = 前回 sma7 run と実行条件が一致し、前回比として比較可能。false = 条件が異なり比較不可。 */
+  prevSma7RunComparable: boolean;
 }>> {
   const supabase = createClient();
   const { data, error } = await supabase
@@ -58,13 +112,22 @@ export async function fetchLatestRuns(): Promise<QueryResult<{
   const dailyRuns = runs.filter((r) => getSeriesType(r) === "daily");
   const sma7Runs  = runs.filter((r) => getSeriesType(r) === "sma7");
 
+  // 前回 run が存在する場合のみ比較可能性を判定する。
+  // 前回 run が存在しない場合は true にしておくが、prev metrics が空なので MaeDeltaBadge は表示されない。
+  const prevDailyRunComparable =
+    dailyRuns[0] && dailyRuns[1] ? isRunComparable(dailyRuns[0], dailyRuns[1]) : true;
+  const prevSma7RunComparable =
+    sma7Runs[0] && sma7Runs[1] ? isRunComparable(sma7Runs[0], sma7Runs[1]) : true;
+
   return {
     kind: "ok",
     data: {
-      dailyRun:     dailyRuns[0] ?? null,
-      sma7Run:      sma7Runs[0]  ?? null,
-      prevDailyRun: dailyRuns[1] ?? null,
-      prevSma7Run:  sma7Runs[1]  ?? null,
+      dailyRun:              dailyRuns[0] ?? null,
+      sma7Run:               sma7Runs[0]  ?? null,
+      prevDailyRun:          dailyRuns[1] ?? null,
+      prevSma7Run:           sma7Runs[1]  ?? null,
+      prevDailyRunComparable,
+      prevSma7RunComparable,
     },
   };
 }


### PR DESCRIPTION
## 概要

バックテスト精度ページの「前回比」が、実行条件の異なる run 間でも改善/悪化として表示されてしまう問題を修正します。比較条件の一致判定をクエリ層に持たせ、不一致時は UI 側でバッジを抑止・注記を表示するようにしました。

## 変更内容

### `src/lib/queries/backtest.ts`

- `isRunComparable(current, prev)` を追加
  - 比較可能性の判定フィールド: `horizons`（top-level カラム）・`feature_set`（config JSON）・`origin_step_days`（config JSON）
  - どちらかのフィールドが旧 run に存在しない場合は「比較可能」とみなす（graceful fallback）
- `fetchLatestRuns` の戻り値に `prevDailyRunComparable: boolean` / `prevSma7RunComparable: boolean` を追加

### `src/app/forecast-accuracy/page.tsx`

- 新フィールドを destructure して `BacktestComparison` に `prevDailyComparable` / `prevSma7Comparable` として渡す

### `src/components/charts/BacktestComparison.tsx`

- `prevDailyComparable?: boolean` / `prevSma7Comparable?: boolean` prop を追加（デフォルト `true`）
- `comparable=false` のとき `prevDailyMap` / `prevSma7Map` を空 Map にして `MaeDeltaBadge` を全面抑止
- モバイル footer に条件不一致時の注記を追加（「前回と実行条件が異なるため前回比は表示していません」）
- デスクトップ footer にも同様の短縮注記を追加
- モバイル footer に「▲▼ = 今回のホライズン別最良モデルの自己前回比」を明示

## 比較可能性の判定基準

| フィールド | 判定理由 |
|---|---|
| `horizons` | ホライズンセットが異なると同じ H=14 の MAE を比べられない |
| `feature_set` | 特徴量セットが異なると別実験とみなすべき |
| `origin_step_days` | 評価ウィンドウのサンプリング間隔が変わると MAE の分母が変わる |

`eval_policies` は判定から除外。`BacktestComparison` は `all_days` のみ参照しており、prev run に `all_days` メトリクスがなければ `MaeDeltaBadge` が自己解消するため不要。

## 条件不一致時の UI 方針

- `MaeDeltaBadge` をモバイル/デスクトップ両方で完全抑止（ダミー値・0 差分表示なし）
- 前回 run が存在するにもかかわらず条件不一致の場合のみ注記を表示（前回 run なし時は無音）
- 条件一致時の挙動は既存のまま（前回比バッジ表示）

## モバイルサマリーの意味論整理

「▲▼」は「**今回のホライズン別最良モデルの自己前回比**」として整理しました。

- 実装: `prevDailyMaeBest = dBest ? prevDailyMap.get(`${dBest.model}:${h}`) ?? null : null`
- 意味: 今回の best モデルが前回の同一モデルと比べてどう変化したか
- ベストモデルが入れ替わった場合でも「今回の best が前回どうだったか」として解釈できる
- デスクトップテーブルは「モデル別自己前回比」（全モデル）で意味が明確のため変更なし

## 影響範囲

- `BacktestComparison` の prop 追加（`prevDailyComparable` / `prevSma7Comparable`、デフォルト `true` のため後方互換あり）
- `fetchLatestRuns` の戻り値フィールド追加（`forecast-accuracy/page.tsx` のみが呼び出し元）
- 比較条件が常に一致している環境では UI 変化なし

## 補足

- 条件不一致時に `prevRun` 自体を `null` にする方法も検討したが、「なぜ比較がないか」を UI に伝えるためフラグ方式を採用
- `eval_policies` の不一致（例: 新しいポリシーを追加した run）は対象外とした。`all_days` メトリクスは両 run に存在することが前提で、BacktestComparison の比較軸は変わらないため

Closes #461
🤖 Generated with [Claude Code](https://claude.com/claude-code)