### PR TITLE
fix: correct wake-date sleep save routing when next-day record absent (#511)

### DIFF
--- a/src/app/actions/__tests__/saveDailyLog.test.ts
+++ b/src/app/actions/__tests__/saveDailyLog.test.ts
@@ -755,7 +755,11 @@ describe("saveDailyLog — bed_time 保存 (#501)", () => {
   // ── 両方が同一 payload にある場合 ──────────────────────────────────────────
 
   test("前日夜就寝は翌日の起床日レコードへ保存される (23:00→07:00=8h)", async () => {
-    const capture = makeRpcMock();
+    // 翌日レコードが存在する場合のみシフトが発生する (#511 fix)
+    const capture = makeRpcMock(undefined, {
+      "2026-04-07": { bed_time: null, weigh_in_time: null },
+      "2026-04-08": { bed_time: null, weigh_in_time: null },
+    });
     const result = await saveDailyLog({
       log_date: "2026-04-07",
       bed_time: "23:00",
@@ -765,6 +769,28 @@ describe("saveDailyLog — bed_time 保存 (#501)", () => {
     expect(result.ok).toBe(true);
     expect(capture.calls).toHaveLength(1);
     expect(capture.calls[0]?.p_log_date).toBe("2026-04-08");
+    expect(capture.calls[0]?.p_fields.bed_time).toBe("23:00");
+    expect(capture.calls[0]?.p_fields.weigh_in_time).toBe("07:00");
+    expect(capture.calls[0]?.p_fields.sleep_hours).toBe(8.0);
+  });
+
+  test("翌日レコードが存在しない場合、overnight ペアでも当日に保存される (new_log_requires_weight を防ぐ)", async () => {
+    // 4/8 が存在しない → シフトせず 4/7 に保存 (#511 fix)
+    const capture = makeRpcMock(undefined, {
+      "2026-04-07": null,
+      "2026-04-08": null,
+    });
+    const result = await saveDailyLog({
+      log_date: "2026-04-07",
+      weight: 70.0,
+      bed_time: "23:00",
+      weigh_in_time: "07:00",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(capture.calls).toHaveLength(1);
+    // 翌日レコードなし → シフトしない → 当日 (4/7) に保存
+    expect(capture.calls[0]?.p_log_date).toBe("2026-04-07");
     expect(capture.calls[0]?.p_fields.bed_time).toBe("23:00");
     expect(capture.calls[0]?.p_fields.weigh_in_time).toBe("07:00");
     expect(capture.calls[0]?.p_fields.sleep_hours).toBe(8.0);
@@ -914,8 +940,12 @@ describe("saveDailyLog — bed_time 保存 (#501)", () => {
     expect("sleep_hours" in (capture.p_fields ?? {})).toBe(false);
   });
 
-  test("睡眠系と食事系を同時保存しても、睡眠系だけ翌日の起床日レコードへ分離される", async () => {
-    const capture = makeRpcMock();
+  test("睡眠系と食事系を同時保存しても、翌日レコードがあれば睡眠系だけ翌日の起床日レコードへ分離される", async () => {
+    // 翌日レコードが存在する場合のみシフトが発生する (#511 fix)
+    const capture = makeRpcMock(undefined, {
+      "2026-04-07": { bed_time: null, weigh_in_time: null },
+      "2026-04-08": { bed_time: null, weigh_in_time: null },
+    });
     const result = await saveDailyLog({
       log_date: "2026-04-07",
       calories: 2100,
@@ -935,6 +965,31 @@ describe("saveDailyLog — bed_time 保存 (#501)", () => {
     expect(capture.calls[1]?.p_fields.bed_time).toBe("23:30");
     expect(capture.calls[1]?.p_fields.weigh_in_time).toBe("07:00");
     expect(capture.calls[1]?.p_fields.sleep_hours).toBe(7.5);
+  });
+
+  test("睡眠系と食事系を同時保存・翌日レコードなしの場合は sleep も当日にまとめて保存される", async () => {
+    // 翌日レコードなし → シフトせず当日にまとめる (#511 fix: 部分保存エラーも防ぐ)
+    const capture = makeRpcMock(undefined, {
+      "2026-04-07": { bed_time: null, weigh_in_time: null },
+      "2026-04-08": null,
+    });
+    const result = await saveDailyLog({
+      log_date: "2026-04-07",
+      calories: 2100,
+      last_meal_end_time: "22:00",
+      bed_time: "23:30",
+      weigh_in_time: "07:00",
+    });
+
+    expect(result.ok).toBe(true);
+    // 翌日レコードなし → 1回のRPCで当日(4/7)にまとめる
+    expect(capture.calls).toHaveLength(1);
+    expect(capture.calls[0]?.p_log_date).toBe("2026-04-07");
+    expect(capture.calls[0]?.p_fields.calories).toBe(2100);
+    expect(capture.calls[0]?.p_fields.last_meal_end_time).toBe("22:00");
+    expect(capture.calls[0]?.p_fields.bed_time).toBe("23:30");
+    expect(capture.calls[0]?.p_fields.weigh_in_time).toBe("07:00");
+    expect(capture.calls[0]?.p_fields.sleep_hours).toBe(7.5);
   });
 
   test("片側更新で合成後に異常値になる場合 sleep_hours は更新されない", async () => {

--- a/src/app/actions/saveDailyLog.ts
+++ b/src/app/actions/saveDailyLog.ts
@@ -278,10 +278,16 @@ function deriveSleepSavePlan(
     deriveSleepHours(currentRow.bed_time, currentRow.weigh_in_time) !== null &&
     timeIsOnOrBefore(currentRow.weigh_in_time, currentRow.bed_time)
   );
+  // 翌日レコードが存在しない場合はシフトしない。
+  // weighInPayload=true のとき nextWeigh はペイロード値を使うため、
+  // nextRow=null でも deriveSleepHours が有効値を返してしまう。
+  // 翌日が存在しないままシフトすると save_daily_log_partial が
+  // 新規 INSERT を試みて new_log_requires_weight エラーを起こす。
   const shouldShiftToNextDay = (
     input.bed_time !== undefined &&
     input.bed_time !== null &&
     nextWeigh !== null &&
+    nextRow !== null &&
     deriveSleepHours(input.bed_time, nextWeigh) !== null &&
     timeIsOnOrBefore(nextWeigh, input.bed_time) &&
     !currentRowAlreadyHasWakeDateOvernightPair


### PR DESCRIPTION
## 概要

#511 の調査 + 修正を含む PR。

**親 Issue**: #500 / **保存基盤**: #501 / **意味論整理**: #507 / **前回実装**: #509 (PR #510)

---

## 調査結果

### 再現ケース一覧

| ケース | 入力 | 4/8 の有無 | 期待 | 実際 |
|---|---|---|---|---|
| A | 4/7 screen, bed=23:30, weigh=07:00 | 4/8 あり | 4/8 に保存 | ✓ 正常 |
| **B** | **4/7 screen, bed=23:30, weigh=07:00** | **4/8 なし** | **4/8 に保存** | ❌ エラー |
| C | 4/8 screen, bed=01:30, weigh=08:00 | — | 4/8 に保存 | ✓ 正常 |
| D | 4/8 screen, bed=04:00, weigh=10:00 | — | 4/8 に保存 | ✓ 正常 |
| E | 4/8 に overnight ペアあり、weigh のみ更新 | — | 4/8 のまま更新 | ✓ 正常 |
| **F** | **4/7 screen, calories+bed+weigh, 4/8 なし** | **4/8 なし** | **両方 4/7 に保存** | ❌ 部分保存エラー |

### 原因箇所

`saveDailyLog.ts` の `deriveSleepSavePlan` 内 `shouldShiftToNextDay` 条件式。

```ts
// 問題: weighInPayload=true のとき nextWeigh はペイロード値を使う
const nextWeigh = weighInPayload ? input.weigh_in_time ?? null : nextRow?.weigh_in_time ?? null;

const shouldShiftToNextDay = (
  input.bed_time !== undefined &&
  input.bed_time !== null &&
  nextWeigh !== null &&          // ← weighInPayload=true なら nextRow=null でも通過してしまう
  deriveSleepHours(input.bed_time, nextWeigh) !== null &&
  timeIsOnOrBefore(nextWeigh, input.bed_time) &&
  !currentRowAlreadyHasWakeDateOvernightPair
);
```

`weighInPayload=true` かつ `bed_time > weigh_in_time`（overnight ペア）の場合:
- `nextWeigh` はペイロード値（`"07:00"`）を使うため `nextRow = null`（4/8 不存在）でも `nextWeigh !== null` を通過
- `shouldShiftToNextDay = true` → sleep RPC を 4/8 に対して呼ぶ
- 4/8 は存在しないため `save_daily_log_partial` が INSERT を試みて `new_log_requires_weight` 例外を発生させる
- ユーザーには「新しい日付を作成するには体重の入力が必要です」と表示され、意味が分からない

食事 + sleep の同時保存ケース（ケース F）は食事 RPC（4/7）が先に成功するため、部分保存状態になる。

### テストが通っていた理由

既存テスト `"前日夜就寝は翌日の起床日レコードへ保存される"` は `makeRpcMock()` でモックしており、RPC は常に成功を返すため `new_log_requires_weight` を再現できていなかった。

---

## 修正内容

`shouldShiftToNextDay` に `nextRow !== null` 条件を追加。翌日レコードが存在しない場合はシフトせず、当日（入力日）に保存する。

```ts
const shouldShiftToNextDay = (
  input.bed_time !== undefined &&
  input.bed_time !== null &&
  nextWeigh !== null &&
  nextRow !== null &&   // ← 追加: 翌日レコードが存在する場合のみシフト
  deriveSleepHours(input.bed_time, nextWeigh) !== null &&
  timeIsOnOrBefore(nextWeigh, input.bed_time) &&
  !currentRowAlreadyHasWakeDateOvernightPair
);
```

**フォールバック動作**: 翌日レコードが存在しない場合、overnight ペアでも当日（4/7）に `{ bed_time, weigh_in_time, sleep_hours }` を保存する。エラーなし・データ消失なし。

**副次効果**: 食事 + sleep 同時保存ケースで 4/8 が存在しない場合、2回の RPC（4/7+4/8）ではなく 1回の RPC（4/7 にまとめ）になる。部分保存問題も解消。

---

## テスト確認

- 既存テスト 2件を更新: `nextRow` を明示的に non-null で渡すよう修正（より現実的なモック）
- 新規テスト 2件追加: `nextRow=null` のフォールバック動作を確認
- 全 1353 テスト通過

---

## スコープ外

- 起床日基準の UI 表示改善（4/7 screen で 4/8 に保存した sleep データが見えない問題）
- sleep-only な新規レコード作成を許可する RPC 変更
- 既存データの日付再配置

Closes #511