### PR TITLE
fix: treat daily_logs fetch failure as unavailable in analytics freshness (#488)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -99,10 +99,16 @@ export default async function DashboardPage() {
 
   // MAX(updated_at) を使って stale 判定する。
   // MAX(log_date) ではなく MAX(updated_at) を使うことで、過去日の行修正でも stale を正しく検知できる。
-  const latestRawLogUpdatedAt = logs.reduce<string | null>((max, l) => {
-    if (!l.updated_at) return max;
-    return max === null || l.updated_at > max ? l.updated_at : max;
-  }, null);
+  //
+  // logsResult.kind === "error" のとき undefined を渡すことで、analytics の鮮度判定を
+  // "unavailable" に落とす。null（ログが0件の正常初期状態）と区別するため undefined を使う。
+  const latestRawLogUpdatedAt: string | null | undefined =
+    logsResult.kind === "error"
+      ? undefined
+      : logsResult.data.reduce<string | null>((max, l) => {
+          if (!l.updated_at) return max;
+          return max === null || l.updated_at > max ? l.updated_at : max;
+        }, null);
   const enrichedResult = await fetchEnrichedLogs(latestRawLogUpdatedAt);
 
   const enrichedRows = enrichedResult.rows;

--- a/src/lib/analytics/status.test.ts
+++ b/src/lib/analytics/status.test.ts
@@ -21,6 +21,13 @@ describe("getAnalyticsAvailability", () => {
     expect(r.status).toBe("unavailable");
   });
 
+  it("latestDependencyUpdatedAt が undefined (取得失敗) → unavailable", () => {
+    const r = getAnalyticsAvailability("2026-03-14T12:00:00Z", undefined);
+    expect(r.status).toBe("unavailable");
+    expect(r.lastUpdatedDate).toBeNull();
+    expect(r.staleDays).toBeNull();
+  });
+
   // ── fresh ─────────────────────────────────────────────────────────────────
 
   it("latestRawLogDate が null (ログなし) → fresh", () => {
@@ -127,6 +134,11 @@ describe("getEnrichedLogsAvailability", () => {
     expect(r.status).toBe("unavailable");
   });
 
+  it("latestRawLogDate が undefined (取得失敗) → unavailable", () => {
+    const r = getEnrichedLogsAvailability("2026-03-14T12:00:00Z", undefined);
+    expect(r.status).toBe("unavailable");
+  });
+
   it("stale 判定が伝播する", () => {
     const r = getEnrichedLogsAvailability("2026-03-12T00:00:00Z", "2026-03-14");
     expect(r.status).toBe("stale");
@@ -142,6 +154,11 @@ describe("getXgboostAvailability", () => {
 
   it("cacheUpdatedAt が null → unavailable", () => {
     const r = getXgboostAvailability(null, "2026-03-14");
+    expect(r.status).toBe("unavailable");
+  });
+
+  it("latestRawLogDate が undefined (取得失敗) → unavailable", () => {
+    const r = getXgboostAvailability("2026-03-14T12:00:00Z", undefined);
     expect(r.status).toBe("unavailable");
   });
 

--- a/src/lib/analytics/status.ts
+++ b/src/lib/analytics/status.ts
@@ -41,16 +41,20 @@ export function errorAvailability(): AnalyticsAvailability {
  * analytics_cache エントリの新鮮さを判定する汎用関数。
  *
  * @param cacheUpdatedAt             analytics_cache.updated_at (ISO 8601)。null = バッチ未実行
- * @param latestDependencyUpdatedAt  依存データの最新日 (YYYY-MM-DD)。null = 依存データなし
+ * @param latestDependencyUpdatedAt  依存データの最新日 (YYYY-MM-DD)。
+ *                                   null      = 依存データが存在しない（ログ0件の初期状態）→ fresh
+ *                                   undefined = 依存データの取得自体が失敗 → unavailable
  *
  * 判定ロジック:
  *   - cacheUpdatedAt が null → unavailable
+ *   - latestDependencyUpdatedAt が undefined（取得失敗）→ unavailable
+ *   - latestDependencyUpdatedAt が null（依存データなし）→ fresh
  *   - cacheUpdatedAt の日付部分 < latestDependencyUpdatedAt → stale
  *   - それ以外 → fresh
  */
 export function getAnalyticsAvailability(
   cacheUpdatedAt: string | null,
-  latestDependencyUpdatedAt: string | null
+  latestDependencyUpdatedAt: string | null | undefined
 ): AnalyticsAvailability {
   if (!cacheUpdatedAt) {
     return unavailableAvailability();
@@ -58,7 +62,13 @@ export function getAnalyticsAvailability(
 
   const lastUpdatedDate = cacheUpdatedAt.slice(0, 10); // "YYYY-MM-DD" (表示用)
 
-  if (!latestDependencyUpdatedAt) {
+  // undefined = 依存データの取得が失敗している。鮮度を判定できないため unavailable を返す。
+  // null = 依存データが存在しない正常な初期状態（ログ0件）。バッチは最新と見なして fresh を返す。
+  if (latestDependencyUpdatedAt === undefined) {
+    return unavailableAvailability();
+  }
+
+  if (latestDependencyUpdatedAt === null) {
     return { status: "fresh", lastUpdatedDate, staleDays: null };
   }
 
@@ -87,7 +97,7 @@ export function getAnalyticsAvailability(
  */
 export function getEnrichedLogsAvailability(
   cacheUpdatedAt: string | null,
-  latestRawLogDate: string | null
+  latestRawLogDate: string | null | undefined
 ): AnalyticsAvailability {
   return getAnalyticsAvailability(cacheUpdatedAt, latestRawLogDate);
 }
@@ -101,7 +111,7 @@ export function getEnrichedLogsAvailability(
  */
 export function getXgboostAvailability(
   cacheUpdatedAt: string | null,
-  latestRawLogDate: string | null
+  latestRawLogDate: string | null | undefined
 ): AnalyticsAvailability {
   return getAnalyticsAvailability(cacheUpdatedAt, latestRawLogDate);
 }

--- a/src/lib/queries/analytics.ts
+++ b/src/lib/queries/analytics.ts
@@ -98,10 +98,11 @@ function isValidFactorEntryShape(val: unknown): boolean {
  * @param latestRawLogUpdatedAt  daily_logs の MAX(updated_at) (ISO 8601)。stale 判定に使用する。
  *                               MAX(log_date) ではなく MAX(updated_at) を使うことで、
  *                               過去日の行修正でも stale を正しく検知できる。
- *                               null を渡した場合は cacheUpdatedAt のみで判定する。
+ *                               null      = ログが0件の初期状態（正常）→ fresh を維持
+ *                               undefined = daily_logs の取得が失敗している → unavailable を返す
  */
 export async function fetchEnrichedLogs(
-  latestRawLogUpdatedAt: string | null
+  latestRawLogUpdatedAt: string | null | undefined
 ): Promise<EnrichedLogsResult> {
   const supabase = createClient();
   const { data, error } = await supabase
@@ -172,10 +173,11 @@ export async function fetchEnrichedLogs(
  * @param latestRawLogUpdatedAt  daily_logs の MAX(updated_at) (ISO 8601)。stale 判定に使用する。
  *                               MAX(log_date) ではなく MAX(updated_at) を使うことで、
  *                               過去日の行修正でも stale を正しく検知できる。
- *                               null を渡した場合は cacheUpdatedAt のみで判定する。
+ *                               null      = ログが0件の初期状態（正常）→ fresh を維持
+ *                               undefined = daily_logs の取得が失敗している → unavailable を返す
  */
 export async function fetchFactorAnalysis(
-  latestRawLogUpdatedAt: string | null
+  latestRawLogUpdatedAt: string | null | undefined
 ): Promise<FactorAnalysisResult> {
   const supabase = createClient();
   const { data, error } = await supabase


### PR DESCRIPTION
## Summary

- `getAnalyticsAvailability()` の `latestDependencyUpdatedAt` 型を `string | null | undefined` に拡張
  - `undefined` = 依存データの取得が失敗 → `unavailable` を返す
  - `null` = ログが0件の正常初期状態 → 従来通り `fresh`（変更なし）
- `getEnrichedLogsAvailability` / `getXgboostAvailability` / `fetchEnrichedLogs` / `fetchFactorAnalysis` の型を連動更新
- `page.tsx`（ダッシュボード）: `logsResult.kind === "error"` のとき `undefined` を渡すよう修正。従来は `logs = []` フォールバックにより `reduce()` が `null` を返し、フェッチ失敗なのに `fresh` と表示されていた

## Test plan

- [x] `status.test.ts`: 24 tests pass（`undefined` ケース 3件追加）
- [x] `npx tsc --noEmit` エラーなし

Closes #488

🤖 Generated with [Claude Code](https://claude.com/claude-code)