### PR TITLE
feat: add PFC-derived calorie helper to temp food form

### DIFF
--- a/src/components/meal/TempFoodForm.tsx
+++ b/src/components/meal/TempFoodForm.tsx
@@ -193,6 +193,19 @@ export function TempFoodForm({ onAdd }: TempFoodFormProps) {
             {errors.carbs && <p className="mt-1 text-xs text-rose-500">{errors.carbs}</p>}
           </div>
         </div>
+        {/* PFC由来kcal 参考表示 */}
+        {(() => {
+          const p = parseFloat(form.protein);
+          const f = parseFloat(form.fat);
+          const c = parseFloat(form.carbs);
+          if (!Number.isFinite(p) || !Number.isFinite(f) || !Number.isFinite(c)) return null;
+          const pfcKcal = Math.round(p * 4 + f * 9 + c * 4);
+          return (
+            <p className="mt-2 text-xs text-amber-700/70 dark:text-amber-500/70">
+              PFC由来kcal: <span className="font-medium">{pfcKcal} kcal</span>
+            </p>
+          );
+        })()}
       </div>
 
       <button


### PR DESCRIPTION
## 概要

一時食品フォーム（TempFoodForm）で P/F/C を入力すると「PFC由来kcal: N kcal」が補助文として表示されるようにした。

## 変更内容

- `src/components/meal/TempFoodForm.tsx`
  - 栄養値グリッドの直下（submit ボタンの上）に PFC 由来 kcal の参考表示を追加
  - P/F/C がすべて有効な数値の場合のみ表示（いずれかが未入力・不正値なら非表示）
  - 計算式: P×4 + F×9 + C×4（整数に丸め）
  - kcal 入力欄の値は一切変更しない

## 実装方針

FoodTable.tsx（#495）および SettingsForm.tsx と同一パターン。IIFE で `parseFloat` + `Number.isFinite` により入力完全性を確認してから表示する。テキスト色はフォームのアンバーテーマ（`text-amber-700/70 dark:text-amber-500/70`）に合わせた。

## 判断理由

- FoodTable・SettingsForm に同一パターンが既存実装として存在するため、ロジックと文言をそのまま踏襲
- 補助表示のみの追加で保存ロジック・バリデーション・DB スキーマへの変更は不要
- テキスト色だけフォームのアンバーテーマに合わせることで、TempFoodForm 固有の「一時食品」の文脈に沿った視覚的統一感を維持

## テスト / 確認内容

- `src/components/meal/` 配下テスト 52 件: 全パス
- TypeScript 型チェック: エラーなし

## 補足

- FoodTable の補助表示は `text-slate-400 dark:text-slate-500` だが、TempFoodForm はアンバーテーマのため色を変更している

Closes #496