### PR TITLE
feat: add PFC-derived calorie helper to new food form

### DIFF
--- a/src/components/foods/FoodTable.tsx
+++ b/src/components/foods/FoodTable.tsx
@@ -282,6 +282,19 @@ export function FoodTable({ initialFoods }: FoodTableProps) {
               )}
             </div>
           </div>
+          {/* PFC由来kcal 参考表示 */}
+          {(() => {
+            const p = parseFloat(form.protein);
+            const f = parseFloat(form.fat);
+            const c = parseFloat(form.carbs);
+            if (!Number.isFinite(p) || !Number.isFinite(f) || !Number.isFinite(c)) return null;
+            const pfcKcal = Math.round(p * 4 + f * 9 + c * 4);
+            return (
+              <p className="mt-2 text-xs text-slate-400 dark:text-slate-500">
+                PFC由来kcal: <span className="font-medium text-slate-600 dark:text-slate-300">{pfcKcal} kcal</span>
+              </p>
+            );
+          })()}
           {error && <p className="mt-2 text-xs text-rose-500">{error}</p>}
           <div className="mt-3 flex items-center justify-end gap-2">
             {saveSuccess && (


### PR DESCRIPTION
## 概要

新規食品追加フォーム（FoodTable）で P/F/C を入力すると「PFC由来kcal: N kcal」が補助文として表示されるようにした。

## 変更内容

- `src/components/foods/FoodTable.tsx`
  - 追加フォームのグリッドとエラー表示の間に PFC 由来 kcal の参考表示を追加
  - P/F/C がすべて有効な数値の場合のみ表示（いずれかが未入力・不正値なら非表示）
  - 計算式: P×4 + F×9 + C×4（整数に丸め）
  - kcal 入力欄の値は一切変更しない

## 実装方針

フォームグリッド直下に IIFE パターンで計算・表示を行う。`parseFloat` で string → number に変換し、`Number.isFinite` で入力完全性を確認する。

## 判断理由

- `SettingsForm.tsx` に同一パターン（`calcPfcDerivedKcal`）が既存実装として存在するため、ロジックと文言をそのまま踏襲した
- 補助表示のみの追加で保存ロジック・バリデーション・DB スキーマへの変更は不要
- ローカル IIFE で完結するため、新たな関数エクスポートや共通化は不要（同一ファイル内の 1 箇所にしか使わないため）

## テスト / 確認内容

- 既存 `FoodTable.integration.test.tsx` 全件パス（23 件）
- TypeScript 型チェック: エラーなし

## 補足

- 一時食品フォーム（TempFoodForm）への横展開はスコープ外
- PFC と kcal の整合性警告（SettingsForm にある `pfcConsistencyWarning`）は今回追加していない（Issue の要求範囲外）

Closes #494