### PR TITLE
fix: ensure sleep_hours syncs when creating new daily_logs

### DIFF
--- a/src/components/meal/MealLogger.integration.test.tsx
+++ b/src/components/meal/MealLogger.integration.test.tsx
@@ -233,4 +233,37 @@ describe("MealLogger handleSave — 保存順序 (#528 回帰)", () => {
     expect(mockSaveSleepSession).not.toHaveBeenCalled();
     expect(callOrder).toEqual(["saveDailyLog"]);
   });
+
+  /**
+   * daily_logs 変更あり + 睡眠が片側入力のとき、何も保存しない (#528 事前チェック回帰)。
+   *
+   * 修正前は saveDailyLog → 片側入力エラーの順序だったため、
+   * daily_logs だけ保存されてからエラーが返る回帰が存在した。
+   * 片側入力の妥当性チェックを saveDailyLog より前に移動することで
+   * 両方未保存のまま早期 return されることを確認する。
+   */
+  it("daily_logs 変更あり + 睡眠が片側入力のとき saveDailyLog / saveSleepSession ともに呼ばれない", async () => {
+    render(<MealLogger />);
+
+    // 体重を入力（daily_logs の変更フラグを立てる）
+    const weightInput = screen.getByLabelText(/体重/);
+    fireEvent.change(weightInput, { target: { value: "70.5" } });
+
+    // 就寝時刻のみ入力（起床時刻は空のまま = 片側入力）
+    const bedTimeInput = screen.getByLabelText(/就寝時刻/);
+    fireEvent.change(bedTimeInput, { target: { value: "23:00" } });
+    // wakeTimeInput は変更しない
+
+    const saveButton = screen.getByRole("button", { name: /保存/ });
+    fireEvent.click(saveButton);
+
+    // 片側入力エラーで早期 return → どちらも呼ばれない
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: /保存中/ })).toBeNull();
+    });
+
+    expect(mockSaveDailyLog).not.toHaveBeenCalled();
+    expect(mockSaveSleepSession).not.toHaveBeenCalled();
+    expect(callOrder).toEqual([]);
+  });
 });

--- a/src/components/meal/MealLogger.integration.test.tsx
+++ b/src/components/meal/MealLogger.integration.test.tsx
@@ -1,0 +1,236 @@
+/**
+ * MealLogger 保存順序 回帰テスト (#528)
+ *
+ * 新規 daily_logs 作成を伴う保存で、
+ * saveDailyLog → saveSleepSession の順序が守られることを検証する。
+ *
+ * 【不具合の再現条件】
+ * 保存順序が逆（saveSleepSession → saveDailyLog）だと:
+ * 1. sleep_sessions upsert → DB トリガー (trg_sync_sleep_hours) 発火
+ * 2. `UPDATE daily_logs SET sleep_hours=... WHERE log_date=wake_date` を実行
+ * 3. しかし daily_logs 行がまだ存在しないため UPDATE 0 行で終了
+ * 4. その後 saveDailyLog が daily_logs 行を新規 INSERT するが sleep_hours は NULL のまま
+ *
+ * 【修正後の正しい順序】
+ * 1. saveDailyLog → daily_logs 行を新規作成（sleep_hours は一時的に NULL）
+ * 2. saveSleepSession → DB トリガーが発火し、既存の daily_logs 行の sleep_hours を更新
+ */
+
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+// ── モック定義 ────────────────────────────────────────────────────────────────
+// jest.mock は jest の babel transform でファイル先頭にホイストされるため、
+// 変数への参照を避けて素直な factory として定義し、
+// 実際のモック挙動 (callOrder 記録) は beforeEach の mockImplementation で設定する。
+
+jest.mock("@/app/actions/saveDailyLog", () => ({
+  saveDailyLog: jest.fn(async () => ({ ok: true })),
+}));
+
+jest.mock("@/app/actions/saveSleepSession", () => ({
+  saveSleepSession: jest.fn(async () => ({ ok: true })),
+  deleteSleepSession: jest.fn(async () => ({ ok: true })),
+}));
+
+// SWR フックをモック: 空データ（新規日付 = 既存ログなし）
+jest.mock("@/lib/hooks/useDailyLogs", () => ({
+  useDailyLogs: () => ({ data: [], mutate: jest.fn() }),
+}));
+
+jest.mock("@/lib/hooks/useSleepSessions", () => ({
+  useSleepSessions: () => ({ data: [], mutate: jest.fn() }),
+}));
+
+// Cart と calcCartTotals のモック
+jest.mock("./Cart", () => ({
+  Cart: () => null,
+  calcCartTotals: () => ({ calories: 0, protein: 0, fat: 0, carbs: 0 }),
+}));
+
+// FoodPicker のモック
+jest.mock("./FoodPicker", () => ({
+  FoodPicker: () => null,
+}));
+
+// Toast のモック
+jest.mock("@/components/ui/Toast", () => ({
+  Toast: () => null,
+}));
+
+// lucide-react のモック（アイコンを span に差し替えてレンダリングを安定させる）
+jest.mock("lucide-react", () => ({
+  Loader2:     () => <span data-testid="icon-loader" />,
+  PenLine:     () => <span data-testid="icon-penline" />,
+  X:           () => <span data-testid="icon-x" />,
+  Undo2:       () => <span data-testid="icon-undo2" />,
+  ChevronDown: () => <span data-testid="icon-chevron-down" />,
+  Plus:        () => <span data-testid="icon-plus" />,
+}));
+
+// toJstDateStr を固定日付に差し替える（テスト日依存を排除）
+jest.mock("@/lib/utils/date", () => ({
+  ...jest.requireActual<typeof import("@/lib/utils/date")>("@/lib/utils/date"),
+  toJstDateStr: () => "2026-04-10",
+}));
+
+// ── モジュールのインポート（jest.mock より後に配置）─────────────────────────────
+import { saveDailyLog } from "@/app/actions/saveDailyLog";
+import { saveSleepSession } from "@/app/actions/saveSleepSession";
+import { MealLogger } from "./MealLogger";
+
+const mockSaveDailyLog    = saveDailyLog    as jest.Mock;
+const mockSaveSleepSession = saveSleepSession as jest.Mock;
+
+// ─── セットアップ ─────────────────────────────────────────────────────────────
+
+let callOrder: string[] = [];
+
+beforeEach(() => {
+  callOrder = [];
+
+  mockSaveDailyLog.mockImplementation(async () => {
+    callOrder.push("saveDailyLog");
+    return { ok: true };
+  });
+
+  mockSaveSleepSession.mockImplementation(async () => {
+    callOrder.push("saveSleepSession");
+    return { ok: true };
+  });
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+  jest.useRealTimers();
+});
+
+// ─── テスト ───────────────────────────────────────────────────────────────────
+
+describe("MealLogger handleSave — 保存順序 (#528 回帰)", () => {
+  /**
+   * 新規日付 + 体重 + 睡眠の保存:
+   * saveDailyLog が saveSleepSession より先に呼ばれることを検証する。
+   *
+   * これが逆順だと DB トリガー (trg_sync_sleep_hours) が発火した時点で
+   * daily_logs 行が存在せず、sleep_hours が null のまま残る (#528)。
+   */
+  it("新規日付: 体重 + 睡眠を同時保存するとき saveDailyLog が saveSleepSession より先に呼ばれる", async () => {
+    render(<MealLogger />);
+
+    // 体重を入力（daily_logs の変更フラグを立てる）
+    const weightInput = screen.getByLabelText(/体重/);
+    fireEvent.change(weightInput, { target: { value: "70.5" } });
+
+    // 就寝時刻を入力
+    const bedTimeInput = screen.getByLabelText(/就寝時刻/);
+    fireEvent.change(bedTimeInput, { target: { value: "23:00" } });
+
+    // 起床時刻を入力
+    const wakeTimeInput = screen.getByLabelText(/起床時刻/);
+    fireEvent.change(wakeTimeInput, { target: { value: "07:00" } });
+
+    // 保存ボタンをクリック
+    const saveButton = screen.getByRole("button", { name: /保存/ });
+    fireEvent.click(saveButton);
+
+    // 両方の保存が呼ばれるのを待つ
+    await waitFor(() => {
+      expect(mockSaveDailyLog).toHaveBeenCalledTimes(1);
+      expect(mockSaveSleepSession).toHaveBeenCalledTimes(1);
+    });
+
+    // saveDailyLog → saveSleepSession の順序を検証
+    expect(callOrder).toEqual(["saveDailyLog", "saveSleepSession"]);
+  });
+
+  /**
+   * 睡眠のみ変更（体重などの daily_logs 変更なし）:
+   * saveDailyLog は呼ばれず、saveSleepSession のみ呼ばれることを検証する。
+   * 既存日の場合、sleep_sessions 保存 → DB トリガーで既存行の sleep_hours が更新される。
+   */
+  it("睡眠のみ変更のとき saveDailyLog は呼ばれず saveSleepSession のみ呼ばれる", async () => {
+    render(<MealLogger />);
+
+    // 就寝時刻のみ入力（daily_logs 変更なし）
+    const bedTimeInput = screen.getByLabelText(/就寝時刻/);
+    fireEvent.change(bedTimeInput, { target: { value: "22:30" } });
+
+    const wakeTimeInput = screen.getByLabelText(/起床時刻/);
+    fireEvent.change(wakeTimeInput, { target: { value: "06:30" } });
+
+    const saveButton = screen.getByRole("button", { name: /保存/ });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockSaveSleepSession).toHaveBeenCalledTimes(1);
+    });
+
+    // daily_logs 変更なし → saveDailyLog は呼ばれない
+    expect(mockSaveDailyLog).not.toHaveBeenCalled();
+    expect(callOrder).toEqual(["saveSleepSession"]);
+  });
+
+  /**
+   * saveSleepSession の呼び出し引数を検証する。
+   * wake_date が画面の日付 (2026-04-10) と一致することを確認。
+   */
+  it("saveSleepSession は正しい wake_date と時刻で呼ばれる", async () => {
+    render(<MealLogger />);
+
+    const weightInput = screen.getByLabelText(/体重/);
+    fireEvent.change(weightInput, { target: { value: "68.0" } });
+
+    const bedTimeInput = screen.getByLabelText(/就寝時刻/);
+    fireEvent.change(bedTimeInput, { target: { value: "23:30" } });
+
+    const wakeTimeInput = screen.getByLabelText(/起床時刻/);
+    fireEvent.change(wakeTimeInput, { target: { value: "07:30" } });
+
+    const saveButton = screen.getByRole("button", { name: /保存/ });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockSaveSleepSession).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockSaveSleepSession).toHaveBeenCalledWith({
+      wake_date: "2026-04-10",
+      bed_time:  "23:30",
+      wake_time: "07:30",
+    });
+  });
+
+  /**
+   * saveDailyLog が失敗した場合、saveSleepSession は呼ばれない。
+   * 新規日付で daily_logs 作成が失敗した場合に孤立した sleep_sessions 行を作らない。
+   */
+  it("saveDailyLog が失敗したとき saveSleepSession は呼ばれない", async () => {
+    mockSaveDailyLog.mockImplementationOnce(async () => {
+      callOrder.push("saveDailyLog");
+      return { ok: false, message: "新しい日付を作成するには体重の入力が必要です" };
+    });
+
+    render(<MealLogger />);
+
+    const weightInput = screen.getByLabelText(/体重/);
+    fireEvent.change(weightInput, { target: { value: "70.0" } });
+
+    const bedTimeInput = screen.getByLabelText(/就寝時刻/);
+    fireEvent.change(bedTimeInput, { target: { value: "23:00" } });
+
+    const wakeTimeInput = screen.getByLabelText(/起床時刻/);
+    fireEvent.change(wakeTimeInput, { target: { value: "07:00" } });
+
+    const saveButton = screen.getByRole("button", { name: /保存/ });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockSaveDailyLog).toHaveBeenCalledTimes(1);
+    });
+
+    // saveDailyLog 失敗後 → saveSleepSession は呼ばれない
+    expect(mockSaveSleepSession).not.toHaveBeenCalled();
+    expect(callOrder).toEqual(["saveDailyLog"]);
+  });
+});

--- a/src/components/meal/MealLogger.tsx
+++ b/src/components/meal/MealLogger.tsx
@@ -302,45 +302,19 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
     setStatus("saving");
 
     try {
-      // ── 睡眠セッション保存（sleep_sessions が source of truth）──
-      // saveDailyLog とは独立して先に処理する。
-      // DB トリガーが daily_logs.sleep_hours を自動更新するため、
-      // 後続の saveDailyLog 時点では sleep_hours が既に反映されている。
-      if (sleepSessionTouched) {
-        let sleepResult: { ok: boolean; message?: string };
-        if (sleepSessionPendingDelete && hydratedSleepSession) {
-          // セッション削除
-          sleepResult = await deleteSleepSession(date);
-        } else if (sleepBedTime && sleepWakeTime) {
-          // セッション保存（新規 or 上書き）
-          sleepResult = await saveSleepSession({
-            wake_date: date,
-            bed_time:  sleepBedTime,
-            wake_time: sleepWakeTime,
-          });
-        } else if (sleepBedTime || sleepWakeTime) {
-          // どちらか片方だけ入力 → 保存を止めてユーザーに知らせる
-          setErrorMessage("就寝時刻と起床時刻はセットで入力してください。");
-          setStatus("error");
-          setTimeout(() => { setStatus("idle"); setErrorMessage(""); }, 5000);
-          return;
-        } else {
-          // 両方空 (操作なし) → スキップ
-          sleepResult = { ok: true };
-        }
-        if (!sleepResult.ok) {
-          console.error("[MealLogger] sleep save error:", sleepResult.message);
-          setErrorMessage(sleepResult.message ?? "睡眠記録の保存に失敗しました");
-          setStatus("error");
-          setTimeout(() => { setStatus("idle"); setErrorMessage(""); }, 5000);
-          return;
-        }
-      }
-
       // ── daily_logs 保存（変更がある場合のみ）──
+      // sleep_sessions より先に保存する (#528)。
+      //
+      // 【保存順序の重要性】
+      // DB トリガー (trg_sync_sleep_hours) は sleep_sessions の INSERT/UPDATE 後に
+      // `UPDATE daily_logs SET sleep_hours=... WHERE log_date=wake_date` を実行する。
+      // 新規日付の場合、saveSleepSession を先に呼ぶとトリガーが発火した時点で
+      // daily_logs 行がまだ存在せず、UPDATE が 0 行で終わって sleep_hours が null のまま残る。
+      // daily_logs を先に作成してから saveSleepSession を呼ぶことで、
+      // トリガーが正しく sleep_hours を書き込める。
+      //
       // sleepSessionTouched のみが true の場合（睡眠だけ変更）は daily_logs 更新は不要。
       // computeHasDailyLogChanges で判定して saveDailyLog を呼ぶか決める。
-      // 呼ばずに済ませることで「保存するデータがありません」エラーを防ぐ。
       const hasDailyLogChanges = computeHasDailyLogChanges({
         weight, weightTouched, cartItems, cartEverHadItems,
         note, noteTouched, touchedTags,
@@ -390,6 +364,43 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
         if (!result.ok) {
           console.error("[MealLogger] save error:", result.message);
           setErrorMessage(result.message);
+          setStatus("error");
+          setTimeout(() => { setStatus("idle"); setErrorMessage(""); }, 5000);
+          return;
+        }
+      }
+
+      // ── 睡眠セッション保存（sleep_sessions が source of truth）──
+      // daily_logs より後に保存する (#528)。
+      // DB トリガー (trg_sync_sleep_hours) が daily_logs.sleep_hours を更新するとき、
+      // daily_logs 行が既に存在している必要がある。
+      // 既存日はどちらの順序でも動作するが、新規日でも正しく動作するよう
+      // daily_logs を先に保存する順序を維持すること。
+      if (sleepSessionTouched) {
+        let sleepResult: { ok: boolean; message?: string };
+        if (sleepSessionPendingDelete && hydratedSleepSession) {
+          // セッション削除
+          sleepResult = await deleteSleepSession(date);
+        } else if (sleepBedTime && sleepWakeTime) {
+          // セッション保存（新規 or 上書き）
+          sleepResult = await saveSleepSession({
+            wake_date: date,
+            bed_time:  sleepBedTime,
+            wake_time: sleepWakeTime,
+          });
+        } else if (sleepBedTime || sleepWakeTime) {
+          // どちらか片方だけ入力 → 保存を止めてユーザーに知らせる
+          setErrorMessage("就寝時刻と起床時刻はセットで入力してください。");
+          setStatus("error");
+          setTimeout(() => { setStatus("idle"); setErrorMessage(""); }, 5000);
+          return;
+        } else {
+          // 両方空 (操作なし) → スキップ
+          sleepResult = { ok: true };
+        }
+        if (!sleepResult.ok) {
+          console.error("[MealLogger] sleep save error:", sleepResult.message);
+          setErrorMessage(sleepResult.message ?? "睡眠記録の保存に失敗しました");
           setStatus("error");
           setTimeout(() => { setStatus("idle"); setErrorMessage(""); }, 5000);
           return;

--- a/src/components/meal/MealLogger.tsx
+++ b/src/components/meal/MealLogger.tsx
@@ -302,6 +302,22 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
     setStatus("saving");
 
     try {
+      // ── 睡眠入力の事前妥当性チェック ──
+      // saveDailyLog より先に実行する (#528)。
+      // 片側だけ入力されたまま saveDailyLog まで進むと、daily_logs が保存された後に
+      // エラーが返る回帰が生じるため、何も保存する前にここでガードする。
+      if (
+        sleepSessionTouched &&
+        !sleepSessionPendingDelete &&
+        (sleepBedTime || sleepWakeTime) &&
+        !(sleepBedTime && sleepWakeTime)
+      ) {
+        setErrorMessage("就寝時刻と起床時刻はセットで入力してください。");
+        setStatus("error");
+        setTimeout(() => { setStatus("idle"); setErrorMessage(""); }, 5000);
+        return;
+      }
+
       // ── daily_logs 保存（変更がある場合のみ）──
       // sleep_sessions より先に保存する (#528)。
       //
@@ -388,14 +404,9 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
             bed_time:  sleepBedTime,
             wake_time: sleepWakeTime,
           });
-        } else if (sleepBedTime || sleepWakeTime) {
-          // どちらか片方だけ入力 → 保存を止めてユーザーに知らせる
-          setErrorMessage("就寝時刻と起床時刻はセットで入力してください。");
-          setStatus("error");
-          setTimeout(() => { setStatus("idle"); setErrorMessage(""); }, 5000);
-          return;
         } else {
           // 両方空 (操作なし) → スキップ
+          // 片側入力は tryブロック冒頭の事前チェックで弾いているため、ここには到達しない。
           sleepResult = { ok: true };
         }
         if (!sleepResult.ok) {


### PR DESCRIPTION
## 概要

新規 `daily_logs` 作成を伴う保存でも `daily_logs.sleep_hours` が確実に反映されるよう、`MealLogger.handleSave` の保存順序を修正する。

## 不具合原因

`handleSave` の保存順序が逆だった。

1. `saveSleepSession` が先に実行 → DB トリガー (`trg_sync_sleep_hours`) が発火
2. トリガーが `UPDATE daily_logs SET sleep_hours=... WHERE log_date=wake_date` を実行
3. しかし**新規日付では `daily_logs` 行がまだ存在しない** → UPDATE が 0 行で終了
4. `saveDailyLog` が後から `daily_logs` 行を INSERT → `sleep_hours` は NULL のまま

## 採用した修正方針

**案A（採用）: `daily_logs` を先に保存し、その後 `sleep_sessions` を保存する**

`daily_logs` を先に作成してから `saveSleepSession` を呼ぶことで、DB トリガーが発火した時点で `daily_logs` 行が必ず存在し、`sleep_hours` が正しく更新される。

**案B（不採用）: 現行順序を維持しつつ `daily_logs` 新規作成後に `sleep_hours` を再同期する**

別途 DB 呼び出しが必要で複雑になる。案Aが最小差分かつ根本解決のため不採用。

## 変更内容

### `src/components/meal/MealLogger.tsx`

`handleSave` 内の保存ブロックを入れ替え:

- **Before**: `saveSleepSession` → `saveDailyLog`
- **After**: `saveDailyLog` → `saveSleepSession`

保存順序の理由をコメントに明記。

### `src/components/meal/MealLogger.integration.test.tsx`（新規）

保存順序の回帰テスト 4件:

1. 新規日付 + 体重 + 睡眠 → `saveDailyLog` が `saveSleepSession` より先に呼ばれる
2. 睡眠のみ変更 → `saveDailyLog` は呼ばれず `saveSleepSession` のみ呼ばれる
3. `saveSleepSession` が正しい `wake_date` / 時刻で呼ばれる
4. `saveDailyLog` が失敗したとき `saveSleepSession` は呼ばれない（孤立 sleep_session を防ぐ）

## 影響範囲

- **新規日付 + 体重 + 睡眠**: `sleep_hours` が確実に反映される（バグ修正）
- **既存日 + 睡眠のみ変更**: `daily_logs` 行はすでに存在するため、どちらの順序でも動作する（変化なし）
- **既存日 + 体重 + 睡眠**: 両方とも変更あり → `saveDailyLog` 先に実行（変化なし・正常動作）
- **睡眠セッション削除**: 既存セッション削除は `deleteSleepSession` のみ → 変化なし

## テスト / 確認内容

- `node_modules/.bin/jest --no-coverage "MealLogger"` → 45 tests passed
- `node_modules/.bin/tsc --noEmit` → エラーなし

## 補足

- `sleep_sessions` を source of truth とする設計は維持
- スコープ外: 「新規日付 + 睡眠のみ（体重なし）」で `sleep_hours` が設定されない問題は別 Issue

Closes #528

🤖 Generated with [Claude Code](https://claude.com/claude-code)