### PR TITLE
feat: drop weigh_in_time column, replace all references with sleep_sessions.wake_at (#526)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,20 +139,20 @@ body-comp-tracker-v2/
 
 - `daily_logs` — log_date(PK), weight, calories, protein, fat, carbs, note,
   sleep_hours, had_bowel_movement, training_type, work_mode,
-  last_meal_end_time, weigh_in_time, bed_time, step_count
+  last_meal_end_time, bed_time, step_count
   - `had_bowel_movement` は `BOOLEAN DEFAULT NULL`（三状態: null=未記録 / false=便通なし / true=便通あり）
   - leg_flag は派生値（deriveLegFlag のみ定義源）。直接書き込まない
   - `sleep_hours` は `sleep_sessions` の `bed_at` / `wake_at` から DB トリガー（`trg_sync_sleep_hours`）が自動同期する **projection 値**。直接書き込まない（定義源はトリガー、`deriveSleepHours()` ではない）。`is_poor_sleep` カラムは削除済み（#338）
   - `last_meal_end_time` は TIME 型・nullable。空腹時間算出用（#435）。
-  - `weigh_in_time` は TIME 型・nullable。**projection 値**。`sleep_sessions.wake_at` から DB トリガー（`trg_sync_weigh_in_time`）が自動同期する（#526）。ユーザーは手動入力不可。空腹時間算出（`calcFastingHours`）が透過的に参照する。
+  - `weigh_in_time` は **#526 で廃止済み**。起床時刻は `sleep_sessions.wake_at` を直接参照する。`calcFastingHours` は `sleepSessions` prop 経由で `wake_at` を受け取る
   - `bed_time` は TIME 型・nullable。**移行期カラム（廃止方向）**。#515 で睡眠の source of truth は `sleep_sessions` へ移行済み。MealLogger からの新規書き込みは行わない。廃止 migration は将来の別 Issue で作成予定
   - `step_count` は INTEGER 型・nullable。Apple Health インポート専用（#436）。手動入力 UI なし
   - `work_mode` の DB CHECK 制約は `off/office/remote/active/travel/other` の 6 値を許容するが、
     フロントエンド（`src/lib/utils/trainingType.ts`）では `off/office/remote` の 3 値のみ定義している。
     `active/travel/other` はフロント UI・CSV import・表示整形で現状扱われない（将来拡張余地）
   - **`save_daily_log_partial` RPC を `CREATE OR REPLACE` で再定義する際は、廃止済みカラム
-    （`is_poor_sleep` など）を誤って含めないこと。過去 migration のコピー元に廃止前のコードが
-    残っている場合があるため、最新 migration を参照すること（#442 で発生した regression）**
+    （`is_poor_sleep` / `weigh_in_time` など）を誤って含めないこと。過去 migration のコピー元に廃止前のコードが
+    残っている場合があるため、最新 migration を参照すること（#442 / #526 で発生した regression）**
 - `food_master` — name(PK), protein, fat, carbs, calories, category
 - `menu_master` — name(PK), recipe(JSONB)
 - `settings` — key(PK), value_num, value_str

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,7 +143,8 @@ body-comp-tracker-v2/
   - `had_bowel_movement` は `BOOLEAN DEFAULT NULL`（三状態: null=未記録 / false=便通なし / true=便通あり）
   - leg_flag は派生値（deriveLegFlag のみ定義源）。直接書き込まない
   - `sleep_hours` は `sleep_sessions` の `bed_at` / `wake_at` から DB トリガー（`trg_sync_sleep_hours`）が自動同期する **projection 値**。直接書き込まない（定義源はトリガー、`deriveSleepHours()` ではない）。`is_poor_sleep` カラムは削除済み（#338）
-  - `last_meal_end_time` / `weigh_in_time` は TIME 型・nullable。空腹時間算出用（#435）。`weigh_in_time` は睡眠の `wake_at` とは独立したフィールド
+  - `last_meal_end_time` は TIME 型・nullable。空腹時間算出用（#435）。
+  - `weigh_in_time` は TIME 型・nullable。**projection 値**。`sleep_sessions.wake_at` から DB トリガー（`trg_sync_weigh_in_time`）が自動同期する（#526）。ユーザーは手動入力不可。空腹時間算出（`calcFastingHours`）が透過的に参照する。
   - `bed_time` は TIME 型・nullable。**移行期カラム（廃止方向）**。#515 で睡眠の source of truth は `sleep_sessions` へ移行済み。MealLogger からの新規書き込みは行わない。廃止 migration は将来の別 Issue で作成予定
   - `step_count` は INTEGER 型・nullable。Apple Health インポート専用（#436）。手動入力 UI なし
   - `work_mode` の DB CHECK 制約は `off/office/remote/active/travel/other` の 6 値を許容するが、

--- a/src/app/actions/__tests__/saveDailyLog.test.ts
+++ b/src/app/actions/__tests__/saveDailyLog.test.ts
@@ -751,31 +751,36 @@ describe("buildUpdatePayload — bed_time (#501)", () => {
 // saveDailyLog — bed_time / sleep_hours 自動算出 (#501)
 // ════════════════════════════════════════════════════════════════════════════
 
-describe("saveDailyLog — bed_time 保存 (#501)", () => {
-  // ── 両方が同一 payload にある場合 ──────────────────────────────────────────
+describe("saveDailyLog — bed_time 保存 (#501, #526)", () => {
+  // #526: weigh_in_time は user input から削除。sleep_sessions.wake_at からの DB トリガーで
+  // 自動同期される。saveDailyLog は weigh_in_time を payload に含まない。
+  // sleep_hours 算出は user の bed_time + DB の weigh_in_time (projection 値) から行う。
+
+  // ── 前日夜就寝（overnight シフト）──────────────────────────────────────────
 
   test("前日夜就寝は翌日の起床日レコードへ保存される (23:00→07:00=8h)", async () => {
-    // 翌日レコードが存在する場合のみシフトが発生する (#511 fix)
+    // DB "2026-04-08" に weigh_in_time: "07:00" がある → 翌日シフト + sleep_hours 算出
     const capture = makeRpcMock(undefined, {
       "2026-04-07": { bed_time: null, weigh_in_time: null },
-      "2026-04-08": { bed_time: null, weigh_in_time: null },
+      "2026-04-08": { bed_time: null, weigh_in_time: "07:00" },
     });
     const result = await saveDailyLog({
       log_date: "2026-04-07",
       bed_time: "23:00",
-      weigh_in_time: "07:00",
     });
 
     expect(result.ok).toBe(true);
     expect(capture.calls).toHaveLength(1);
     expect(capture.calls[0]?.p_log_date).toBe("2026-04-08");
     expect(capture.calls[0]?.p_fields.bed_time).toBe("23:00");
-    expect(capture.calls[0]?.p_fields.weigh_in_time).toBe("07:00");
+    // #526: weigh_in_time は DB トリガー専管 → payload に含まれない
+    expect("weigh_in_time" in (capture.calls[0]?.p_fields ?? {})).toBe(false);
     expect(capture.calls[0]?.p_fields.sleep_hours).toBe(8.0);
   });
 
-  test("翌日レコードが存在しない場合、overnight ペアでも当日に保存される (new_log_requires_weight を防ぐ)", async () => {
+  test("翌日レコードが存在しない場合、overnight 時刻でも当日に保存される (new_log_requires_weight を防ぐ)", async () => {
     // 4/8 が存在しない → シフトせず 4/7 に保存 (#511 fix)
+    // DB の weigh_in_time がないため sleep_hours は算出不能
     const capture = makeRpcMock(undefined, {
       "2026-04-07": null,
       "2026-04-08": null,
@@ -784,52 +789,65 @@ describe("saveDailyLog — bed_time 保存 (#501)", () => {
       log_date: "2026-04-07",
       weight: 70.0,
       bed_time: "23:00",
-      weigh_in_time: "07:00",
     });
 
     expect(result.ok).toBe(true);
     expect(capture.calls).toHaveLength(1);
     // 翌日レコードなし → シフトしない → 当日 (4/7) に保存
     expect(capture.calls[0]?.p_log_date).toBe("2026-04-07");
+    expect(capture.calls[0]?.p_fields.weight).toBe(70.0);
     expect(capture.calls[0]?.p_fields.bed_time).toBe("23:00");
-    expect(capture.calls[0]?.p_fields.weigh_in_time).toBe("07:00");
-    expect(capture.calls[0]?.p_fields.sleep_hours).toBe(8.0);
+    // weigh_in_time が DB にない → sleep_hours 算出不能
+    expect("sleep_hours" in (capture.calls[0]?.p_fields ?? {})).toBe(false);
+    expect("weigh_in_time" in (capture.calls[0]?.p_fields ?? {})).toBe(false);
   });
 
+  // ── 当日就寝（シフトなし）── ──────────────────────────────────────────────
+
   test("当日深夜就寝は同日の起床日レコードへ保存される (01:30→08:00=6.5h)", async () => {
-    const capture = makeRpcMock();
+    // DB に weigh_in_time: "08:00" がある → 同日に sleep_hours 算出
+    const capture = makeRpcMock(undefined, {
+      "2026-04-08": { bed_time: null, weigh_in_time: "08:00" },
+      "2026-04-09": null,
+    });
     const result = await saveDailyLog({
       log_date: "2026-04-08",
       bed_time: "01:30",
-      weigh_in_time: "08:00",
     });
 
     expect(result.ok).toBe(true);
     expect(capture.calls).toHaveLength(1);
     expect(capture.calls[0]?.p_log_date).toBe("2026-04-08");
     expect(capture.calls[0]?.p_fields.sleep_hours).toBe(6.5);
+    expect("weigh_in_time" in (capture.calls[0]?.p_fields ?? {})).toBe(false);
   });
 
   test("早朝就寝も同日の起床日レコードへ保存される (04:00→10:00=6h)", async () => {
-    const capture = makeRpcMock();
+    const capture = makeRpcMock(undefined, {
+      "2026-04-08": { bed_time: null, weigh_in_time: "10:00" },
+      "2026-04-09": null,
+    });
     const result = await saveDailyLog({
       log_date: "2026-04-08",
       bed_time: "04:00",
-      weigh_in_time: "10:00",
     });
 
     expect(result.ok).toBe(true);
     expect(capture.calls).toHaveLength(1);
     expect(capture.calls[0]?.p_log_date).toBe("2026-04-08");
     expect(capture.calls[0]?.p_fields.sleep_hours).toBe(6.0);
+    expect("weigh_in_time" in (capture.calls[0]?.p_fields ?? {})).toBe(false);
   });
 
-  test("両方 payload にある・算出結果が異常値 (同一時刻→24h) の場合 sleep_hours は更新しない", async () => {
-    const capture = makeRpcMock();
+  test("算出結果が異常値 (同一時刻→24h) の場合 sleep_hours は更新しない", async () => {
+    // DB の weigh_in_time と user の bed_time が同一時刻 → delta=0 → 24h → null
+    const capture = makeRpcMock(undefined, {
+      "2026-04-07": { bed_time: null, weigh_in_time: "07:00" },
+      "2026-04-08": null,
+    });
     const result = await saveDailyLog({
       log_date: "2026-04-07",
       bed_time: "07:00",
-      weigh_in_time: "07:00",
     });
 
     expect(result.ok).toBe(true);
@@ -838,7 +856,7 @@ describe("saveDailyLog — bed_time 保存 (#501)", () => {
     expect("sleep_hours" in (capture.p_fields ?? {})).toBe(false);
   });
 
-  // ── 片側のみ payload にある場合 (DB マージ) ────────────────────────────────
+  // ── bed_time のみ更新 (DB マージ) ────────────────────────────────────────
 
   test("bed_time のみ更新: 翌日レコードに weigh_in_time があれば翌日起床日レコードで再計算する", async () => {
     const capture = makeRpcMock(undefined, {
@@ -858,43 +876,6 @@ describe("saveDailyLog — bed_time 保存 (#501)", () => {
     expect("weigh_in_time" in (capture.calls[0]?.p_fields ?? {})).toBe(false);
   });
 
-  test("weigh_in_time のみ更新: sleep_hours はペイロードに含まれない（DB トリガーが管理）", async () => {
-    // #515 以降: sleep_hours は sleep_sessions DB トリガーが管理するため、
-    // weigh_in_time のみ更新しても saveDailyLog は sleep_hours を書き込まない。
-    const capture = makeRpcMock(undefined, { bed_time: "23:00", weigh_in_time: null });
-    const result = await saveDailyLog({
-      log_date: "2026-04-07",
-      weigh_in_time: "07:00",
-    });
-
-    expect(result.ok).toBe(true);
-    expect(capture.p_fields?.weigh_in_time).toBe("07:00");
-    // sleep_hours はペイロードに含まれない（DB トリガー専管）
-    expect("sleep_hours" in (capture.p_fields ?? {})).toBe(false);
-    // bed_time は今回更新しないのでペイロードに含まれない
-    expect("bed_time" in (capture.p_fields ?? {})).toBe(false);
-  });
-
-  test("既に起床日基準で保存済みの overnight レコードで weigh_in_time だけ更新しても翌日に再シフトしない", async () => {
-    // weigh_in_time のみ更新 → 翌日シフトは発生しない（bed_time が payload にないため）
-    // sleep_hours は DB トリガー専管なのでペイロードに含まれない
-    const capture = makeRpcMock(undefined, {
-      "2026-04-08": { bed_time: "23:30", weigh_in_time: "07:00" },
-      "2026-04-09": null,
-    });
-    const result = await saveDailyLog({
-      log_date: "2026-04-08",
-      weigh_in_time: "06:45",
-    });
-
-    expect(result.ok).toBe(true);
-    expect(capture.calls).toHaveLength(1);
-    expect(capture.calls[0]?.p_log_date).toBe("2026-04-08");
-    expect(capture.calls[0]?.p_fields.weigh_in_time).toBe("06:45");
-    // sleep_hours はペイロードに含まれない（DB トリガー専管）
-    expect("sleep_hours" in (capture.calls[0]?.p_fields ?? {})).toBe(false);
-  });
-
   test("既に起床日基準で保存済みの overnight レコードで bed_time だけ更新しても翌日に再シフトしない", async () => {
     const capture = makeRpcMock(undefined, {
       "2026-04-08": { bed_time: "23:30", weigh_in_time: "07:00" },
@@ -909,10 +890,11 @@ describe("saveDailyLog — bed_time 保存 (#501)", () => {
     expect(capture.calls).toHaveLength(1);
     expect(capture.calls[0]?.p_log_date).toBe("2026-04-08");
     expect(capture.calls[0]?.p_fields.bed_time).toBe("23:45");
+    // 23:45→07:00 = 7h15m = 7.3h
     expect(capture.calls[0]?.p_fields.sleep_hours).toBe(7.3);
   });
 
-  test("bed_time のみ更新: DB に weigh_in_time なし → sleep_hours は更新されない", async () => {
+  test("bed_time 更新: DB の weigh_in_time なし → sleep_hours は更新されない", async () => {
     // DB: weigh_in_time = null → 算出不能
     const capture = makeRpcMock(undefined, { bed_time: null, weigh_in_time: null });
     const result = await saveDailyLog({
@@ -926,8 +908,8 @@ describe("saveDailyLog — bed_time 保存 (#501)", () => {
     expect("sleep_hours" in (capture.p_fields ?? {})).toBe(false);
   });
 
-  test("bed_time のみ更新: 既存行なし (新規) → sleep_hours は更新されない", async () => {
-    // DB: 行なし (null)
+  test("bed_time 更新: 既存行なし (新規) → sleep_hours は更新されない", async () => {
+    // DB: 行なし (null) → weigh_in_time 取得不能 → sleep_hours 算出不能
     const capture = makeRpcMock(undefined, {
       "2026-04-07": null,
       "2026-04-08": null,
@@ -940,41 +922,43 @@ describe("saveDailyLog — bed_time 保存 (#501)", () => {
 
     expect(result.ok).toBe(true);
     expect(capture.p_fields?.bed_time).toBe("23:00");
-    // 行がない場合は weigh_in_time が取れないので算出不能
     expect("sleep_hours" in (capture.p_fields ?? {})).toBe(false);
   });
 
+  // ── 睡眠 + 食事の複合保存 ─────────────────────────────────────────────────
+
   test("睡眠系と食事系を同時保存しても、翌日レコードがあれば睡眠系だけ翌日の起床日レコードへ分離される", async () => {
-    // 翌日レコードが存在する場合のみシフトが発生する (#511 fix)
+    // DB "2026-04-08" に weigh_in_time: "07:00" → shift + sleep_hours 算出
     const capture = makeRpcMock(undefined, {
       "2026-04-07": { bed_time: null, weigh_in_time: null },
-      "2026-04-08": { bed_time: null, weigh_in_time: null },
+      "2026-04-08": { bed_time: null, weigh_in_time: "07:00" },
     });
     const result = await saveDailyLog({
       log_date: "2026-04-07",
       calories: 2100,
       last_meal_end_time: "22:00",
       bed_time: "23:30",
-      weigh_in_time: "07:00",
     });
 
     expect(result.ok).toBe(true);
     expect(capture.calls).toHaveLength(2);
+    // Call 1: 当日 → 食事系のみ（bed_time は分離）
     expect(capture.calls[0]?.p_log_date).toBe("2026-04-07");
     expect(capture.calls[0]?.p_fields.calories).toBe(2100);
     expect(capture.calls[0]?.p_fields.last_meal_end_time).toBe("22:00");
     expect("bed_time" in (capture.calls[0]?.p_fields ?? {})).toBe(false);
-
+    // Call 2: 翌日起床日 → 睡眠系（weigh_in_time は DB トリガー専管）
     expect(capture.calls[1]?.p_log_date).toBe("2026-04-08");
     expect(capture.calls[1]?.p_fields.bed_time).toBe("23:30");
-    expect(capture.calls[1]?.p_fields.weigh_in_time).toBe("07:00");
+    expect("weigh_in_time" in (capture.calls[1]?.p_fields ?? {})).toBe(false);
     expect(capture.calls[1]?.p_fields.sleep_hours).toBe(7.5);
   });
 
   test("睡眠系と食事系を同時保存・翌日レコードなしの場合は sleep も当日にまとめて保存される", async () => {
+    // DB "2026-04-07" に weigh_in_time: "07:00" → 同日に sleep_hours 算出
     // 翌日レコードなし → シフトせず当日にまとめる (#511 fix: 部分保存エラーも防ぐ)
     const capture = makeRpcMock(undefined, {
-      "2026-04-07": { bed_time: null, weigh_in_time: null },
+      "2026-04-07": { bed_time: null, weigh_in_time: "07:00" },
       "2026-04-08": null,
     });
     const result = await saveDailyLog({
@@ -982,7 +966,6 @@ describe("saveDailyLog — bed_time 保存 (#501)", () => {
       calories: 2100,
       last_meal_end_time: "22:00",
       bed_time: "23:30",
-      weigh_in_time: "07:00",
     });
 
     expect(result.ok).toBe(true);
@@ -992,21 +975,9 @@ describe("saveDailyLog — bed_time 保存 (#501)", () => {
     expect(capture.calls[0]?.p_fields.calories).toBe(2100);
     expect(capture.calls[0]?.p_fields.last_meal_end_time).toBe("22:00");
     expect(capture.calls[0]?.p_fields.bed_time).toBe("23:30");
-    expect(capture.calls[0]?.p_fields.weigh_in_time).toBe("07:00");
+    // weigh_in_time は DB トリガー専管 → payload に含まれない
+    expect("weigh_in_time" in (capture.calls[0]?.p_fields ?? {})).toBe(false);
     expect(capture.calls[0]?.p_fields.sleep_hours).toBe(7.5);
-  });
-
-  test("片側更新で合成後に異常値になる場合 sleep_hours は更新されない", async () => {
-    // 既存 DB: bed_time = "07:00"、今回 weigh_in_time も "07:00" に更新 → 同一時刻 → 24h → null
-    const capture = makeRpcMock(undefined, { bed_time: "07:00", weigh_in_time: null });
-    const result = await saveDailyLog({
-      log_date: "2026-04-07",
-      weigh_in_time: "07:00",
-    });
-
-    expect(result.ok).toBe(true);
-    // 同一時刻 → 24h → 無効 → sleep_hours はペイロードに含まれない
-    expect("sleep_hours" in (capture.p_fields ?? {})).toBe(false);
   });
 
   // ── 明示クリア / 未操作 ───────────────────────────────────────────────────
@@ -1024,19 +995,6 @@ describe("saveDailyLog — bed_time 保存 (#501)", () => {
     expect(capture.p_fields?.bed_time).toBeNull();
     // bed_time クリア時は sleep_hours も連動してクリア
     expect("sleep_hours" in (capture.p_fields ?? {})).toBe(true);
-    expect(capture.p_fields?.sleep_hours).toBeNull();
-  });
-
-  test("bed_time: null + weigh_in_time: null でも sleep_hours は null になる（bed_time クリア優先）", async () => {
-    const capture = makeRpcMock();
-    const result = await saveDailyLog({
-      log_date: "2026-04-07",
-      bed_time: null,
-      weigh_in_time: null,
-    });
-
-    expect(result.ok).toBe(true);
-    expect(capture.p_fields?.bed_time).toBeNull();
     expect(capture.p_fields?.sleep_hours).toBeNull();
   });
 

--- a/src/app/actions/__tests__/saveDailyLog.test.ts
+++ b/src/app/actions/__tests__/saveDailyLog.test.ts
@@ -32,23 +32,32 @@ type RpcCapture = {
   calls: Array<{ name: string; p_log_date: string; p_fields: Record<string, unknown> }>;
 };
 
-type TimeFields = { bed_time: string | null; weigh_in_time: string | null };
+/**
+ * TimeFields: log_date ごとの DB 状態を表す。
+ *
+ * bed_time  — daily_logs.bed_time (TIME | null)
+ * wake_at   — sleep_sessions.wake_at (TIMESTAMPTZ 文字列 | null)
+ *             null はその log_date に対応する sleep_session が存在しないことを示す。
+ *             例: "2026-04-08T07:00:00+09:00" = JST 07:00 の起床
+ */
+type TimeFields = { bed_time: string | null; wake_at: string | null };
 type TimeFieldMap = Record<string, TimeFields | null>;
 
 function isTimeFields(value: unknown): value is TimeFields {
-  return typeof value === "object" && value !== null && "bed_time" in value && "weigh_in_time" in value;
+  return typeof value === "object" && value !== null && "bed_time" in value && "wake_at" in value;
 }
 
 /**
  * saveDailyLog が内部で呼ぶ supabase クライアントをモックする。
  *
  * - rpc("save_daily_log_partial", ...) の引数を capture に記録する
- * - existingRow を渡すと from("daily_logs").select().eq().maybeSingle() もモックし、
- *   bed_time / weigh_in_time の片側のみ更新する際の既存行フェッチに応答する
+ * - existingRow を渡すと from("daily_logs") / from("sleep_sessions") の
+ *   select().eq().maybeSingle() をモックし、床入り時刻算出に使う既存行フェッチに応答する
+ *   - from("daily_logs"): { bed_time } を返す
+ *   - from("sleep_sessions"): { wake_at } を返す（wake_at が null なら null を返す）
  *
  * @param rpcError    - RPC が返すエラー（省略時は null = 成功）
  * @param existingRow - DB フェッチ結果。省略時は from チェーンをモックしない
- *                      (両方が payload にある場合 or どちらも payload にない場合はフェッチが走らないため不要)
  */
 function makeRpcMock(
   rpcError?: { message: string },
@@ -78,13 +87,22 @@ function makeRpcMock(
           ? { "2026-04-07": existingRow }
           : existingRow;
 
-  mockClient.from = jest.fn().mockReturnValue({
+  mockClient.from = jest.fn().mockImplementation((table: string) => ({
     select: jest.fn().mockReturnValue({
-      eq: jest.fn().mockImplementation((_: string, logDate: string) => ({
-        maybeSingle: jest.fn().mockResolvedValue({ data: rowMap[logDate] ?? null, error: null }),
+      eq: jest.fn().mockImplementation((_col: string, logDate: string) => ({
+        maybeSingle: jest.fn().mockResolvedValue({
+          data: table === "daily_logs"
+            // daily_logs: 行があれば { bed_time }、なければ null
+            ? (rowMap[logDate] != null ? { bed_time: rowMap[logDate]!.bed_time } : null)
+            // sleep_sessions: wake_at が null でなければ { wake_at }、なければ null
+            : (rowMap[logDate] != null && rowMap[logDate]!.wake_at != null
+                ? { wake_at: rowMap[logDate]!.wake_at }
+                : null),
+          error: null,
+        }),
       })),
     }),
-  });
+  }));
 
   mockCreateClient.mockReturnValueOnce(mockClient as unknown as ReturnType<typeof createClient>);
   return capture;
@@ -752,17 +770,16 @@ describe("buildUpdatePayload — bed_time (#501)", () => {
 // ════════════════════════════════════════════════════════════════════════════
 
 describe("saveDailyLog — bed_time 保存 (#501, #526)", () => {
-  // #526: weigh_in_time は user input から削除。sleep_sessions.wake_at からの DB トリガーで
-  // 自動同期される。saveDailyLog は weigh_in_time を payload に含まない。
-  // sleep_hours 算出は user の bed_time + DB の weigh_in_time (projection 値) から行う。
+  // #526: weigh_in_time は廃止。sleep_sessions.wake_at が起床時刻の source of truth。
+  // saveDailyLog は sleep_sessions から wake_at を読み、extractJstHHMM で JST 変換して sleep_hours を算出する。
 
   // ── 前日夜就寝（overnight シフト）──────────────────────────────────────────
 
   test("前日夜就寝は翌日の起床日レコードへ保存される (23:00→07:00=8h)", async () => {
-    // DB "2026-04-08" に weigh_in_time: "07:00" がある → 翌日シフト + sleep_hours 算出
+    // DB "2026-04-08" に sleep_sessions.wake_at: JST 07:00 がある → 翌日シフト + sleep_hours 算出
     const capture = makeRpcMock(undefined, {
-      "2026-04-07": { bed_time: null, weigh_in_time: null },
-      "2026-04-08": { bed_time: null, weigh_in_time: "07:00" },
+      "2026-04-07": { bed_time: null, wake_at: null },
+      "2026-04-08": { bed_time: null, wake_at: "2026-04-08T07:00:00+09:00" },
     });
     const result = await saveDailyLog({
       log_date: "2026-04-07",
@@ -773,14 +790,14 @@ describe("saveDailyLog — bed_time 保存 (#501, #526)", () => {
     expect(capture.calls).toHaveLength(1);
     expect(capture.calls[0]?.p_log_date).toBe("2026-04-08");
     expect(capture.calls[0]?.p_fields.bed_time).toBe("23:00");
-    // #526: weigh_in_time は DB トリガー専管 → payload に含まれない
+    // #526: weigh_in_time は廃止 → payload に含まれない
     expect("weigh_in_time" in (capture.calls[0]?.p_fields ?? {})).toBe(false);
     expect(capture.calls[0]?.p_fields.sleep_hours).toBe(8.0);
   });
 
   test("翌日レコードが存在しない場合、overnight 時刻でも当日に保存される (new_log_requires_weight を防ぐ)", async () => {
     // 4/8 が存在しない → シフトせず 4/7 に保存 (#511 fix)
-    // DB の weigh_in_time がないため sleep_hours は算出不能
+    // sleep_sessions が存在しないため sleep_hours は算出不能
     const capture = makeRpcMock(undefined, {
       "2026-04-07": null,
       "2026-04-08": null,
@@ -797,7 +814,7 @@ describe("saveDailyLog — bed_time 保存 (#501, #526)", () => {
     expect(capture.calls[0]?.p_log_date).toBe("2026-04-07");
     expect(capture.calls[0]?.p_fields.weight).toBe(70.0);
     expect(capture.calls[0]?.p_fields.bed_time).toBe("23:00");
-    // weigh_in_time が DB にない → sleep_hours 算出不能
+    // sleep_sessions なし → sleep_hours 算出不能
     expect("sleep_hours" in (capture.calls[0]?.p_fields ?? {})).toBe(false);
     expect("weigh_in_time" in (capture.calls[0]?.p_fields ?? {})).toBe(false);
   });
@@ -805,9 +822,9 @@ describe("saveDailyLog — bed_time 保存 (#501, #526)", () => {
   // ── 当日就寝（シフトなし）── ──────────────────────────────────────────────
 
   test("当日深夜就寝は同日の起床日レコードへ保存される (01:30→08:00=6.5h)", async () => {
-    // DB に weigh_in_time: "08:00" がある → 同日に sleep_hours 算出
+    // DB に sleep_sessions.wake_at: JST 08:00 がある → 同日に sleep_hours 算出
     const capture = makeRpcMock(undefined, {
-      "2026-04-08": { bed_time: null, weigh_in_time: "08:00" },
+      "2026-04-08": { bed_time: null, wake_at: "2026-04-08T08:00:00+09:00" },
       "2026-04-09": null,
     });
     const result = await saveDailyLog({
@@ -824,7 +841,7 @@ describe("saveDailyLog — bed_time 保存 (#501, #526)", () => {
 
   test("早朝就寝も同日の起床日レコードへ保存される (04:00→10:00=6h)", async () => {
     const capture = makeRpcMock(undefined, {
-      "2026-04-08": { bed_time: null, weigh_in_time: "10:00" },
+      "2026-04-08": { bed_time: null, wake_at: "2026-04-08T10:00:00+09:00" },
       "2026-04-09": null,
     });
     const result = await saveDailyLog({
@@ -840,9 +857,9 @@ describe("saveDailyLog — bed_time 保存 (#501, #526)", () => {
   });
 
   test("算出結果が異常値 (同一時刻→24h) の場合 sleep_hours は更新しない", async () => {
-    // DB の weigh_in_time と user の bed_time が同一時刻 → delta=0 → 24h → null
+    // sleep_sessions.wake_at と user の bed_time が同一時刻 → delta=0 → 24h → null
     const capture = makeRpcMock(undefined, {
-      "2026-04-07": { bed_time: null, weigh_in_time: "07:00" },
+      "2026-04-07": { bed_time: null, wake_at: "2026-04-07T07:00:00+09:00" },
       "2026-04-08": null,
     });
     const result = await saveDailyLog({
@@ -858,10 +875,10 @@ describe("saveDailyLog — bed_time 保存 (#501, #526)", () => {
 
   // ── bed_time のみ更新 (DB マージ) ────────────────────────────────────────
 
-  test("bed_time のみ更新: 翌日レコードに weigh_in_time があれば翌日起床日レコードで再計算する", async () => {
+  test("bed_time のみ更新: 翌日レコードに sleep_sessions.wake_at があれば翌日起床日レコードで再計算する", async () => {
     const capture = makeRpcMock(undefined, {
-      "2026-04-07": { bed_time: null, weigh_in_time: null },
-      "2026-04-08": { bed_time: null, weigh_in_time: "07:00" },
+      "2026-04-07": { bed_time: null, wake_at: null },
+      "2026-04-08": { bed_time: null, wake_at: "2026-04-08T07:00:00+09:00" },
     });
     const result = await saveDailyLog({
       log_date: "2026-04-07",
@@ -878,7 +895,7 @@ describe("saveDailyLog — bed_time 保存 (#501, #526)", () => {
 
   test("既に起床日基準で保存済みの overnight レコードで bed_time だけ更新しても翌日に再シフトしない", async () => {
     const capture = makeRpcMock(undefined, {
-      "2026-04-08": { bed_time: "23:30", weigh_in_time: "07:00" },
+      "2026-04-08": { bed_time: "23:30", wake_at: "2026-04-08T07:00:00+09:00" },
       "2026-04-09": null,
     });
     const result = await saveDailyLog({
@@ -894,9 +911,9 @@ describe("saveDailyLog — bed_time 保存 (#501, #526)", () => {
     expect(capture.calls[0]?.p_fields.sleep_hours).toBe(7.3);
   });
 
-  test("bed_time 更新: DB の weigh_in_time なし → sleep_hours は更新されない", async () => {
-    // DB: weigh_in_time = null → 算出不能
-    const capture = makeRpcMock(undefined, { bed_time: null, weigh_in_time: null });
+  test("bed_time 更新: sleep_sessions なし → sleep_hours は更新されない", async () => {
+    // DB: wake_at = null (sleep_sessions なし) → 算出不能
+    const capture = makeRpcMock(undefined, { bed_time: null, wake_at: null });
     const result = await saveDailyLog({
       log_date: "2026-04-07",
       bed_time: "23:00",
@@ -904,12 +921,12 @@ describe("saveDailyLog — bed_time 保存 (#501, #526)", () => {
 
     expect(result.ok).toBe(true);
     expect(capture.p_fields?.bed_time).toBe("23:00");
-    // weigh_in_time が null なので算出不能 → sleep_hours はペイロードに含まれない
+    // sleep_sessions なし → sleep_hours はペイロードに含まれない
     expect("sleep_hours" in (capture.p_fields ?? {})).toBe(false);
   });
 
   test("bed_time 更新: 既存行なし (新規) → sleep_hours は更新されない", async () => {
-    // DB: 行なし (null) → weigh_in_time 取得不能 → sleep_hours 算出不能
+    // DB: 行なし (null) → sleep_sessions なし → sleep_hours 算出不能
     const capture = makeRpcMock(undefined, {
       "2026-04-07": null,
       "2026-04-08": null,
@@ -928,10 +945,10 @@ describe("saveDailyLog — bed_time 保存 (#501, #526)", () => {
   // ── 睡眠 + 食事の複合保存 ─────────────────────────────────────────────────
 
   test("睡眠系と食事系を同時保存しても、翌日レコードがあれば睡眠系だけ翌日の起床日レコードへ分離される", async () => {
-    // DB "2026-04-08" に weigh_in_time: "07:00" → shift + sleep_hours 算出
+    // DB "2026-04-08" に sleep_sessions.wake_at: JST 07:00 → shift + sleep_hours 算出
     const capture = makeRpcMock(undefined, {
-      "2026-04-07": { bed_time: null, weigh_in_time: null },
-      "2026-04-08": { bed_time: null, weigh_in_time: "07:00" },
+      "2026-04-07": { bed_time: null, wake_at: null },
+      "2026-04-08": { bed_time: null, wake_at: "2026-04-08T07:00:00+09:00" },
     });
     const result = await saveDailyLog({
       log_date: "2026-04-07",
@@ -947,7 +964,7 @@ describe("saveDailyLog — bed_time 保存 (#501, #526)", () => {
     expect(capture.calls[0]?.p_fields.calories).toBe(2100);
     expect(capture.calls[0]?.p_fields.last_meal_end_time).toBe("22:00");
     expect("bed_time" in (capture.calls[0]?.p_fields ?? {})).toBe(false);
-    // Call 2: 翌日起床日 → 睡眠系（weigh_in_time は DB トリガー専管）
+    // Call 2: 翌日起床日 → 睡眠系（weigh_in_time は廃止）
     expect(capture.calls[1]?.p_log_date).toBe("2026-04-08");
     expect(capture.calls[1]?.p_fields.bed_time).toBe("23:30");
     expect("weigh_in_time" in (capture.calls[1]?.p_fields ?? {})).toBe(false);
@@ -955,10 +972,10 @@ describe("saveDailyLog — bed_time 保存 (#501, #526)", () => {
   });
 
   test("睡眠系と食事系を同時保存・翌日レコードなしの場合は sleep も当日にまとめて保存される", async () => {
-    // DB "2026-04-07" に weigh_in_time: "07:00" → 同日に sleep_hours 算出
+    // DB "2026-04-07" に sleep_sessions.wake_at: JST 07:00 → 同日に sleep_hours 算出
     // 翌日レコードなし → シフトせず当日にまとめる (#511 fix: 部分保存エラーも防ぐ)
     const capture = makeRpcMock(undefined, {
-      "2026-04-07": { bed_time: null, weigh_in_time: "07:00" },
+      "2026-04-07": { bed_time: null, wake_at: "2026-04-07T07:00:00+09:00" },
       "2026-04-08": null,
     });
     const result = await saveDailyLog({
@@ -975,7 +992,7 @@ describe("saveDailyLog — bed_time 保存 (#501, #526)", () => {
     expect(capture.calls[0]?.p_fields.calories).toBe(2100);
     expect(capture.calls[0]?.p_fields.last_meal_end_time).toBe("22:00");
     expect(capture.calls[0]?.p_fields.bed_time).toBe("23:30");
-    // weigh_in_time は DB トリガー専管 → payload に含まれない
+    // weigh_in_time は廃止 → payload に含まれない
     expect("weigh_in_time" in (capture.calls[0]?.p_fields ?? {})).toBe(false);
     expect(capture.calls[0]?.p_fields.sleep_hours).toBe(7.5);
   });

--- a/src/app/actions/buildUpdatePayload.ts
+++ b/src/app/actions/buildUpdatePayload.ts
@@ -41,7 +41,6 @@ export function buildUpdatePayload(
   }
 
   // #435 追加: 食事タイミング
-  // weigh_in_time は #526 で手動入力廃止。sleep_sessions.wake_at からの DB トリガーで自動同期される。
   if (input.last_meal_end_time !== undefined) payload.last_meal_end_time = input.last_meal_end_time;
 
   // #436 追加: 歩数（Apple Health インポート専用。MealLogger からは渡されない）

--- a/src/app/actions/buildUpdatePayload.ts
+++ b/src/app/actions/buildUpdatePayload.ts
@@ -41,8 +41,8 @@ export function buildUpdatePayload(
   }
 
   // #435 追加: 食事タイミング
+  // weigh_in_time は #526 で手動入力廃止。sleep_sessions.wake_at からの DB トリガーで自動同期される。
   if (input.last_meal_end_time !== undefined) payload.last_meal_end_time = input.last_meal_end_time;
-  if (input.weigh_in_time      !== undefined) payload.weigh_in_time      = input.weigh_in_time;
 
   // #436 追加: 歩数（Apple Health インポート専用。MealLogger からは渡されない）
   if (input.step_count !== undefined) payload.step_count = input.step_count;

--- a/src/app/actions/saveDailyLog.ts
+++ b/src/app/actions/saveDailyLog.ts
@@ -4,6 +4,7 @@ import { createClient } from "@/lib/supabase/server";
 import { revalidateAfterDailyLogMutation } from "@/lib/cache/revalidate";
 import { isValidTrainingType, isValidWorkMode } from "@/lib/utils/trainingType";
 import { deriveSleepHours } from "@/lib/utils/sleep";
+import { extractJstHHMM } from "@/lib/utils/sleepSession";
 import { buildUpdatePayload } from "./buildUpdatePayload";
 import { addDaysStr, parseLocalDateStr } from "@/lib/utils/date";
 
@@ -52,7 +53,7 @@ export type SaveDailyLogInput = {
    *
    * #515 以降は sleep_sessions が睡眠の source of truth。MealLogger からは送信しない。
    * 移行期カラムとして DB には残存する（将来 #518 で廃止予定）。
-   * #515 以降は sleep_sessions が source of truth。#526 で weigh_in_time は廃止（projection 値へ移行）。
+   * #515 以降は sleep_sessions が source of truth。#526 で weigh_in_time カラムは廃止済み。
    */
   bed_time?: string | null;
 };
@@ -237,7 +238,7 @@ export async function saveDailyLog(
   return { ok: true };
 }
 
-type ExistingTimeFields = { bed_time: string | null; weigh_in_time: string | null } | null;
+type ExistingTimeFields = { bed_time: string | null; wake_at: string | null } | null;
 
 type SleepSavePlan = {
   targetLogDate: string;
@@ -265,21 +266,19 @@ function deriveSleepSavePlan(
   // ここまで到達した場合、input.bed_time は string（undefined/null は早期 return 済み）
   const bedTime: string = input.bed_time;
 
-  // weigh_in_time は #526 で手動入力廃止。sleep_sessions.wake_at から DB トリガーで自動同期される。
-  // ここでは既存行の weigh_in_time (projection 値) を DB から読んで睡眠計算の起床時刻として使う。
-  const currentBed   = currentRow?.bed_time    ?? null;
-  const currentWeigh = currentRow?.weigh_in_time ?? null;
+  // 起床時刻は sleep_sessions.wake_at を JST HH:MM に変換して使う (#526)
+  const currentWeigh = currentRow?.wake_at ? extractJstHHMM(currentRow.wake_at) : null;
 
   const overnightTarget = addDaysStr(input.log_date, 1);
-  // nextWeigh は翌日 DB 行の weigh_in_time (sleep_sessions 由来の projection 値)
-  const nextWeigh = nextRow?.weigh_in_time ?? null;
+  // nextWeigh は翌日 sleep_sessions の wake_at を JST HH:MM に変換した値
+  const nextWeigh = nextRow?.wake_at ? extractJstHHMM(nextRow.wake_at) : null;
+  const currentWakeHHMM = currentRow?.wake_at ? extractJstHHMM(currentRow.wake_at) : null;
   const currentRowAlreadyHasWakeDateOvernightPair = (
     currentRow?.bed_time !== null &&
     currentRow?.bed_time !== undefined &&
-    currentRow?.weigh_in_time !== null &&
-    currentRow?.weigh_in_time !== undefined &&
-    deriveSleepHours(currentRow.bed_time, currentRow.weigh_in_time) !== null &&
-    timeIsOnOrBefore(currentRow.weigh_in_time, currentRow.bed_time)
+    currentWakeHHMM !== null &&
+    deriveSleepHours(currentRow.bed_time, currentWakeHHMM) !== null &&
+    timeIsOnOrBefore(currentWakeHHMM, currentRow.bed_time)
   );
   // 翌日レコードが存在しない場合はシフトしない。
   // 翌日が存在しないままシフトすると save_daily_log_partial が
@@ -318,19 +317,31 @@ function timeIsOnOrBefore(lhs: string, rhs: string): boolean {
 // ─── 内部ヘルパー ──────────────────────────────────────────────────────────────
 
 /**
- * 既存行の bed_time / weigh_in_time を取得する。
+ * bed_time (daily_logs) と wake_at (sleep_sessions) を並行取得する。
  *
  * 片側のみ更新する場合に、もう片側の現在値を取得して sleep_hours の再算出に使う。
- * 行が存在しない場合は null を返す（新規行作成シナリオでは両値ともペイロードにあるはずなので問題なし）。
+ * daily_logs 行が存在しない場合は null を返す。
+ * sleep_sessions が存在しない場合は wake_at = null として返す。
  */
 async function fetchExistingTimeFields(
   supabase: ReturnType<typeof createClient>,
   logDate: string
 ): Promise<ExistingTimeFields> {
-  const { data } = await supabase
-    .from("daily_logs")
-    .select("bed_time, weigh_in_time")
-    .eq("log_date", logDate)
-    .maybeSingle();
-  return (data as { bed_time: string | null; weigh_in_time: string | null } | null) ?? null;
+  const [dailyLogRes, sleepSessionRes] = await Promise.all([
+    supabase
+      .from("daily_logs")
+      .select("bed_time")
+      .eq("log_date", logDate)
+      .maybeSingle(),
+    supabase
+      .from("sleep_sessions")
+      .select("wake_at")
+      .eq("wake_date", logDate)
+      .maybeSingle(),
+  ]);
+
+  if (!dailyLogRes.data) return null;
+  const bed_time = (dailyLogRes.data as { bed_time: string | null }).bed_time;
+  const wake_at  = (sleepSessionRes.data as { wake_at: string } | null)?.wake_at ?? null;
+  return { bed_time, wake_at };
 }

--- a/src/app/actions/saveDailyLog.ts
+++ b/src/app/actions/saveDailyLog.ts
@@ -39,8 +39,6 @@ export type SaveDailyLogInput = {
   // ── #435 追加 ──
   /** 最後の食事終了時刻 "HH:MM" 形式。null = 明示クリア */
   last_meal_end_time?: string | null;
-  /** 体重測定時刻 "HH:MM" 形式。null = 明示クリア */
-  weigh_in_time?: string | null;
   // ── #436 追加 ──
   /** Apple Health 歩数（日次集計）。null = 明示クリア */
   step_count?: number | null;
@@ -54,7 +52,7 @@ export type SaveDailyLogInput = {
    *
    * #515 以降は sleep_sessions が睡眠の source of truth。MealLogger からは送信しない。
    * 移行期カラムとして DB には残存する（将来 #518 で廃止予定）。
-   * weigh_in_time のみ更新した場合に sleep_hours を再計算しないよう deriveSleepSavePlan が制御する。
+   * #515 以降は sleep_sessions が source of truth。#526 で weigh_in_time は廃止（projection 値へ移行）。
    */
   bed_time?: string | null;
 };
@@ -135,7 +133,7 @@ export async function saveDailyLog(
   }
 
   // 時刻バリデーション: "HH:MM" または "HH:MM:SS" 形式 + 値域チェック
-  for (const key of ["last_meal_end_time", "weigh_in_time", "bed_time"] as const) {
+  for (const key of ["last_meal_end_time", "bed_time"] as const) {
     const v = input[key];
     if (v !== undefined && v !== null) {
       const parts = v.split(":");
@@ -165,7 +163,7 @@ export async function saveDailyLog(
   let sleepPlan: SleepSavePlan = { targetLogDate: input.log_date, payload: {} };
   let hasSleepPayload = false;
 
-  if (input.bed_time !== undefined || input.weigh_in_time !== undefined) {
+  if (input.bed_time !== undefined) {
     const baseInput: SaveDailyLogInput = { ...input };
     const overnightLogDate = addDaysStr(input.log_date, 1);
     const nextDayTimeFields = overnightLogDate
@@ -178,7 +176,6 @@ export async function saveDailyLog(
 
     if (saveSleepSeparately) {
       baseInput.bed_time = undefined;
-      baseInput.weigh_in_time = undefined;
       baseInput.sleep_hours = undefined;
     } else {
       baseInput.sleep_hours = sleepPlan.payload.sleep_hours;
@@ -252,25 +249,30 @@ function deriveSleepSavePlan(
   currentRow: ExistingTimeFields,
   nextRow: ExistingTimeFields
 ): SleepSavePlan {
-  const bedInPayload = input.bed_time !== undefined;
-  const weighInPayload = input.weigh_in_time !== undefined;
-
-  if (!bedInPayload && !weighInPayload) {
+  if (input.bed_time === undefined) {
     return { targetLogDate: input.log_date, payload: {} };
   }
 
-  if (bedInPayload && input.bed_time === null) {
+  const bedInPayload = true; // bed_time が undefined でないことを明示
+
+  if (input.bed_time === null) {
     return {
       targetLogDate: input.log_date,
       payload: buildUpdatePayload({ bed_time: null, sleep_hours: null }),
     };
   }
 
-  const currentBed = bedInPayload ? input.bed_time ?? null : currentRow?.bed_time ?? null;
-  const currentWeigh = weighInPayload ? input.weigh_in_time ?? null : currentRow?.weigh_in_time ?? null;
+  // ここまで到達した場合、input.bed_time は string（undefined/null は早期 return 済み）
+  const bedTime: string = input.bed_time;
+
+  // weigh_in_time は #526 で手動入力廃止。sleep_sessions.wake_at から DB トリガーで自動同期される。
+  // ここでは既存行の weigh_in_time (projection 値) を DB から読んで睡眠計算の起床時刻として使う。
+  const currentBed   = currentRow?.bed_time    ?? null;
+  const currentWeigh = currentRow?.weigh_in_time ?? null;
 
   const overnightTarget = addDaysStr(input.log_date, 1);
-  const nextWeigh = weighInPayload ? input.weigh_in_time ?? null : nextRow?.weigh_in_time ?? null;
+  // nextWeigh は翌日 DB 行の weigh_in_time (sleep_sessions 由来の projection 値)
+  const nextWeigh = nextRow?.weigh_in_time ?? null;
   const currentRowAlreadyHasWakeDateOvernightPair = (
     currentRow?.bed_time !== null &&
     currentRow?.bed_time !== undefined &&
@@ -280,38 +282,25 @@ function deriveSleepSavePlan(
     timeIsOnOrBefore(currentRow.weigh_in_time, currentRow.bed_time)
   );
   // 翌日レコードが存在しない場合はシフトしない。
-  // weighInPayload=true のとき nextWeigh はペイロード値を使うため、
-  // nextRow=null でも deriveSleepHours が有効値を返してしまう。
   // 翌日が存在しないままシフトすると save_daily_log_partial が
   // 新規 INSERT を試みて new_log_requires_weight エラーを起こす。
   const shouldShiftToNextDay = (
-    input.bed_time !== undefined &&
-    input.bed_time !== null &&
     nextWeigh !== null &&
     nextRow !== null &&
-    deriveSleepHours(input.bed_time, nextWeigh) !== null &&
-    timeIsOnOrBefore(nextWeigh, input.bed_time) &&
+    deriveSleepHours(bedTime, nextWeigh) !== null &&
+    timeIsOnOrBefore(nextWeigh, bedTime) &&
     !currentRowAlreadyHasWakeDateOvernightPair
   );
 
   const targetLogDate = shouldShiftToNextDay && overnightTarget ? overnightTarget : input.log_date;
-  const targetBed = shouldShiftToNextDay
-    ? (bedInPayload ? input.bed_time ?? null : currentBed)
-    : currentBed;
-  const targetWeigh = shouldShiftToNextDay
-    ? (weighInPayload ? input.weigh_in_time ?? null : nextWeigh)
-    : currentWeigh;
+  // targetBed は常に user's new value（bedInPayload/null は上の早期 return で保証済み）
+  const targetBed   = bedTime;
+  const targetWeigh = shouldShiftToNextDay ? nextWeigh : currentWeigh;
 
   const sleepInput: Omit<SaveDailyLogInput, "log_date"> = {};
-  if (bedInPayload) sleepInput.bed_time = input.bed_time;
-  if (weighInPayload) sleepInput.weigh_in_time = input.weigh_in_time;
+  if (bedInPayload) sleepInput.bed_time = bedTime;
 
-  // sleep_hours の計算・書き込みは bed_time が明示的にペイロードにある場合のみ行う。
-  // weigh_in_time のみ更新のケースでは計算しない（sleep_hours は sleep_sessions DB
-  // トリガーが管理するため、saveDailyLog が上書きすることを防ぐ）。
-  if (bedInPayload && input.bed_time === null) {
-    sleepInput.sleep_hours = null;
-  } else if (bedInPayload && targetBed !== null && targetWeigh !== null) {
+  if (targetWeigh !== null) {
     const derived = deriveSleepHours(targetBed, targetWeigh);
     if (derived !== null) sleepInput.sleep_hours = derived;
   }

--- a/src/app/api/export/route.ts
+++ b/src/app/api/export/route.ts
@@ -85,7 +85,7 @@ export async function GET(req: NextRequest) {
       "log_date", "weight", "calories", "protein", "fat", "carbs", "note",
       "is_cheat_day", "is_refeed_day", "is_eating_out", "is_travel_day",
       "sleep_hours", "had_bowel_movement", "training_type", "work_mode", "leg_flag",
-      "last_meal_end_time", "weigh_in_time", "step_count",
+      "last_meal_end_time", "step_count",
     ];
     const csv = toCSV((data ?? []) as Record<string, unknown>[], columns);
     const filename = `bodymake_log_${start || "all"}_${end || "all"}.csv`;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,6 +17,7 @@ import { buildMonthlyGoalSummaryRows, buildMonthlyGoalComparisonRows } from "@/l
 import { calcMonthlyBehaviorStats } from "@/lib/utils/calcMonthlyBehaviorStats";
 import { resolveMonthlyPlanHistoryAnchor } from "@/lib/utils/monthlyPlanHistory";
 import { fetchDashboardDailyLogs, fetchPredictions, fetchCareerLogsForDashboard } from "@/lib/queries/dailyLogs";
+import { fetchSleepSessionsForRange } from "@/lib/queries/sleepSessions";
 import { fetchSettings } from "@/lib/queries/settings";
 import { fetchEnrichedLogs } from "@/lib/queries/analytics";
 import { mapToAppSettings } from "@/lib/domain/settings";
@@ -96,6 +97,13 @@ export default async function DashboardPage() {
   // QueryResult を展開。エラー時はフォールバック値で graceful degradation を維持する。
   const logs = logsResult.kind === "ok" ? logsResult.data : [];
   const settings = settingsResult.kind === "ok" ? settingsResult.data : mapToAppSettings([]);
+
+  // 断食時間算出用: sleep_sessions を logs の日付範囲で取得する
+  const firstLogDate = logs.at(0)?.log_date ?? null;
+  const lastLogDate  = logs.at(-1)?.log_date ?? null;
+  const sleepSessions = firstLogDate && lastLogDate
+    ? await fetchSleepSessionsForRange(firstLogDate, lastLogDate)
+    : [];
 
   // MAX(updated_at) を使って stale 判定する。
   // MAX(log_date) ではなく MAX(updated_at) を使うことで、過去日の行修正でも stale を正しく検知できる。
@@ -304,6 +312,7 @@ export default async function DashboardPage() {
           )}
           <LogsAndSummaryTabs
             logs={logs}
+            sleepSessions={sleepSessions}
             monthStats={monthStats}
             seasonMap={seasonMap}
             currentSeason={currentSeason}

--- a/src/components/dashboard/LogsAndSummaryTabs.tsx
+++ b/src/components/dashboard/LogsAndSummaryTabs.tsx
@@ -7,13 +7,14 @@ import { MonthlyCalendar } from "./MonthlyCalendar";
 import { MonthlyGoalTable } from "./MonthlyGoalTable";
 import { MonthlyBehaviorSummary } from "./MonthlyBehaviorSummary";
 import { SeasonSummary } from "@/components/history/SeasonSummary";
-import type { DashboardDailyLog } from "@/lib/supabase/types";
+import type { DashboardDailyLog, SleepSession } from "@/lib/supabase/types";
 import type { MonthStats } from "@/components/history/SeasonSummary";
 import type { MonthlyGoalComparisonRow } from "@/lib/utils/monthlyGoalVisualization";
 import type { MonthlyBehaviorStats } from "@/lib/utils/calcMonthlyBehaviorStats";
 
 interface LogsAndSummaryTabsProps {
   logs: DashboardDailyLog[];
+  sleepSessions?: Pick<SleepSession, "wake_date" | "wake_at">[];
   monthStats: MonthStats[];
   seasonMap?: Map<string, string>;
   currentSeason?: string | null;
@@ -33,7 +34,7 @@ const TAB_LABELS: Record<Tab, string> = {
   monthly:  "月別",
 };
 
-export function LogsAndSummaryTabs({ logs, monthStats, seasonMap, currentSeason, monthlyGoalSummaryRows, phase, monthlyBehaviorStats }: LogsAndSummaryTabsProps) {
+export function LogsAndSummaryTabs({ logs, sleepSessions = [], monthStats, seasonMap, currentSeason, monthlyGoalSummaryRows, phase, monthlyBehaviorStats }: LogsAndSummaryTabsProps) {
   const [tab, setTab] = useState<Tab>("logs");
 
   return (
@@ -63,16 +64,16 @@ export function LogsAndSummaryTabs({ logs, monthStats, seasonMap, currentSeason,
           <div role="tabpanel" id="panel-logs" aria-labelledby="tab-logs">
             {/* モバイル: カードリスト。sm+ ではテーブル表示に切り替え */}
             <div className="sm:hidden">
-              <RecentLogsCards logs={logs} seasonMap={seasonMap} currentSeason={currentSeason} />
+              <RecentLogsCards logs={logs} sleepSessions={sleepSessions} seasonMap={seasonMap} currentSeason={currentSeason} />
             </div>
             <div className="hidden sm:block">
-              <RecentLogsTable logs={logs} embedded seasonMap={seasonMap} currentSeason={currentSeason} />
+              <RecentLogsTable logs={logs} sleepSessions={sleepSessions} embedded seasonMap={seasonMap} currentSeason={currentSeason} />
             </div>
           </div>
         )}
         {tab === "calendar" && (
           <div role="tabpanel" id="panel-calendar" aria-labelledby="tab-calendar">
-            <MonthlyCalendar logs={logs} />
+            <MonthlyCalendar logs={logs} sleepSessions={sleepSessions} />
           </div>
         )}
         {tab === "monthly" && (

--- a/src/components/dashboard/MonthlyCalendar.tsx
+++ b/src/components/dashboard/MonthlyCalendar.tsx
@@ -33,7 +33,7 @@ import { createContext, useContext, useMemo, useState } from "react";
 import { DayPicker } from "react-day-picker";
 import { ja } from "date-fns/locale";
 import * as JapaneseHolidays from "japanese-holidays";
-import type { DashboardDailyLog } from "@/lib/supabase/types";
+import type { DashboardDailyLog, SleepSession } from "@/lib/supabase/types";
 import { buildCalendarDayMap, getMobileTrainingLabel, toDateKey, type CalendarDayData } from "@/lib/utils/calendarUtils";
 import type { DayProps } from "react-day-picker";
 import { toJstDateStr } from "@/lib/utils/date";
@@ -257,15 +257,16 @@ function CalendarDayCell({ day, modifiers }: DayProps) {
 
 interface MonthlyCalendarProps {
   logs: DashboardDailyLog[];
+  sleepSessions?: Pick<SleepSession, "wake_date" | "wake_at">[];
 }
 
-export function MonthlyCalendar({ logs }: MonthlyCalendarProps) {
+export function MonthlyCalendar({ logs, sleepSessions = [] }: MonthlyCalendarProps) {
   // 当月（JST 基準）でデフォルト初期化
   const todayKey          = toJstDateStr();
   const [y, m]            = todayKey.split("-").map(Number) as [number, number, number];
   const [month, setMonth] = useState<Date>(new Date(y, m - 1, 1));
 
-  const dayMap = useMemo(() => buildCalendarDayMap(logs), [logs]);
+  const dayMap = useMemo(() => buildCalendarDayMap(logs, sleepSessions), [logs, sleepSessions]);
 
   const ctxValue: CalendarCtx = useMemo(
     () => ({ dayMap, todayKey }),

--- a/src/components/dashboard/RecentLogsCards.tsx
+++ b/src/components/dashboard/RecentLogsCards.tsx
@@ -15,7 +15,8 @@
  */
 
 import { ArrowDown, ArrowUp, Minus } from "lucide-react";
-import type { DashboardDailyLog } from "@/lib/supabase/types";
+import type { DashboardDailyLog, SleepSession } from "@/lib/supabase/types";
+import { extractJstHHMM } from "@/lib/utils/sleepSession";
 import { DAY_TAGS, DAY_TAG_LABELS, DAY_TAG_BADGE_COLORS } from "@/lib/utils/dayTags";
 import { formatConditionSummary } from "@/lib/utils/trainingType";
 import { computeWeightDelta, buildRecentLogArrays } from "@/lib/utils/recentLogsUtils";
@@ -24,14 +25,21 @@ import { addDaysStr } from "@/lib/utils/date";
 
 interface RecentLogsCardsProps {
   logs: DashboardDailyLog[];
+  sleepSessions?: Pick<SleepSession, "wake_date" | "wake_at">[];
   seasonMap?: Map<string, string>;
   currentSeason?: string | null;
 }
 
-export function RecentLogsCards({ logs, seasonMap, currentSeason }: RecentLogsCardsProps) {
+export function RecentLogsCards({ logs, sleepSessions = [], seasonMap, currentSeason }: RecentLogsCardsProps) {
   const { sorted, ascending } = buildRecentLogArrays(logs);
   // 断食時間算出用: 日付 → ログ の高速参照テーブル（前日 D-1 の last_meal_end_time を参照するため）
   const logByDate = new Map(ascending.map((l) => [l.log_date, l]));
+  // 断食時間算出用: wake_date → wake_at (JST HH:MM) の高速参照テーブル
+  const wakeTimeByDate = new Map(
+    sleepSessions
+      .map((s) => [s.wake_date, extractJstHHMM(s.wake_at)] as [string, string | null])
+      .filter((entry): entry is [string, string] => entry[1] !== null)
+  );
 
   if (sorted.length === 0) {
     return (
@@ -80,7 +88,8 @@ export function RecentLogsCards({ logs, seasonMap, currentSeason }: RecentLogsCa
               {(() => {
                 const prevDate    = addDaysStr(log.log_date, -1);
                 const prevDayLog  = prevDate ? (logByDate.get(prevDate) ?? null) : null;
-                const fastingHours = calcFastingHours(prevDayLog?.last_meal_end_time, log.weigh_in_time);
+                const wakeUpTime  = wakeTimeByDate.get(log.log_date) ?? null;
+                const fastingHours = calcFastingHours(prevDayLog?.last_meal_end_time, wakeUpTime);
                 if (!conditionSummary && log.sleep_hours === null && fastingHours === null) return null;
                 return (
                   <div className="mt-0.5 text-[10px] leading-snug text-slate-400 dark:text-slate-500">

--- a/src/components/dashboard/RecentLogsTable.tsx
+++ b/src/components/dashboard/RecentLogsTable.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { ArrowDown, ArrowUp, Minus } from "lucide-react";
-import type { DashboardDailyLog } from "@/lib/supabase/types";
+import type { DashboardDailyLog, SleepSession } from "@/lib/supabase/types";
+import { extractJstHHMM } from "@/lib/utils/sleepSession";
 import { DAY_TAGS, DAY_TAG_LABELS, DAY_TAG_BADGE_COLORS } from "@/lib/utils/dayTags";
 import { formatConditionSummary } from "@/lib/utils/trainingType";
 import { computeWeightDelta, buildRecentLogArrays } from "@/lib/utils/recentLogsUtils";
@@ -10,15 +11,22 @@ import { addDaysStr } from "@/lib/utils/date";
 
 interface RecentLogsTableProps {
   logs: DashboardDailyLog[];
+  sleepSessions?: Pick<SleepSession, "wake_date" | "wake_at">[];
   embedded?: boolean;
   seasonMap?: Map<string, string>;   // log_date → season name
   currentSeason?: string | null;
 }
 
-export function RecentLogsTable({ logs, embedded = false, seasonMap, currentSeason }: RecentLogsTableProps) {
+export function RecentLogsTable({ logs, sleepSessions = [], embedded = false, seasonMap, currentSeason }: RecentLogsTableProps) {
   const { sorted, ascending } = buildRecentLogArrays(logs);
   // 断食時間算出用: 日付 → ログ の高速参照テーブル（前日 D-1 の last_meal_end_time を参照するため）
   const logByDate = new Map(ascending.map((l) => [l.log_date, l]));
+  // 断食時間算出用: wake_date → wake_at (JST HH:MM) の高速参照テーブル
+  const wakeTimeByDate = new Map(
+    sleepSessions
+      .map((s) => [s.wake_date, extractJstHHMM(s.wake_at)] as [string, string | null])
+      .filter((entry): entry is [string, string] => entry[1] !== null)
+  );
 
   /** 直前ログとのカロリー差分。calories / 前回 calories いずれかが null なら null */
   function getCalDelta(log: DashboardDailyLog): number | null {
@@ -77,7 +85,8 @@ export function RecentLogsTable({ logs, embedded = false, seasonMap, currentSeas
                   {(() => {
                     const prevDate    = addDaysStr(log.log_date, -1);
                     const prevDayLog  = prevDate ? (logByDate.get(prevDate) ?? null) : null;
-                    const fastingHours = calcFastingHours(prevDayLog?.last_meal_end_time, log.weigh_in_time);
+                    const wakeUpTime  = wakeTimeByDate.get(log.log_date) ?? null;
+                    const fastingHours = calcFastingHours(prevDayLog?.last_meal_end_time, wakeUpTime);
                     if (!conditionSummary && log.sleep_hours === null && fastingHours === null) return null;
                     return (
                       <div className="mt-1 text-xs leading-snug text-slate-500 dark:text-slate-400">

--- a/src/components/meal/MealLogger.test.ts
+++ b/src/components/meal/MealLogger.test.ts
@@ -13,7 +13,6 @@ const base = {
   trainingTypeTouched: false,
   workModeTouched: false,
   lastMealEndTimeTouched: false,
-  weighInTimeTouched: false,
 } satisfies Parameters<typeof computeHasContent>[0];
 
 describe("computeHasContent", () => {
@@ -204,10 +203,6 @@ describe("computeHasDailyLogChanges", () => {
 
   it("lastMealEndTimeTouched=true → true", () => {
     expect(computeHasDailyLogChanges({ ...base, lastMealEndTimeTouched: true })).toBe(true);
-  });
-
-  it("weighInTimeTouched=true → true", () => {
-    expect(computeHasDailyLogChanges({ ...base, weighInTimeTouched: true })).toBe(true);
   });
 
   // ── 複合ケース ──

--- a/src/components/meal/MealLogger.tsx
+++ b/src/components/meal/MealLogger.tsx
@@ -50,7 +50,6 @@ export interface HasContentInput {
   trainingTypeTouched: boolean;
   workModeTouched: boolean;
   lastMealEndTimeTouched: boolean;
-  weighInTimeTouched: boolean;
 }
 
 export function computeHasContent(input: HasContentInput): boolean {
@@ -67,8 +66,7 @@ export function computeHasContent(input: HasContentInput): boolean {
     input.hadBowelMovementTouched || // touched なら null 送信も含め有効化
     input.trainingTypeTouched ||
     input.workModeTouched ||
-    input.lastMealEndTimeTouched ||
-    input.weighInTimeTouched
+    input.lastMealEndTimeTouched
   );
 }
 
@@ -89,8 +87,7 @@ export function computeHasDailyLogChanges(input: HasContentInput): boolean {
     input.hadBowelMovementTouched ||
     input.trainingTypeTouched ||
     input.workModeTouched ||
-    input.lastMealEndTimeTouched ||
-    input.weighInTimeTouched
+    input.lastMealEndTimeTouched
     // sleepSessionTouched は sleep_sessions 側の変更。daily_logs には含めない。
   );
 }
@@ -162,8 +159,6 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
   // "" = 未入力, "HH:MM" = 入力値。null は使わない（time input はクリアで "" になる）
   const [lastMealEndTime, setLastMealEndTime] = useState("");
   const [lastMealEndTimeTouched, setLastMealEndTimeTouched] = useState(false);
-  const [weighInTime, setWeighInTime] = useState("");
-  const [weighInTimeTouched, setWeighInTimeTouched] = useState(false);
 
   // 食品を追加セクションの開閉状態（初期: 非表示）
   const [foodPickerOpen, setFoodPickerOpen] = useState(false);
@@ -191,7 +186,6 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
     setTrainingTypeTouched(false);
     setWorkModeTouched(false);
     setLastMealEndTimeTouched(false);
-    setWeighInTimeTouched(false);
     setTouchedTags(new Set());
 
     // カートはマクロ値から復元不可のためリセット
@@ -213,7 +207,6 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
       });
       // TIME 型は "HH:MM:SS" で返るため、input[type=time] 用に "HH:MM" に切り出す
       setLastMealEndTime(existingLog.last_meal_end_time?.slice(0, 5) ?? "");
-      setWeighInTime(existingLog.weigh_in_time?.slice(0, 5) ?? "");
     } else {
       // 新規日付: 空フォームにリセット
       setWeight("");
@@ -223,7 +216,6 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
       setWorkMode(null);
       setTags(emptyTagState());
       setLastMealEndTime("");
-      setWeighInTime("");
     }
 
     // 睡眠セッション: TIMESTAMPTZ (UTC) から JST の "HH:MM" を復元
@@ -354,7 +346,7 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
         note, noteTouched, touchedTags,
         sleepSessionTouched, // 渡すが computeHasDailyLogChanges 内では無視される
         hadBowelMovementTouched, trainingTypeTouched, workModeTouched,
-        lastMealEndTimeTouched, weighInTimeTouched,
+        lastMealEndTimeTouched,
       });
 
       if (hasDailyLogChanges) {
@@ -393,7 +385,6 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
           work_mode:          workModeTouched     ? workMode     : undefined,
           // 時刻: touched かつ非空 → 値保存、touched かつ空 → null（明示クリア）、未操作 → undefined
           last_meal_end_time: lastMealEndTimeTouched ? (lastMealEndTime !== "" ? lastMealEndTime : null) : undefined,
-          weigh_in_time:      weighInTimeTouched     ? (weighInTime      !== "" ? weighInTime      : null) : undefined,
         });
 
         if (!result.ok) {
@@ -430,8 +421,6 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
       setWorkModeTouched(false);
       setLastMealEndTime("");
       setLastMealEndTimeTouched(false);
-      setWeighInTime("");
-      setWeighInTimeTouched(false);
       // SWR キャッシュを更新して次回 hydrate に最新ログを反映させる
       void mutateLogs();
       void mutateSleepSessions();
@@ -453,7 +442,7 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
     note, noteTouched, touchedTags,
     sleepSessionTouched,
     hadBowelMovementTouched, trainingTypeTouched, workModeTouched,
-    lastMealEndTimeTouched, weighInTimeTouched,
+    lastMealEndTimeTouched,
   });
 
   // 就寝・起床時刻から推定睡眠時間をリアルタイム計算（入力フィードバック用）
@@ -717,20 +706,6 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
               onChange={(e) => { setLastMealEndTime(e.target.value); setLastMealEndTimeTouched(true); }}
               className={inputCls}
             />
-          </div>
-          {/* 体重測定時刻 */}
-          <div>
-            <label htmlFor="meal-log-weigh-in-time" className="mb-1.5 block text-xs font-medium text-slate-500">体重測定時刻</label>
-            <input
-              id="meal-log-weigh-in-time"
-              type="time"
-              value={weighInTime}
-              onChange={(e) => { setWeighInTime(e.target.value); setWeighInTimeTouched(true); }}
-              className={inputCls}
-            />
-            <p className="mt-1 text-[10px] text-slate-400">
-              空腹時間算出に使用（最終食事終了〜測定まで）
-            </p>
           </div>
           {/* 便通 */}
           <div>

--- a/src/lib/queries/dailyLogs.ts
+++ b/src/lib/queries/dailyLogs.ts
@@ -45,7 +45,7 @@ import type { QueryResult } from "./queryResult";
  *   log_date, weight, calories, protein, fat, carbs,
  *   is_cheat_day, is_refeed_day, is_eating_out, is_travel_day,
  *   sleep_hours, had_bowel_movement, training_type, work_mode, updated_at,
- *   last_meal_end_time, weigh_in_time, step_count
+ *   last_meal_end_time, weigh_in_time (sleep_sessions.wake_at から自動同期 #526), step_count
  *
  * 除外列 (2列):
  *   - note     : Dashboard のいずれの関数・コンポーネントでも参照されない

--- a/src/lib/queries/dailyLogs.ts
+++ b/src/lib/queries/dailyLogs.ts
@@ -41,15 +41,16 @@ import type { QueryResult } from "./queryResult";
  *
  * ## 取得列と除外列の根拠（#165 棚卸し済み、#435 で時刻列追加、#436 で step_count 追加）
  *
- * 取得列 (19列):
+ * 取得列 (18列):
  *   log_date, weight, calories, protein, fat, carbs,
  *   is_cheat_day, is_refeed_day, is_eating_out, is_travel_day,
  *   sleep_hours, had_bowel_movement, training_type, work_mode, updated_at,
- *   last_meal_end_time, weigh_in_time (sleep_sessions.wake_at から自動同期 #526), step_count
+ *   last_meal_end_time, step_count, bed_time
  *
- * 除外列 (2列):
- *   - note     : Dashboard のいずれの関数・コンポーネントでも参照されない
- *   - leg_flag : Dashboard では参照されない（training_type から導出される派生値）
+ * 除外列 (3列):
+ *   - note          : Dashboard のいずれの関数・コンポーネントでも参照されない
+ *   - leg_flag      : Dashboard では参照されない（training_type から導出される派生値）
+ *   - weigh_in_time : #526 で廃止。起床時刻は sleep_sessions.wake_at を直接参照する
  *
  * ## 用途別の列対応
  *   - calcReadiness          : log_date, weight
@@ -84,7 +85,7 @@ export async function fetchDashboardDailyLogs(): Promise<QueryResult<DashboardDa
       "log_date, weight, calories, protein, fat, carbs, " +
       "is_cheat_day, is_refeed_day, is_eating_out, is_travel_day, " +
       "sleep_hours, had_bowel_movement, training_type, work_mode, updated_at, " +
-      "last_meal_end_time, weigh_in_time, step_count"
+      "last_meal_end_time, step_count, bed_time"
     )
     .order("log_date", { ascending: true });
   if (error) {

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -81,7 +81,6 @@ export type Database = {
           step_count: number | null
           training_type: string | null
           updated_at: string
-          weigh_in_time: string | null
           weight: number
           work_mode: string | null
         }
@@ -106,7 +105,6 @@ export type Database = {
           step_count?: number | null
           training_type?: string | null
           updated_at?: string
-          weigh_in_time?: string | null
           weight: number
           work_mode?: string | null
         }
@@ -131,7 +129,6 @@ export type Database = {
           step_count?: number | null
           training_type?: string | null
           updated_at?: string
-          weigh_in_time?: string | null
           weight?: number
           work_mode?: string | null
         }

--- a/src/lib/utils/__tests__/calcMonthlyBehaviorStats.test.ts
+++ b/src/lib/utils/__tests__/calcMonthlyBehaviorStats.test.ts
@@ -27,7 +27,6 @@ function makeLog(
     is_eating_out: false,
     is_travel_day: false,
     last_meal_end_time: null,
-    weigh_in_time: null,
     step_count: null,
     bed_time: null,
     created_at: null,

--- a/src/lib/utils/calcMacro.test.ts
+++ b/src/lib/utils/calcMacro.test.ts
@@ -23,7 +23,6 @@ function makeLog(log_date: string, overrides: Partial<DailyLog> = {}): DailyLog 
     work_mode:          null,
     leg_flag:           null,
     last_meal_end_time: null,
-    weigh_in_time:      null,
     step_count: null,
     bed_time:           null,
     updated_at:         "2026-03-01T00:00:00Z",

--- a/src/lib/utils/calcReadiness.test.ts
+++ b/src/lib/utils/calcReadiness.test.ts
@@ -47,7 +47,6 @@ function makeDailyLog(
     is_travel_day: false,
     leg_flag: false,
     last_meal_end_time: null,
-    weigh_in_time: null,
     step_count: null,
     bed_time: null,
     updated_at: "2026-03-01T00:00:00Z",

--- a/src/lib/utils/calcWeeklyReview.test.ts
+++ b/src/lib/utils/calcWeeklyReview.test.ts
@@ -26,7 +26,6 @@ function makeLog(
     updated_at: "2026-04-02T00:00:00Z",
     work_mode: null,
     last_meal_end_time: null,
-    weigh_in_time: null,
     step_count: null,
     bed_time: null,
     ...overrides,

--- a/src/lib/utils/calendarUtils.test.ts
+++ b/src/lib/utils/calendarUtils.test.ts
@@ -31,7 +31,6 @@ function makeLog(overrides: Omit<Partial<DailyLog>, "weight"> & { log_date: stri
     work_mode:          overrides.work_mode          ?? null,
     leg_flag:           overrides.leg_flag           ?? null,
     last_meal_end_time: overrides.last_meal_end_time ?? null,
-    weigh_in_time:      overrides.weigh_in_time      ?? null,
     step_count:         overrides.step_count         ?? null,
     bed_time:           overrides.bed_time           ?? null,
     updated_at:         overrides.updated_at         ?? "2026-03-01T00:00:00Z",
@@ -297,13 +296,14 @@ describe("buildConditionTags", () => {
 // ── buildCalendarDayMap — fasting_hours (前日参照仕様) ─────────────────────────
 
 describe("buildCalendarDayMap — fasting_hours", () => {
-  it("前日 last_meal_end_time と当日 weigh_in_time から算出する", () => {
+  it("前日 last_meal_end_time と当日 sleep_sessions.wake_at から算出する", () => {
     // 前日 22:30 → 当日 07:00 = 8.5h
     const logs = [
       makeLog({ log_date: "2026-03-09", weight: 70, last_meal_end_time: "22:30:00" }),
-      makeLog({ log_date: "2026-03-10", weight: 70, weigh_in_time: "07:00:00" }),
+      makeLog({ log_date: "2026-03-10", weight: 70 }),
     ];
-    const map = buildCalendarDayMap(logs);
+    const sleepSessions = [{ wake_date: "2026-03-10", wake_at: "2026-03-10T07:00:00+09:00" }];
+    const map = buildCalendarDayMap(logs, sleepSessions);
     expect(map.get("2026-03-10")!.fasting_hours).toBe(8.5);
   });
 
@@ -311,9 +311,10 @@ describe("buildCalendarDayMap — fasting_hours", () => {
     // 2026-03-11 の前日 (2026-03-10) はログなし
     const logs = [
       makeLog({ log_date: "2026-03-09", weight: 70, last_meal_end_time: "22:30:00" }),
-      makeLog({ log_date: "2026-03-11", weight: 70, weigh_in_time: "07:00:00" }),
+      makeLog({ log_date: "2026-03-11", weight: 70 }),
     ];
-    const map = buildCalendarDayMap(logs);
+    const sleepSessions = [{ wake_date: "2026-03-11", wake_at: "2026-03-11T07:00:00+09:00" }];
+    const map = buildCalendarDayMap(logs, sleepSessions);
     // 2026-03-10 のログが存在しないので 2026-03-11 は null
     expect(map.get("2026-03-11")!.fasting_hours).toBeNull();
   });
@@ -321,17 +322,19 @@ describe("buildCalendarDayMap — fasting_hours", () => {
   it("前日 last_meal_end_time がない場合は null", () => {
     const logs = [
       makeLog({ log_date: "2026-03-09", weight: 70, last_meal_end_time: null }),
-      makeLog({ log_date: "2026-03-10", weight: 70, weigh_in_time: "07:00:00" }),
+      makeLog({ log_date: "2026-03-10", weight: 70 }),
     ];
-    const map = buildCalendarDayMap(logs);
+    const sleepSessions = [{ wake_date: "2026-03-10", wake_at: "2026-03-10T07:00:00+09:00" }];
+    const map = buildCalendarDayMap(logs, sleepSessions);
     expect(map.get("2026-03-10")!.fasting_hours).toBeNull();
   });
 
-  it("当日 weigh_in_time がない場合は null", () => {
+  it("当日 sleep_sessions がない場合は null", () => {
     const logs = [
       makeLog({ log_date: "2026-03-09", weight: 70, last_meal_end_time: "22:30:00" }),
-      makeLog({ log_date: "2026-03-10", weight: 70, weigh_in_time: null }),
+      makeLog({ log_date: "2026-03-10", weight: 70 }),
     ];
+    // sleepSessions を渡さない（2026-03-10 の sleep_session なし）
     const map = buildCalendarDayMap(logs);
     expect(map.get("2026-03-10")!.fasting_hours).toBeNull();
   });
@@ -339,28 +342,34 @@ describe("buildCalendarDayMap — fasting_hours", () => {
   it("当日の same-day last_meal_end_time は断食時間に使われない", () => {
     // 当日 D に last_meal_end_time があっても、前日がなければ null
     const logs = [
-      makeLog({ log_date: "2026-03-10", weight: 70, last_meal_end_time: "22:30:00", weigh_in_time: "07:00:00" }),
+      makeLog({ log_date: "2026-03-10", weight: 70, last_meal_end_time: "22:30:00" }),
     ];
-    const map = buildCalendarDayMap(logs);
+    const sleepSessions = [{ wake_date: "2026-03-10", wake_at: "2026-03-10T07:00:00+09:00" }];
+    const map = buildCalendarDayMap(logs, sleepSessions);
     // 前日ログがないので null（旧仕様では 8.5h だった）
     expect(map.get("2026-03-10")!.fasting_hours).toBeNull();
   });
 
   it("ログが1件のみ（前日参照不能）の場合は null", () => {
     const logs = [
-      makeLog({ log_date: "2026-03-10", weight: 70, last_meal_end_time: "22:30:00", weigh_in_time: "07:00:00" }),
+      makeLog({ log_date: "2026-03-10", weight: 70, last_meal_end_time: "22:30:00" }),
     ];
-    const map = buildCalendarDayMap(logs);
+    const sleepSessions = [{ wake_date: "2026-03-10", wake_at: "2026-03-10T07:00:00+09:00" }];
+    const map = buildCalendarDayMap(logs, sleepSessions);
     expect(map.get("2026-03-10")!.fasting_hours).toBeNull();
   });
 
   it("連続ログが複数ある場合、各日は正しく前日を参照する", () => {
     const logs = [
       makeLog({ log_date: "2026-03-08", weight: 70, last_meal_end_time: "21:00:00" }),
-      makeLog({ log_date: "2026-03-09", weight: 70, last_meal_end_time: "22:30:00", weigh_in_time: "06:00:00" }),
-      makeLog({ log_date: "2026-03-10", weight: 70, weigh_in_time: "07:00:00" }),
+      makeLog({ log_date: "2026-03-09", weight: 70, last_meal_end_time: "22:30:00" }),
+      makeLog({ log_date: "2026-03-10", weight: 70 }),
     ];
-    const map = buildCalendarDayMap(logs);
+    const sleepSessions = [
+      { wake_date: "2026-03-09", wake_at: "2026-03-09T06:00:00+09:00" },
+      { wake_date: "2026-03-10", wake_at: "2026-03-10T07:00:00+09:00" },
+    ];
+    const map = buildCalendarDayMap(logs, sleepSessions);
     // 2026-03-09: 前日(08) 21:00 → 当日(09) 06:00 = 9h
     expect(map.get("2026-03-09")!.fasting_hours).toBe(9);
     // 2026-03-10: 前日(09) 22:30 → 当日(10) 07:00 = 8.5h

--- a/src/lib/utils/calendarUtils.test.ts
+++ b/src/lib/utils/calendarUtils.test.ts
@@ -416,7 +416,7 @@ describe("calcFastingHours", () => {
 
   // 境界値テスト
   it("delta=1439（23h59m）: null にならず 24.0h を返す（丸め結果）", () => {
-    // lastMealEndTime=00:01, weighInTime=00:00 → delta=-1+1440=1439 < 1440 → 有効
+    // lastMealEndTime=00:01, wakeUpTime=00:00 → delta=-1+1440=1439 < 1440 → 有効
     // Math.round(1439/60*10)/10 = Math.round(239.83)/10 = 240/10 = 24.0
     expect(calcFastingHours("00:01", "00:00")).toBe(24.0);
   });

--- a/src/lib/utils/calendarUtils.ts
+++ b/src/lib/utils/calendarUtils.ts
@@ -11,9 +11,11 @@
  */
 
 import type { DashboardDailyLog } from "@/lib/supabase/types";
+import type { SleepSession } from "@/lib/supabase/types";
 import { DAY_TAGS, DAY_TAG_LABELS, DAY_TAG_BADGE_COLORS } from "./dayTags";
 import { formatConditionSummary, isValidTrainingType, isValidWorkMode, TRAINING_TYPE_LABELS, WORK_MODE_LABELS } from "./trainingType";
 import { addDaysStr } from "./date";
+import { extractJstHHMM } from "./sleepSession";
 
 // ── 型定義 ──────────────────────────────────────────────────────────────────
 
@@ -47,9 +49,8 @@ export interface CalendarDayData {
   conditionTags: CalendarDayTagInfo[];
   /**
    * 断食時間（時間単位、小数点1桁）。
-   * 表示日 D の断食時間 = 前日 D-1 の last_meal_end_time と 当日 D の weigh_in_time の差分。
-   * weigh_in_time は sleep_sessions.wake_at から DB トリガーで自動同期される（#526）。
-   * 前日ログなし・前日に last_meal_end_time なし・当日に weigh_in_time なし のいずれかで null。
+   * 表示日 D の断食時間 = 前日 D-1 の last_meal_end_time と 当日 D の sleep_sessions.wake_at の差分。
+   * 前日ログなし・前日に last_meal_end_time なし・当日に sleep_sessions なし のいずれかで null。
    */
   fasting_hours: number | null;
 }
@@ -64,7 +65,7 @@ export interface CalendarDayData {
  *
  * 呼び出し側の責務:
  *   - lastMealEndTime には「前日 D-1 の last_meal_end_time」を渡すこと
- *   - wakeUpTime には「当日 D の weigh_in_time」を渡すこと（sleep_sessions.wake_at から自動同期）
+ *   - wakeUpTime には「当日 D の sleep_sessions.wake_at を JST 変換した HH:MM」を渡すこと
  *   - 前日ログが存在しない場合は null を渡し、呼び出し側でハンドリングすること
  */
 export function calcFastingHours(
@@ -176,7 +177,10 @@ export function getMobileTrainingLabel(
  * - ログが存在しない日は Map に含まれない
  * - 差分は「直前のログ日の記録値」との差分（欠損日を跨ぐ）
  */
-export function buildCalendarDayMap(logs: DashboardDailyLog[]): Map<string, CalendarDayData> {
+export function buildCalendarDayMap(
+  logs: DashboardDailyLog[],
+  sleepSessions: Pick<SleepSession, "wake_date" | "wake_at">[] = [],
+): Map<string, CalendarDayData> {
   const sorted = [...logs].sort((a, b) => a.log_date.localeCompare(b.log_date));
 
   // 体重・カロリーそれぞれの「記録ありログ」リスト（差分計算用）
@@ -185,6 +189,13 @@ export function buildCalendarDayMap(logs: DashboardDailyLog[]): Map<string, Cale
 
   // 断食時間算出用: 日付 → ログ の高速参照テーブル
   const logByDate = new Map(sorted.map((l) => [l.log_date, l]));
+
+  // 断食時間算出用: wake_date → wake_at (JST HH:MM) の高速参照テーブル
+  const wakeTimeByDate = new Map(
+    sleepSessions
+      .map((s) => [s.wake_date, extractJstHHMM(s.wake_at)] as [string, string | null])
+      .filter((entry): entry is [string, string] => entry[1] !== null)
+  );
 
   const map = new Map<string, CalendarDayData>();
 
@@ -230,11 +241,12 @@ export function buildCalendarDayMap(logs: DashboardDailyLog[]): Map<string, Cale
       work_mode:          log.work_mode,
     });
 
-    // 断食時間: 前日 D-1 の last_meal_end_time → 当日 D の weigh_in_time (sleep_sessions.wake_at から自動同期)
-    // 前日ログなし・前日 last_meal_end_time なし・当日 weigh_in_time なし → null
+    // 断食時間: 前日 D-1 の last_meal_end_time → 当日 D の sleep_sessions.wake_at (JST HH:MM)
+    // 前日ログなし・前日 last_meal_end_time なし・当日 sleep_sessions なし → null
     const prevDateKey = addDaysStr(log.log_date, -1);
     const prevDayLog  = prevDateKey ? (logByDate.get(prevDateKey) ?? null) : null;
-    const fasting_hours = calcFastingHours(prevDayLog?.last_meal_end_time, log.weigh_in_time);
+    const wakeUpTime  = wakeTimeByDate.get(log.log_date) ?? null;
+    const fasting_hours = calcFastingHours(prevDayLog?.last_meal_end_time, wakeUpTime);
 
     map.set(log.log_date, {
       log, weightDelta, calDelta, dayTags, conditionSummary, conditionTags, fasting_hours,

--- a/src/lib/utils/calendarUtils.ts
+++ b/src/lib/utils/calendarUtils.ts
@@ -48,6 +48,7 @@ export interface CalendarDayData {
   /**
    * 断食時間（時間単位、小数点1桁）。
    * 表示日 D の断食時間 = 前日 D-1 の last_meal_end_time と 当日 D の weigh_in_time の差分。
+   * weigh_in_time は sleep_sessions.wake_at から DB トリガーで自動同期される（#526）。
    * 前日ログなし・前日に last_meal_end_time なし・当日に weigh_in_time なし のいずれかで null。
    */
   fasting_hours: number | null;
@@ -57,20 +58,20 @@ export interface CalendarDayData {
  * 2つの時刻文字列から断食時間（h）を算出する低レベルユーティリティ。
  *
  * - 両方の時刻が存在する場合のみ計算する。
- * - 日をまたぐ場合（weighInTime < lastMealEndTime）は +24h で補正する。
+ * - 日をまたぐ場合（wakeUpTime < lastMealEndTime）は +24h で補正する。
  * - タイムゾーン情報なし・時刻のみを扱う。
  * - 入力は "HH:MM" または "HH:MM:SS" 形式を許容する（PostgreSQL TIME 型は "HH:MM:SS" で返す）。
  *
  * 呼び出し側の責務:
  *   - lastMealEndTime には「前日 D-1 の last_meal_end_time」を渡すこと
- *   - weighInTime には「当日 D の weigh_in_time」を渡すこと
+ *   - wakeUpTime には「当日 D の weigh_in_time」を渡すこと（sleep_sessions.wake_at から自動同期）
  *   - 前日ログが存在しない場合は null を渡し、呼び出し側でハンドリングすること
  */
 export function calcFastingHours(
   lastMealEndTime: string | null | undefined,
-  weighInTime: string | null | undefined,
+  wakeUpTime: string | null | undefined,
 ): number | null {
-  if (!lastMealEndTime || !weighInTime) return null;
+  if (!lastMealEndTime || !wakeUpTime) return null;
   const parseMins = (t: string): number | null => {
     const parts = t.split(":");
     const h = parseInt(parts[0] ?? "");
@@ -79,7 +80,7 @@ export function calcFastingHours(
     return h * 60 + m;
   };
   const lastMins  = parseMins(lastMealEndTime);
-  const weighMins = parseMins(weighInTime);
+  const weighMins = parseMins(wakeUpTime);
   if (lastMins === null || weighMins === null) return null;
   let delta = weighMins - lastMins;
   // delta < 0: 日またぎ（例: 前日 22:30 → 翌朝 07:00）→ +24h で正値に補正
@@ -229,7 +230,7 @@ export function buildCalendarDayMap(logs: DashboardDailyLog[]): Map<string, Cale
       work_mode:          log.work_mode,
     });
 
-    // 断食時間: 前日 D-1 の last_meal_end_time → 当日 D の weigh_in_time
+    // 断食時間: 前日 D-1 の last_meal_end_time → 当日 D の weigh_in_time (sleep_sessions.wake_at から自動同期)
     // 前日ログなし・前日 last_meal_end_time なし・当日 weigh_in_time なし → null
     const prevDateKey = addDaysStr(log.log_date, -1);
     const prevDayLog  = prevDateKey ? (logByDate.get(prevDateKey) ?? null) : null;

--- a/src/lib/utils/sleep.test.ts
+++ b/src/lib/utils/sleep.test.ts
@@ -1,7 +1,7 @@
 /**
  * deriveSleepHours — ユニットテスト
  *
- * 就寝時刻 (bed_time) と体重測定時刻 (weigh_in_time) から
+ * 就寝時刻 (bed_time) と起床時刻 (wake_up_time) から
  * 推定睡眠時間 (sleep_hours) を算出する純粋関数の検証。
  */
 
@@ -41,7 +41,7 @@ describe("deriveSleepHours — 日またぎなし（当日内）", () => {
   });
 
   test("22:00 → 22:30: 0.5h", () => {
-    // weigh_in_time (22:30) > bed_time (22:00) → 日またぎなし
+    // wake_up_time (22:30) > bed_time (22:00) → 日またぎなし
     expect(deriveSleepHours("22:00", "22:30")).toBe(0.5);
   });
 });
@@ -78,7 +78,7 @@ describe("deriveSleepHours — 小数点丸め", () => {
 
 describe("deriveSleepHours — 異常値 (null を返す)", () => {
   test("同一時刻: 日またぎ補正後 24h → null", () => {
-    // bed_time = weigh_in_time → 日またぎで +24h → diffHours = 24 → 無効
+    // bed_time = wake_up_time → 日またぎで +24h → diffHours = 24 → 無効
     expect(deriveSleepHours("07:00", "07:00")).toBeNull();
   });
 

--- a/src/lib/utils/sleep.ts
+++ b/src/lib/utils/sleep.ts
@@ -1,14 +1,15 @@
 /**
  * 推定睡眠時間算出ユーティリティ
  *
- * bed_time (就寝時刻) と weigh_in_time (起床・体重測定時刻) から
+ * bed_time (就寝時刻) と weigh_in_time (起床時刻) から
  * 推定睡眠時間 (sleep_hours) を算出する純粋関数群。
  *
  * ## 起床日基準（#507）
  *
- * sleep_hours は「log_date（起床・測定日）に属する睡眠セッション」の長さを表す。
+ * sleep_hours は「log_date（起床日）に属する睡眠セッション」の長さを表す。
  * bed_time が前日夜・当日深夜・早朝のいずれであっても、
- * weigh_in_time（= 起床 proxy）と同じ log_date に属する値として扱う。
+ * weigh_in_time（= 起床時刻。#526 以降は sleep_sessions.wake_at から DB トリガーで自動同期）
+ * と同じ log_date に属する値として扱う。
  *
  * 例（いずれも log_date = 2026-04-08）:
  *   - 前日夜就寝: bed_time=23:30, weigh_in_time=07:00 → 7.5h （日またぎ補正あり）
@@ -48,34 +49,36 @@ function timeToMinutes(time: string): number | null {
 }
 
 /**
- * bed_time と weigh_in_time から推定睡眠時間 (sleep_hours) を算出する。
+ * bed_time と wake_up_time から推定睡眠時間 (sleep_hours) を算出する。
  *
  * 起床日基準: bedTime は log_date の朝に起床した睡眠セッションの開始時刻を表す。
  * 前日夜（23:30 等）・当日深夜（01:30 等）・早朝（04:00 等）のいずれも同じ計算式で処理する。
  *
+ * #526: wake_up_time (= weigh_in_time) は sleep_sessions.wake_at から DB トリガーで自動同期される。
+ *
  * @param bedTime     就寝時刻 "HH:MM" または "HH:MM:SS"
  *                    （この log_date の朝の起床に対応する睡眠セッションの開始時刻）
- * @param weighInTime 起床・体重測定時刻 "HH:MM" または "HH:MM:SS"
+ * @param wakeUpTime  起床時刻 "HH:MM" または "HH:MM:SS"（daily_logs.weigh_in_time の値）
  * @returns 推定睡眠時間 (h, 小数点以下 1 桁)、または null (算出不能・異常値)
  *
  * 仕様:
- *   - weigh_in_time <= bed_time: 日またぎとみなし weigh_in_time に 24h を加算
- *     （log_date の朝 = bed_time の翌朝にあたる前日夜就寝ケース）
+ *   - wakeUpTime <= bedTime: 日またぎとみなし wakeUpTime に 24h を加算
+ *     （log_date の朝 = bedTime の翌朝にあたる前日夜就寝ケース）
  *   - 有効範囲: 0h 超かつ 24h 未満 (境界値を除く)
- *     - 0h 以下: 同一時刻または weigh_in_time が bed_time より前すぎる異常値
+ *     - 0h 以下: 同一時刻または wakeUpTime が bedTime より前すぎる異常値
  *     - 24h 以上: 就寝・起床が同一時刻 (日またぎ補正後 24h) = 異常値
  *   - 時刻形式が不正な場合は null を返す
  */
 export function deriveSleepHours(
   bedTime: string,
-  weighInTime: string
+  wakeUpTime: string
 ): number | null {
   const bedMin = timeToMinutes(bedTime);
-  const weighMin = timeToMinutes(weighInTime);
+  const weighMin = timeToMinutes(wakeUpTime);
 
   if (bedMin === null || weighMin === null) return null;
 
-  // 日またぎ補正: weigh_in_time <= bed_time → 前日夜就寝（log_date の朝が bed_time の翌朝）
+  // 日またぎ補正: wakeUpTime <= bedTime → 前日夜就寝（log_date の朝が bedTime の翌朝）
   const adjustedWeighMin = weighMin <= bedMin ? weighMin + 24 * 60 : weighMin;
 
   const diffHours = (adjustedWeighMin - bedMin) / 60;

--- a/src/lib/utils/sleep.ts
+++ b/src/lib/utils/sleep.ts
@@ -1,24 +1,24 @@
 /**
  * 推定睡眠時間算出ユーティリティ
  *
- * bed_time (就寝時刻) と weigh_in_time (起床時刻) から
+ * bed_time (就寝時刻) と wake_up_time (起床時刻) から
  * 推定睡眠時間 (sleep_hours) を算出する純粋関数群。
  *
  * ## 起床日基準（#507）
  *
  * sleep_hours は「log_date（起床日）に属する睡眠セッション」の長さを表す。
  * bed_time が前日夜・当日深夜・早朝のいずれであっても、
- * weigh_in_time（= 起床時刻。#526 以降は sleep_sessions.wake_at から DB トリガーで自動同期）
+ * wake_up_time（= 起床時刻。sleep_sessions.wake_at を extractJstHHMM で変換した値）
  * と同じ log_date に属する値として扱う。
  *
  * 例（いずれも log_date = 2026-04-08）:
- *   - 前日夜就寝: bed_time=23:30, weigh_in_time=07:00 → 7.5h （日またぎ補正あり）
- *   - 当日深夜就寝: bed_time=01:30, weigh_in_time=08:00 → 6.5h
- *   - 早朝就寝: bed_time=04:00, weigh_in_time=10:00 → 6.0h
+ *   - 前日夜就寝: bed_time=23:30, wake_up_time=07:00 → 7.5h （日またぎ補正あり）
+ *   - 当日深夜就寝: bed_time=01:30, wake_up_time=08:00 → 6.5h
+ *   - 早朝就寝: bed_time=04:00, wake_up_time=10:00 → 6.0h
  *
  * 設計方針:
  *   - 計算ロジックをここに集約し、UI 側での再実装を禁止する
- *   - 日またぎ補正: weigh_in_time <= bed_time の場合、weigh_in_time に 24h を加算
+ *   - 日またぎ補正: wake_up_time <= bed_time の場合、wake_up_time に 24h を加算
  *     （log_date の朝 = bed_time の翌朝にあたるため）
  *   - 有効範囲: (0, 24) — 0h 以下・24h 以上は異常値として null を返す
  *   - 結果は小数点以下 1 桁に丸める (例: 7.5h)
@@ -54,11 +54,11 @@ function timeToMinutes(time: string): number | null {
  * 起床日基準: bedTime は log_date の朝に起床した睡眠セッションの開始時刻を表す。
  * 前日夜（23:30 等）・当日深夜（01:30 等）・早朝（04:00 等）のいずれも同じ計算式で処理する。
  *
- * #526: wake_up_time (= weigh_in_time) は sleep_sessions.wake_at から DB トリガーで自動同期される。
+ * #526: wake_up_time は sleep_sessions.wake_at を extractJstHHMM で JST 変換した値。
  *
  * @param bedTime     就寝時刻 "HH:MM" または "HH:MM:SS"
  *                    （この log_date の朝の起床に対応する睡眠セッションの開始時刻）
- * @param wakeUpTime  起床時刻 "HH:MM" または "HH:MM:SS"（daily_logs.weigh_in_time の値）
+ * @param wakeUpTime  起床時刻 "HH:MM" または "HH:MM:SS"（sleep_sessions.wake_at の JST 変換値）
  * @returns 推定睡眠時間 (h, 小数点以下 1 桁)、または null (算出不能・異常値)
  *
  * 仕様:

--- a/supabase/migrations/20260409000000_sync_weigh_in_time_from_sleep_sessions.sql
+++ b/supabase/migrations/20260409000000_sync_weigh_in_time_from_sleep_sessions.sql
@@ -1,0 +1,44 @@
+-- daily_logs.weigh_in_time を sleep_sessions.wake_at から自動同期するトリガー (#526)
+--
+-- 目的:
+--   体重測定時刻 (weigh_in_time) を廃止し、起床時刻へ統合する。
+--   「体重は常に起床直後に測定する」という運用前提のもと、
+--   朝の基準時刻の source of truth を sleep_sessions.wake_at に一本化する。
+--
+--   これにより daily_logs.weigh_in_time は手動入力列ではなく、
+--   sleep_sessions.wake_at から派生した projection 値となる。
+--   (sleep_hours の trg_sync_sleep_hours と同じパターン)
+--
+-- 動作:
+--   INSERT / UPDATE: wake_at を JST (Asia/Tokyo) に変換し TIME として weigh_in_time に書き込む
+--   DELETE: weigh_in_time を NULL に戻す
+--
+-- 対応する daily_logs 行がない場合は UPDATE 0 行で無害に終了する。
+
+CREATE OR REPLACE FUNCTION sync_weigh_in_time_from_sleep_sessions()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    UPDATE daily_logs
+    SET weigh_in_time = NULL
+    WHERE log_date = OLD.wake_date;
+    RETURN OLD;
+  ELSE
+    -- wake_at (TIMESTAMPTZ) を JST に変換して TIME として保存
+    UPDATE daily_logs
+    SET weigh_in_time = (NEW.wake_at AT TIME ZONE 'Asia/Tokyo')::TIME
+    WHERE log_date = NEW.wake_date;
+    RETURN NEW;
+  END IF;
+END;
+$$;
+
+COMMENT ON FUNCTION sync_weigh_in_time_from_sleep_sessions() IS
+  'sleep_sessions の INSERT/UPDATE/DELETE 後に daily_logs.weigh_in_time を同期する。
+   weigh_in_time = wake_at を JST (Asia/Tokyo) に変換した TIME 値。
+   断食時間算出 (calcFastingHours) に使用する。
+   対応する daily_logs 行がなければ UPDATE 0 行で無害に終了する。';
+
+CREATE TRIGGER trg_sync_weigh_in_time
+AFTER INSERT OR UPDATE OR DELETE ON sleep_sessions
+FOR EACH ROW EXECUTE FUNCTION sync_weigh_in_time_from_sleep_sessions();

--- a/supabase/migrations/20260409000001_backfill_weigh_in_time_from_sleep_sessions.sql
+++ b/supabase/migrations/20260409000001_backfill_weigh_in_time_from_sleep_sessions.sql
@@ -1,0 +1,24 @@
+-- 既存 sleep_sessions → daily_logs.weigh_in_time の一括 backfill (#526)
+--
+-- 目的:
+--   20260409000000 で追加したトリガー (trg_sync_weigh_in_time) は
+--   今後の sleep_sessions INSERT/UPDATE を同期するが、
+--   migration 適用前に保存済みの sleep_sessions は同期されていない。
+--   ここで既存レコードをすべて一括同期する。
+--
+-- 動作:
+--   sleep_sessions に対応する wake_date をもつ daily_logs の行について
+--   weigh_in_time = wake_at (JST) の TIME 値 を設定する。
+--   対応する sleep_sessions がない daily_logs 行には触れない（NULL のまま）。
+
+UPDATE daily_logs dl
+SET weigh_in_time = (
+  SELECT (ss.wake_at AT TIME ZONE 'Asia/Tokyo')::TIME
+  FROM sleep_sessions ss
+  WHERE ss.wake_date = dl.log_date
+)
+WHERE EXISTS (
+  SELECT 1
+  FROM sleep_sessions ss
+  WHERE ss.wake_date = dl.log_date
+);

--- a/supabase/migrations/20260410000000_drop_weigh_in_time_from_daily_logs.sql
+++ b/supabase/migrations/20260410000000_drop_weigh_in_time_from_daily_logs.sql
@@ -1,0 +1,148 @@
+-- daily_logs.weigh_in_time カラムを廃止する (#526 Option B)
+--
+-- 目的:
+--   sleep_sessions.wake_at が起床時刻の source of truth となったため、
+--   projection カラム weigh_in_time は不要となった。
+--   フロントエンドは sleep_sessions.wake_at を直接参照する。
+--
+-- 手順:
+--   1. trg_sync_weigh_in_time トリガー・関数を削除
+--   2. save_daily_log_partial RPC から weigh_in_time を除去して再定義
+--   3. daily_logs.weigh_in_time カラムを削除
+--
+-- 既存データ移行:
+--   20260409000001 の backfill migration で weigh_in_time には
+--   sleep_sessions.wake_at の JST TIME 値が入っている。
+--   フロントエンドは今後 sleep_sessions.wake_at を直接参照するため
+--   weigh_in_time の過去値は移行先が不要（sleep_sessions に源泉データが存在する）。
+
+-- ── Step 1: トリガー・関数を削除 ─────────────────────────────────────────────
+
+DROP TRIGGER IF EXISTS trg_sync_weigh_in_time ON sleep_sessions;
+
+DROP FUNCTION IF EXISTS sync_weigh_in_time_from_sleep_sessions();
+
+-- ── Step 2: save_daily_log_partial を weigh_in_time なしで再定義 ──────────────
+
+CREATE OR REPLACE FUNCTION save_daily_log_partial(
+  p_log_date DATE,
+  p_fields   JSONB
+) RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  -- ── Step 2-1: 既存行への partial update を試みる ─────────────────────────
+  UPDATE daily_logs SET
+    weight             = CASE WHEN p_fields ? 'weight'
+                              THEN (p_fields->>'weight')::NUMERIC
+                              ELSE weight             END,
+    calories           = CASE WHEN p_fields ? 'calories'
+                              THEN (p_fields->>'calories')::NUMERIC
+                              ELSE calories           END,
+    protein            = CASE WHEN p_fields ? 'protein'
+                              THEN (p_fields->>'protein')::NUMERIC
+                              ELSE protein            END,
+    fat                = CASE WHEN p_fields ? 'fat'
+                              THEN (p_fields->>'fat')::NUMERIC
+                              ELSE fat                END,
+    carbs              = CASE WHEN p_fields ? 'carbs'
+                              THEN (p_fields->>'carbs')::NUMERIC
+                              ELSE carbs              END,
+    note               = CASE WHEN p_fields ? 'note'
+                              THEN p_fields->>'note'
+                              ELSE note               END,
+    is_cheat_day       = CASE WHEN p_fields ? 'is_cheat_day'
+                              THEN (p_fields->>'is_cheat_day')::BOOLEAN
+                              ELSE is_cheat_day       END,
+    is_refeed_day      = CASE WHEN p_fields ? 'is_refeed_day'
+                              THEN (p_fields->>'is_refeed_day')::BOOLEAN
+                              ELSE is_refeed_day      END,
+    is_eating_out      = CASE WHEN p_fields ? 'is_eating_out'
+                              THEN (p_fields->>'is_eating_out')::BOOLEAN
+                              ELSE is_eating_out      END,
+    is_travel_day      = CASE WHEN p_fields ? 'is_travel_day'
+                              THEN (p_fields->>'is_travel_day')::BOOLEAN
+                              ELSE is_travel_day      END,
+    sleep_hours        = CASE WHEN p_fields ? 'sleep_hours'
+                              THEN (p_fields->>'sleep_hours')::NUMERIC
+                              ELSE sleep_hours        END,
+    had_bowel_movement = CASE WHEN p_fields ? 'had_bowel_movement'
+                              THEN (p_fields->>'had_bowel_movement')::BOOLEAN
+                              ELSE had_bowel_movement END,
+    training_type      = CASE WHEN p_fields ? 'training_type'
+                              THEN p_fields->>'training_type'
+                              ELSE training_type      END,
+    work_mode          = CASE WHEN p_fields ? 'work_mode'
+                              THEN p_fields->>'work_mode'
+                              ELSE work_mode          END,
+    leg_flag           = CASE WHEN p_fields ? 'leg_flag'
+                              THEN (p_fields->>'leg_flag')::BOOLEAN
+                              ELSE leg_flag           END,
+    last_meal_end_time = CASE WHEN p_fields ? 'last_meal_end_time'
+                              THEN (p_fields->>'last_meal_end_time')::TIME
+                              ELSE last_meal_end_time END,
+    step_count         = CASE WHEN p_fields ? 'step_count'
+                              THEN (p_fields->>'step_count')::INTEGER
+                              ELSE step_count         END,
+    bed_time           = CASE WHEN p_fields ? 'bed_time'
+                              THEN (p_fields->>'bed_time')::TIME
+                              ELSE bed_time           END
+  WHERE log_date = p_log_date;
+
+  -- 既存行が更新できたなら終了（INSERT 側には一切触れない）
+  IF FOUND THEN
+    RETURN;
+  END IF;
+
+  -- ── Step 2-2: 新規行の場合は weight 必須チェック ─────────────────────────
+  IF NOT (p_fields ? 'weight') OR (p_fields->>'weight') IS NULL THEN
+    RAISE EXCEPTION 'new_log_requires_weight';
+  END IF;
+
+  -- ── Step 2-3: 新規 INSERT ─────────────────────────────────────────────────
+  INSERT INTO daily_logs (
+    log_date,
+    weight, calories, protein, fat, carbs, note,
+    is_cheat_day, is_refeed_day, is_eating_out, is_travel_day,
+    sleep_hours, had_bowel_movement,
+    training_type, work_mode, leg_flag,
+    last_meal_end_time,
+    step_count,
+    bed_time
+  ) VALUES (
+    p_log_date,
+    (p_fields->>'weight')::NUMERIC,
+    (p_fields->>'calories')::NUMERIC,
+    (p_fields->>'protein')::NUMERIC,
+    (p_fields->>'fat')::NUMERIC,
+    (p_fields->>'carbs')::NUMERIC,
+    p_fields->>'note',
+    COALESCE((p_fields->>'is_cheat_day')::BOOLEAN,   FALSE),
+    COALESCE((p_fields->>'is_refeed_day')::BOOLEAN,  FALSE),
+    COALESCE((p_fields->>'is_eating_out')::BOOLEAN,  FALSE),
+    COALESCE((p_fields->>'is_travel_day')::BOOLEAN,  FALSE),
+    (p_fields->>'sleep_hours')::NUMERIC,
+    (p_fields->>'had_bowel_movement')::BOOLEAN,
+    p_fields->>'training_type',
+    p_fields->>'work_mode',
+    (p_fields->>'leg_flag')::BOOLEAN,
+    (p_fields->>'last_meal_end_time')::TIME,
+    (p_fields->>'step_count')::INTEGER,
+    (p_fields->>'bed_time')::TIME
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION save_daily_log_partial(DATE, JSONB) IS
+  '日次ログの partial update/insert。
+   既存行: UPDATE のみ実行（INSERT 側の NOT NULL 制約に触れない）。
+   新規行: weight 必須チェック後に INSERT。
+   p_fields の JSONB キー存在で 未更新(キーなし) / 明示クリア(キーあり+null) / 上書き(キーあり+値) を表現。
+   weight なしで新規作成を試みた場合は new_log_requires_weight 例外を発生させる。
+   is_poor_sleep は 20260327 で廃止済み。
+   bed_time は 20260407 で追加。sleep_hours の算出は saveDailyLog.ts (フロントエンド) で行う。
+   weigh_in_time は 20260410 で廃止。起床時刻は sleep_sessions.wake_at を直接参照する (#526)。';
+
+-- ── Step 3: weigh_in_time カラムを削除 ───────────────────────────────────────
+
+ALTER TABLE daily_logs DROP COLUMN IF EXISTS weigh_in_time;


### PR DESCRIPTION
## Summary

- **Migration** (`20260410000000`): DROP TRIGGER `trg_sync_weigh_in_time`, DROP FUNCTION `sync_weigh_in_time_from_sleep_sessions()`, redefine `save_daily_log_partial` without `weigh_in_time`, `ALTER TABLE daily_logs DROP COLUMN weigh_in_time`
- **Backfill** (`20260409000001`): Existing `sleep_sessions` data synced to `daily_logs.weigh_in_time` before column drop (applied earlier)
- **types.ts**: Remove `weigh_in_time` from `DailyLog` Row / Insert / Update
- **saveDailyLog**: `fetchExistingTimeFields` now parallel-queries `daily_logs.bed_time` + `sleep_sessions.wake_at`; uses `extractJstHHMM()` for JST conversion instead of reading `weigh_in_time`
- **calendarUtils**: `buildCalendarDayMap` gains `sleepSessions` param; fasting hours computed from `sleep_sessions.wake_at` directly
- **page.tsx → LogsAndSummaryTabs → RecentLogsCards / RecentLogsTable / MonthlyCalendar**: `sleepSessions` prop threaded through for fasting hours display
- **CSV export**: `weigh_in_time` column removed
- **Tests**: Mock updated to differentiate `from("daily_logs")` vs `from("sleep_sessions")`; fixtures changed from `weigh_in_time: "HH:MM"` to `wake_at: TIMESTAMPTZ`; `makeLog` fixtures cleaned up across 5 test files

## Data migration

`20260409000001` backfill ran before the column drop — all existing `sleep_sessions` rows were propagated to `daily_logs.weigh_in_time`. Since the column is now dropped and the source data lives in `sleep_sessions.wake_at`, no data loss occurs.

## Test plan

- [x] `npx tsc --noEmit` — no type errors
- [x] `npx jest --no-coverage` — 1408 tests pass (56 suites)
- [x] `npm run build` — build succeeds
- [ ] Confirm fasting hours still display correctly in calendar and recent logs table
- [ ] Save a sleep session and confirm `sleep_hours` auto-updates on the same day's record

🤖 Generated with [Claude Code](https://claude.com/claude-code)