### PR TITLE
fix: allow decimal input for temporary food calories and PFC

### DIFF
--- a/src/components/meal/TempFoodForm.test.ts
+++ b/src/components/meal/TempFoodForm.test.ts
@@ -1,0 +1,67 @@
+import { parseNonNegative } from "./TempFoodForm";
+
+describe("parseNonNegative", () => {
+  // ── 空文字 / 空白 → null ─────────────────────────────────────────────────
+
+  it("空文字は null を返す", () => {
+    expect(parseNonNegative("")).toBeNull();
+  });
+
+  it("空白のみも null を返す", () => {
+    expect(parseNonNegative("  ")).toBeNull();
+  });
+
+  // ── 整数 ─────────────────────────────────────────────────────────────────
+
+  it("整数はそのまま返す", () => {
+    expect(parseNonNegative("350")).toBe(350);
+  });
+
+  it("0 はそのまま返す", () => {
+    expect(parseNonNegative("0")).toBe(0);
+  });
+
+  // ── 小数 ─────────────────────────────────────────────────────────────────
+
+  it("小数 10.5 を正しく返す", () => {
+    expect(parseNonNegative("10.5")).toBe(10.5);
+  });
+
+  it("小数 0.5 を正しく返す", () => {
+    expect(parseNonNegative("0.5")).toBe(0.5);
+  });
+
+  it("小数 100.25 を正しく返す", () => {
+    expect(parseNonNegative("100.25")).toBe(100.25);
+  });
+
+  it("末尾小数点 '10.' は 10 として解釈する（Number('10.') === 10）", () => {
+    // type="text" のとき入力途中の '10.' が state に残るが、
+    // Number('10.') === 10 なので有効値として扱われる（バリデーション通過）
+    expect(parseNonNegative("10.")).toBe(10);
+  });
+
+  // ── 負数 → null ──────────────────────────────────────────────────────────
+
+  it("負数は null を返す", () => {
+    expect(parseNonNegative("-1")).toBeNull();
+  });
+
+  it("-0.5 は null を返す", () => {
+    expect(parseNonNegative("-0.5")).toBeNull();
+  });
+
+  // ── 非数値 → null ────────────────────────────────────────────────────────
+
+  it("アルファベット文字列は null を返す", () => {
+    expect(parseNonNegative("abc")).toBeNull();
+  });
+
+  it("Infinity は null を返す", () => {
+    expect(parseNonNegative("Infinity")).toBeNull();
+  });
+
+  it("小数点のみ '.' は null を返す（Number('.') === NaN）", () => {
+    expect(parseNonNegative(".")).toBeNull();
+  });
+});

--- a/src/components/meal/TempFoodForm.tsx
+++ b/src/components/meal/TempFoodForm.tsx
@@ -24,7 +24,7 @@ const emptyForm = {
 type FormField = keyof typeof emptyForm;
 
 /** 数値フィールドのバリデーション: 空文字 NG、負数 NG、非数値 NG。小数は保持する。 */
-function parseNonNegative(value: string): number | null {
+export function parseNonNegative(value: string): number | null {
   if (value.trim() === "") return null;
   const n = Number(value);
   if (!Number.isFinite(n) || n < 0) return null;
@@ -144,9 +144,8 @@ export function TempFoodForm({ onAdd }: TempFoodFormProps) {
             <label htmlFor="temp-food-calories" className="mb-1 block text-[11px] text-slate-400 dark:text-slate-500">カロリー (kcal)</label>
             <input
               id="temp-food-calories"
-              type="number"
+              type="text"
               inputMode="decimal"
-              min={0}
               placeholder="350"
               value={form.calories}
               onChange={(e) => setField("calories", e.target.value)}
@@ -158,9 +157,8 @@ export function TempFoodForm({ onAdd }: TempFoodFormProps) {
             <label htmlFor="temp-food-protein" className="mb-1 block text-[11px] text-slate-400 dark:text-slate-500">たんぱく質 (g)</label>
             <input
               id="temp-food-protein"
-              type="number"
+              type="text"
               inputMode="decimal"
-              min={0}
               placeholder="25"
               value={form.protein}
               onChange={(e) => setField("protein", e.target.value)}
@@ -172,9 +170,8 @@ export function TempFoodForm({ onAdd }: TempFoodFormProps) {
             <label htmlFor="temp-food-fat" className="mb-1 block text-[11px] text-slate-400 dark:text-slate-500">脂質 (g)</label>
             <input
               id="temp-food-fat"
-              type="number"
+              type="text"
               inputMode="decimal"
-              min={0}
               placeholder="12"
               value={form.fat}
               onChange={(e) => setField("fat", e.target.value)}
@@ -186,9 +183,8 @@ export function TempFoodForm({ onAdd }: TempFoodFormProps) {
             <label htmlFor="temp-food-carbs" className="mb-1 block text-[11px] text-slate-400 dark:text-slate-500">炭水化物 (g)</label>
             <input
               id="temp-food-carbs"
-              type="number"
+              type="text"
               inputMode="decimal"
-              min={0}
               placeholder="30"
               value={form.carbs}
               onChange={(e) => setField("carbs", e.target.value)}


### PR DESCRIPTION
## 概要

一時食品入力フォーム（TempFoodForm）のカロリー・P/F/C 欄で小数が入力できない問題を修正。

## 不具合原因

`type="number"` の input は、`10.`（末尾小数点）のような入力途中の不完全な数値を **ブラウザが無効値と判定** し、`e.target.value` として `""` を返す。この `""` が state に書き戻されるため、小数点を打った瞬間に入力内容が消えていた。

## 変更内容

- `src/components/meal/TempFoodForm.tsx`
  - calories / protein / fat / carbs の 4 フィールド: `type="number"` → `type="text"` に変更
  - `inputMode="decimal"` は維持（モバイルで数値キーボードを出すため）
  - `min={0}` 属性を削除（`type="text"` では無効なため。バリデーションは `parseNonNegative()` が担保）
  - `parseNonNegative` を `export` に変更（テスト可能にするため）
- `src/components/meal/TempFoodForm.test.ts` (新規)
  - `parseNonNegative` の単体テスト 13 件（整数・小数・末尾小数点・負数・非数値）

## 判断理由

- `parseNonNegative` はもともと `Number(value)` で小数を正しく扱える実装になっていた
- state も `string` 管理であり、変更は input の `type` 属性の切り替えのみで済む
- `grams` フィールドは任意入力であり、元々 `type="number"` のままでも問題が顕在化しにくいためスコープ外とした

## テスト / 確認内容

- `parseNonNegative` 単体テスト 13 件: 全パス
- 全テストスイート 54 件 / 1305 件: 全パス
- TypeScript 型チェック: エラーなし

## 補足

- 他フォーム（FoodPicker 等）への横展開は本 Issue のスコープ外
- `grams` フィールドについても同様の問題が潜在するが、任意フィールドかつ今回の Issue では対象外

Closes #492