### PR TITLE
fix: reject non-existent calendar dates in step-import parsers (#489)

### DIFF
--- a/src/app/api/step-import/parsers.test.ts
+++ b/src/app/api/step-import/parsers.test.ts
@@ -78,6 +78,44 @@ describe("parseCsv", () => {
     });
   });
 
+  it("存在しない日付 (2026-02-31) は invalidRows にカウントしてスキップする", () => {
+    const csv = "date,step_count\n2026-02-31,8000\n2024-01-16,5000";
+    const result = parseCsv(csv);
+    expect(result).toEqual({
+      ok: true,
+      records: [{ date: "2024-01-16", stepCount: 5000 }],
+      invalidRows: 1,
+    });
+  });
+
+  it("存在しない月 (2026-13-01) は invalidRows にカウントしてスキップする", () => {
+    const csv = "date,step_count\n2026-13-01,8000";
+    const result = parseCsv(csv);
+    expect(result).toEqual({ ok: true, records: [], invalidRows: 1 });
+  });
+
+  it("存在しない日 (2026-04-31) は invalidRows にカウントしてスキップする", () => {
+    const csv = "date,step_count\n2026-04-31,8000";
+    const result = parseCsv(csv);
+    expect(result).toEqual({ ok: true, records: [], invalidRows: 1 });
+  });
+
+  it("うるう年でない年の 2月29日 (2025-02-29) は invalidRows にカウントしてスキップする", () => {
+    const csv = "date,step_count\n2025-02-29,8000";
+    const result = parseCsv(csv);
+    expect(result).toEqual({ ok: true, records: [], invalidRows: 1 });
+  });
+
+  it("うるう年の 2月29日 (2024-02-29) は通過する", () => {
+    const csv = "date,step_count\n2024-02-29,8000";
+    const result = parseCsv(csv);
+    expect(result).toEqual({
+      ok: true,
+      records: [{ date: "2024-02-29", stepCount: 8000 }],
+      invalidRows: 0,
+    });
+  });
+
   it("step_count が float の行は invalidRows にカウントしてスキップする", () => {
     const csv = "date,step_count\n2024-01-15,8432.9\n2024-01-16,5000";
     const result = parseCsv(csv);
@@ -148,6 +186,29 @@ describe("parseJson", () => {
     expect(result).toEqual({
       ok: true,
       records: [{ date: "2024-01-15", stepCount: 8432 }],
+      invalidRows: 0,
+    });
+  });
+
+  it("存在しない日付 (2026-02-31) は invalidRows にカウントしてスキップする", () => {
+    const result = parseJson('[{"date":"2026-02-31","step_count":8000},{"date":"2024-01-16","step_count":5000}]');
+    expect(result).toEqual({
+      ok: true,
+      records: [{ date: "2024-01-16", stepCount: 5000 }],
+      invalidRows: 1,
+    });
+  });
+
+  it("うるう年でない年の 2月29日 (2025-02-29) は invalidRows にカウントしてスキップする", () => {
+    const result = parseJson('[{"date":"2025-02-29","step_count":8000}]');
+    expect(result).toEqual({ ok: true, records: [], invalidRows: 1 });
+  });
+
+  it("うるう年の 2月29日 (2024-02-29) は通過する", () => {
+    const result = parseJson('[{"date":"2024-02-29","step_count":8000}]');
+    expect(result).toEqual({
+      ok: true,
+      records: [{ date: "2024-02-29", stepCount: 8000 }],
       invalidRows: 0,
     });
   });

--- a/src/app/api/step-import/parsers.ts
+++ b/src/app/api/step-import/parsers.ts
@@ -17,6 +17,19 @@ export type ParseResult =
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
+/**
+ * YYYY-MM-DD 形式の文字列がカレンダー上に実在する日付かどうかを検証する。
+ *
+ * DATE_RE によるフォーマットチェック通過後に呼ぶことを前提とする。
+ * new Date("YYYY-MM-DD") は UTC として解釈されるため、
+ * `d.toISOString().slice(0, 10)` が元の文字列と一致するかで存在確認できる。
+ * 2026-02-31 や 2026-13-01 は Invalid Date になる、または繰り上がった日付になるため不一致として弾かれる。
+ */
+function isCalendarDate(dateStr: string): boolean {
+  const d = new Date(dateStr);
+  return !isNaN(d.getTime()) && d.toISOString().slice(0, 10) === dateStr;
+}
+
 // ── parseCsv ─────────────────────────────────────────────────────────────────
 
 /**
@@ -54,7 +67,7 @@ export function parseCsv(text: string): ParseResult {
     const date = line.slice(0, commaIdx).trim();
     const stepStr = line.slice(commaIdx + 1).trim();
 
-    if (!DATE_RE.test(date)) { invalidRows++; continue; }
+    if (!DATE_RE.test(date) || !isCalendarDate(date)) { invalidRows++; continue; }
 
     const stepCount = Number(stepStr);
     if (!Number.isInteger(stepCount) || stepCount < 0 || isNaN(stepCount)) { invalidRows++; continue; }
@@ -104,7 +117,7 @@ export function parseJson(text: string): ParseResult {
     const obj = item as Record<string, unknown>;
 
     const date = typeof obj["date"] === "string" ? obj["date"].trim() : "";
-    if (!DATE_RE.test(date)) { invalidRows++; continue; }
+    if (!DATE_RE.test(date) || !isCalendarDate(date)) { invalidRows++; continue; }
 
     const stepRaw = obj["step_count"];
 


### PR DESCRIPTION
## Summary

- `isCalendarDate()` ヘルパーを追加: `new Date(dateStr).toISOString().slice(0,10) !== dateStr` で存在しない日付を検出
- `parseCsv` / `parseJson` 両方で `DATE_RE` チェック通過後に `isCalendarDate()` を追加適用
- `2026-02-31` などの存在しない日付が `invalidRows` にカウントされるようになった（従来は `skippedCount` に無言でカウントされていた）

## 修正前の挙動

```
input:  2026-02-31,8000
result: invalidRows: 0 / skippedCount: 1（「体重ログがない日」扱い）
```

## 修正後の挙動

```
input:  2026-02-31,8000
result: invalidRows: 1 / skippedCount: 0（他の不正行と同様にスキップ）
```

## Test plan

- [x] 33 tests pass（8件追加: 存在しない日付 / 月 / 非うるう年2月29日 / うるう年2月29日）
- [x] `npx tsc --noEmit` エラーなし

Closes #489

🤖 Generated with [Claude Code](https://claude.com/claude-code)