### PR TITLE
feat: apply long-event exclusion to NeuralProphet forecast training (#485)

### DIFF
--- a/ml-pipeline/predict.py
+++ b/ml-pipeline/predict.py
@@ -24,7 +24,7 @@ predict.py — NeuralProphet 体重予測バッチ
 import logging
 import math
 import os
-from datetime import datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 
 import pandas as pd
 
@@ -34,6 +34,11 @@ logger = logging.getLogger(__name__)
 MODEL_VERSION = "neuralprophet-v1"
 FORECAST_DAYS = 180  # 大会日が半年先でもカバーできるよう拡張（旧版は90日）
 ADAPTATION_FACTOR = 30  # 代謝適応係数 (日数)
+
+# 長期イベント除外の定数 (backtest.py の _DEFAULT_LONG_EVENT_THRESHOLD と同値で同期する)
+# 5日以上連続するイベント区間 + 終了後 5日間の回復期間を学習から除外する
+_LONG_EVENT_THRESHOLD = 5
+_LONG_EVENT_RECOVERY_DAYS = 5
 
 # 本番予測バッチを成立させるための最低データ数。
 # weekly_seasonality=True の NeuralProphet が学習を完了できる実用的な下限。
@@ -45,6 +50,87 @@ MIN_ROWS = 14
 
 
 # ── 純粋ロジック層 ─────────────────────────────────────────────────────────────
+
+
+def build_clean_series(
+    df: pd.DataFrame,
+    long_event_threshold: int = _LONG_EVENT_THRESHOLD,
+    long_event_recovery_days: int = _LONG_EVENT_RECOVERY_DAYS,
+) -> pd.DataFrame:
+    """長期イベント区間を除いた学習用系列を返す。
+
+    is_cheat_day / is_travel_day フラグが連続して long_event_threshold 日以上続く区間を
+    「長期イベントブロック」とみなし、そのブロック本体 + 終了後 long_event_recovery_days 日間を
+    学習対象から除外した DataFrame を返す。
+
+    短期イベント (1〜long_event_threshold-1 日) は除外しない点が
+    backtest.py の exclude_flagged_plus_recovery ポリシーと異なる。
+    体重の長期的なトレンド学習への影響が小さい短期変動は除外しない方が
+    データ量確保の観点から有利なため。
+
+    Args:
+        df: "ds" (datetime), "y" (float), 任意で "is_cheat_day" / "is_travel_day" (bool) を含む DataFrame。
+        long_event_threshold: 長期イベントブロックとみなす最小連続日数。
+        long_event_recovery_days: ブロック終了後の回復期間 (日数)。
+
+    Returns:
+        除外後の DataFrame ("ds", "y" 列のみ)。元の df は変更しない。
+    """
+    # フラグカラムが存在しない場合はそのまま返す (テスト用 / フラグ未取得環境への安全対策)
+    if "is_cheat_day" not in df.columns and "is_travel_day" not in df.columns:
+        return df[["ds", "y"]].copy()
+
+    # イベント候補日を収集
+    event_days: set[date] = set()
+    if "is_cheat_day" in df.columns:
+        for d in df.loc[df["is_cheat_day"] == True, "ds"].dt.date:  # noqa: E712
+            event_days.add(d)
+    if "is_travel_day" in df.columns:
+        for d in df.loc[df["is_travel_day"] == True, "ds"].dt.date:  # noqa: E712
+            event_days.add(d)
+
+    if not event_days:
+        return df[["ds", "y"]].copy()
+
+    # 連続ブロックを検出
+    sorted_days = sorted(event_days)
+    blocks: list[tuple[date, date]] = []
+    block_start = sorted_days[0]
+    block_end = sorted_days[0]
+    for d in sorted_days[1:]:
+        if d == block_end + timedelta(days=1):
+            block_end = d
+        else:
+            blocks.append((block_start, block_end))
+            block_start = d
+            block_end = d
+    blocks.append((block_start, block_end))
+
+    # 長期ブロック (>= threshold) のみ除外対象にする
+    excluded: set[date] = set()
+    long_block_count = 0
+    for b_start, b_end in blocks:
+        n_days = (b_end - b_start).days + 1
+        if n_days < long_event_threshold:
+            continue
+        long_block_count += 1
+        cur = b_start
+        while cur <= b_end:
+            excluded.add(cur)
+            cur += timedelta(days=1)
+        for i in range(1, long_event_recovery_days + 1):
+            excluded.add(b_end + timedelta(days=i))
+
+    if not excluded:
+        return df[["ds", "y"]].copy()
+
+    logger.info(
+        "build_clean_series: %d long-event block(s) detected, excluding %d days from training.",
+        long_block_count,
+        len(excluded),
+    )
+    mask = ~df["ds"].dt.date.isin(excluded)
+    return df.loc[mask, ["ds", "y"]].copy()
 
 
 def run_model(df: pd.DataFrame) -> pd.DataFrame:
@@ -103,13 +189,21 @@ def run_model(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def fetch_daily_logs(client) -> pd.DataFrame:
-    """Supabase から daily_logs を取得して予測用 DataFrame で返す。"""
-    response = client.table("daily_logs").select("log_date,weight").order("log_date").execute()
+    """Supabase から daily_logs を取得して予測用 DataFrame で返す。
+
+    is_cheat_day / is_travel_day は長期イベント除外 (build_clean_series) のために取得する。
+    """
+    response = (
+        client.table("daily_logs")
+        .select("log_date,weight,is_cheat_day,is_travel_day")
+        .order("log_date")
+        .execute()
+    )
     df = pd.DataFrame(response.data)
     df = df.dropna(subset=["weight"])
     df["ds"] = pd.to_datetime(df["log_date"])
     df["y"] = df["weight"].astype(float)
-    return df[["ds", "y"]]
+    return df[["ds", "y", "is_cheat_day", "is_travel_day"]]
 
 
 def save_predictions(client, records: list[dict]) -> None:
@@ -151,9 +245,26 @@ def main() -> None:
         logger.warning("Insufficient data (%d rows). Skipping prediction.", len(df))
         return
 
-    logger.info("Running NeuralProphet (rows=%d)...", len(df))
+    # 長期イベント区間を除外した学習用系列を構築する。
+    # 実測系列 (df) はログ行数チェックに使い、モデルへは clean 系列のみ渡す。
+    df_clean = build_clean_series(df)
+    logger.info(
+        "Training series: %d rows (raw=%d, excluded=%d).",
+        len(df_clean),
+        len(df),
+        len(df) - len(df_clean),
+    )
+
+    if len(df_clean) < MIN_ROWS:
+        logger.warning(
+            "Insufficient clean data (%d rows after long-event exclusion). Skipping prediction.",
+            len(df_clean),
+        )
+        return
+
+    logger.info("Running NeuralProphet (rows=%d)...", len(df_clean))
     try:
-        forecast = run_model(df)
+        forecast = run_model(df_clean)
     except Exception as e:
         logger.error("NeuralProphet model failed: %s", e)
         raise SystemExit(1)

--- a/ml-pipeline/test_predict.py
+++ b/ml-pipeline/test_predict.py
@@ -116,31 +116,30 @@ class TestFetchDailyLogsTransform:
 
         return _Client(data)
 
-    def test_returns_ds_and_y_columns(self):
-        """返り値は 'ds' と 'y' の2列を持つ。"""
+    def _make_row(self, log_date: str, weight, cheat: bool = False, travel: bool = False) -> dict:
+        return {"log_date": log_date, "weight": weight, "is_cheat_day": cheat, "is_travel_day": travel}
+
+    def test_returns_expected_columns(self):
+        """返り値は 'ds', 'y', 'is_cheat_day', 'is_travel_day' の4列を持つ。"""
         from predict import fetch_daily_logs
         client = self._make_mock_client([
-            {"log_date": "2026-01-01", "weight": 65.0},
-            {"log_date": "2026-01-02", "weight": 64.8},
+            self._make_row("2026-01-01", 65.0),
+            self._make_row("2026-01-02", 64.8),
         ])
         df = fetch_daily_logs(client)
-        assert list(df.columns) == ["ds", "y"]
+        assert list(df.columns) == ["ds", "y", "is_cheat_day", "is_travel_day"]
 
     def test_ds_is_datetime(self):
         """ds 列が datetime 型になっている。"""
         from predict import fetch_daily_logs
-        client = self._make_mock_client([
-            {"log_date": "2026-01-01", "weight": 65.0},
-        ])
+        client = self._make_mock_client([self._make_row("2026-01-01", 65.0)])
         df = fetch_daily_logs(client)
         assert pd.api.types.is_datetime64_any_dtype(df["ds"])
 
     def test_y_is_float(self):
         """y 列が float 型になっている。"""
         from predict import fetch_daily_logs
-        client = self._make_mock_client([
-            {"log_date": "2026-01-01", "weight": 65},  # int として渡す
-        ])
+        client = self._make_mock_client([self._make_row("2026-01-01", 65)])  # int として渡す
         df = fetch_daily_logs(client)
         assert df["y"].dtype == float
 
@@ -148,9 +147,9 @@ class TestFetchDailyLogsTransform:
         """weight が null の行は除外される。"""
         from predict import fetch_daily_logs
         client = self._make_mock_client([
-            {"log_date": "2026-01-01", "weight": 65.0},
-            {"log_date": "2026-01-02", "weight": None},
-            {"log_date": "2026-01-03", "weight": 64.5},
+            self._make_row("2026-01-01", 65.0),
+            self._make_row("2026-01-02", None),
+            self._make_row("2026-01-03", 64.5),
         ])
         df = fetch_daily_logs(client)
         assert len(df) == 2
@@ -160,12 +159,127 @@ class TestFetchDailyLogsTransform:
         """weight が全て null の場合は空 DataFrame を返す。"""
         from predict import fetch_daily_logs
         client = self._make_mock_client([
-            {"log_date": "2026-01-01", "weight": None},
-            {"log_date": "2026-01-02", "weight": None},
+            self._make_row("2026-01-01", None),
+            self._make_row("2026-01-02", None),
         ])
         df = fetch_daily_logs(client)
         assert isinstance(df, pd.DataFrame)
         assert len(df) == 0
+
+
+# ── build_clean_series のテスト ──────────────────────────────────────────────
+
+
+def _make_df(rows: list[dict]) -> pd.DataFrame:
+    """テスト用 DataFrame を生成する。rows は log_date / weight / is_cheat_day / is_travel_day を含む。"""
+    df = pd.DataFrame(rows)
+    df["ds"] = pd.to_datetime(df["log_date"])
+    df["y"] = df["weight"].astype(float)
+    return df[["ds", "y", "is_cheat_day", "is_travel_day"]]
+
+
+class TestBuildCleanSeries:
+    """build_clean_series() の長期イベント除外ロジックを検証する。"""
+
+    def test_no_events_returns_all_rows(self):
+        """イベントフラグが全て False なら全行をそのまま返す。"""
+        from predict import build_clean_series
+        df = _make_df([
+            {"log_date": "2026-01-01", "weight": 65.0, "is_cheat_day": False, "is_travel_day": False},
+            {"log_date": "2026-01-02", "weight": 64.8, "is_cheat_day": False, "is_travel_day": False},
+        ])
+        clean = build_clean_series(df, long_event_threshold=5, long_event_recovery_days=5)
+        assert len(clean) == 2
+        assert list(clean.columns) == ["ds", "y"]
+
+    def test_short_event_not_excluded(self):
+        """threshold 未満の短期イベントは除外されない (3日 < threshold=5)。"""
+        from predict import build_clean_series
+        rows = [
+            {"log_date": f"2026-01-{d:02d}", "weight": 65.0,
+             "is_cheat_day": (3 <= d <= 5), "is_travel_day": False}
+            for d in range(1, 11)
+        ]
+        df = _make_df(rows)
+        clean = build_clean_series(df, long_event_threshold=5, long_event_recovery_days=5)
+        assert len(clean) == 10  # 除外なし
+
+    def test_long_event_block_excluded(self):
+        """threshold 以上 (5日) の連続イベントはブロック + 回復期間が除外される。"""
+        from predict import build_clean_series
+        # 1/05 〜 1/09 (5日連続) = ブロック + 回復 5日 (1/10〜1/14) → 計 10日除外
+        rows = [
+            {"log_date": f"2026-01-{d:02d}", "weight": 65.0,
+             "is_cheat_day": (5 <= d <= 9), "is_travel_day": False}
+            for d in range(1, 21)
+        ]
+        df = _make_df(rows)
+        clean = build_clean_series(df, long_event_threshold=5, long_event_recovery_days=5)
+        # 20行 - 10行(ブロック5日+回復5日) = 10行残る
+        assert len(clean) == 10
+        remaining_dates = clean["ds"].dt.strftime("%Y-%m-%d").tolist()
+        # 1/01〜1/04 は残る
+        assert "2026-01-04" in remaining_dates
+        # 1/05〜1/14 は除外される
+        assert "2026-01-05" not in remaining_dates
+        assert "2026-01-14" not in remaining_dates
+        # 1/15〜1/20 は残る
+        assert "2026-01-15" in remaining_dates
+
+    def test_travel_day_flag_also_triggers_exclusion(self):
+        """is_travel_day フラグも長期ブロックの検出に含まれる。"""
+        from predict import build_clean_series
+        rows = [
+            {"log_date": f"2026-01-{d:02d}", "weight": 65.0,
+             "is_cheat_day": False, "is_travel_day": (3 <= d <= 9)}  # 7日連続
+            for d in range(1, 16)
+        ]
+        df = _make_df(rows)
+        clean = build_clean_series(df, long_event_threshold=5, long_event_recovery_days=3)
+        # ブロック 1/03〜1/09 (7日) + 回復 1/10〜1/12 (3日) = 10日除外
+        assert len(clean) == 5
+
+    def test_mixed_flags_merged_into_single_block(self):
+        """is_cheat_day と is_travel_day が隣接している場合、1つの連続ブロックとして扱われる。"""
+        from predict import build_clean_series
+        rows = [
+            {"log_date": f"2026-01-{d:02d}", "weight": 65.0,
+             "is_cheat_day": (d in [5, 6, 7]), "is_travel_day": (d in [8, 9])}
+            for d in range(1, 16)
+        ]
+        df = _make_df(rows)
+        clean = build_clean_series(df, long_event_threshold=5, long_event_recovery_days=2)
+        # ブロック 1/05〜1/09 (5日) + 回復 1/10〜1/11 (2日) = 7日除外
+        assert len(clean) == 8
+
+    def test_no_flag_columns_returns_ds_y_only(self):
+        """フラグカラムが存在しない場合は全行を ds/y 列のみで返す。"""
+        from predict import build_clean_series
+        df = pd.DataFrame({
+            "ds": pd.to_datetime(["2026-01-01", "2026-01-02"]),
+            "y": [65.0, 64.8],
+        })
+        clean = build_clean_series(df)
+        assert len(clean) == 2
+        assert list(clean.columns) == ["ds", "y"]
+
+    def test_returns_only_ds_y_columns(self):
+        """返り値には ds と y のみが含まれる (フラグカラムは除去される)。"""
+        from predict import build_clean_series
+        rows = [
+            {"log_date": f"2026-01-{d:02d}", "weight": 65.0,
+             "is_cheat_day": False, "is_travel_day": False}
+            for d in range(1, 6)
+        ]
+        df = _make_df(rows)
+        clean = build_clean_series(df)
+        assert list(clean.columns) == ["ds", "y"]
+
+    def test_constants_match_backtest_defaults(self):
+        """_LONG_EVENT_THRESHOLD と _LONG_EVENT_RECOVERY_DAYS が backtest.py のデフォルト値と一致する。"""
+        from predict import _LONG_EVENT_THRESHOLD, _LONG_EVENT_RECOVERY_DAYS
+        assert _LONG_EVENT_THRESHOLD == 5
+        assert _LONG_EVENT_RECOVERY_DAYS == 5
 
 
 # ── record 組み立てロジックのテスト ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `fetch_daily_logs()` now selects `is_cheat_day` / `is_travel_day` in addition to `log_date` / `weight`
- New `build_clean_series()` function mirrors `build_long_event_exclusion_dates()` in `backtest.py`: detects consecutive event blocks ≥ 5 days and removes the block body + 5-day recovery period from the NeuralProphet training set
- `main()` calls `build_clean_series()` before `run_model()` — raw `df` is kept only for the `MIN_ROWS` guard; clean `df_clean` is the sole input to the model
- Short events (< 5 consecutive days) are intentionally kept to preserve data volume
- Constants `_LONG_EVENT_THRESHOLD=5` / `_LONG_EVENT_RECOVERY_DAYS=5` match `backtest.py` defaults

## Test plan

- [x] 23 pytest tests pass (`python -m pytest ml-pipeline/test_predict.py -v`)
- [x] 8 new `TestBuildCleanSeries` tests covering: no events, short events (not excluded), long block excluded, travel flag, mixed flags merged, no flag columns, column output, constant values
- [x] Existing `TestFetchDailyLogsTransform` tests updated for new 4-column return type

Closes #485

🤖 Generated with [Claude Code](https://claude.com/claude-code)