### PR TITLE
feat: add sleep bed/wake times to daily_logs CSV export

### DIFF
--- a/src/app/api/export/route.test.ts
+++ b/src/app/api/export/route.test.ts
@@ -15,6 +15,9 @@ jest.mock("@/lib/supabase/server", () => ({ createClient: jest.fn() }));
 
 import { NextRequest } from "next/server";
 import { GET, isValidDateParam } from "./route";
+import { createClient } from "@/lib/supabase/server";
+
+const mockCreateClient = createClient as jest.Mock;
 
 // ── isValidDateParam ─────────────────────────────────────────────────────────
 
@@ -170,8 +173,6 @@ describe("GET /api/export — daily_logs CSV with sleep times", () => {
   });
 
   it("sleep_bed_time / sleep_wake_time が CSV ヘッダーとデータ行に含まれる", async () => {
-    const { createClient } = require("@/lib/supabase/server") as { createClient: jest.Mock };
-
     const dailyLogsQuery = makeChainableQuery({ data: [SAMPLE_LOG], error: null });
     const sleepQuery = makeChainableQuery({
       data: [{
@@ -184,7 +185,7 @@ describe("GET /api/export — daily_logs CSV with sleep times", () => {
       error: null,
     });
 
-    createClient.mockReturnValue({
+    mockCreateClient.mockReturnValue({
       from: jest.fn((table: string) =>
         table === "daily_logs" ? dailyLogsQuery : sleepQuery
       ),
@@ -206,15 +207,13 @@ describe("GET /api/export — daily_logs CSV with sleep times", () => {
   });
 
   it("sleep_sessions がない日は sleep_bed_time / sleep_wake_time が空欄になる", async () => {
-    const { createClient } = require("@/lib/supabase/server") as { createClient: jest.Mock };
-
     const dailyLogsQuery = makeChainableQuery({
       data: [{ ...SAMPLE_LOG, sleep_hours: null }],
       error: null,
     });
     const sleepQuery = makeChainableQuery({ data: [], error: null }); // セッションなし
 
-    createClient.mockReturnValue({
+    mockCreateClient.mockReturnValue({
       from: jest.fn((table: string) =>
         table === "daily_logs" ? dailyLogsQuery : sleepQuery
       ),

--- a/src/app/api/export/route.test.ts
+++ b/src/app/api/export/route.test.ts
@@ -1,12 +1,12 @@
 /**
- * /api/export route — バリデーションテスト
+ * /api/export route — バリデーション + CSV 出力テスト
  *
  * テスト構成:
  *   1. isValidDateParam — 純粋関数のユニットテスト
  *   2. GET handler — table / start / end の不正入力で 400 を返すことを検証
+ *   3. GET handler — daily_logs CSV 出力（sleep_bed_time / sleep_wake_time 含む）
  *
- * 注: GET handler テストでは supabase をモックする。
- * バリデーション 400 ケースは DB 呼び出し前に return するため、
+ * 注: バリデーション 400 ケースは DB 呼び出し前に return するため、
  * supabase モックが実際に呼ばれることはない。
  */
 
@@ -122,5 +122,113 @@ describe("GET /api/export — バリデーション", () => {
   it("start 未指定（空文字）はバリデーションをスキップする（isValidDateParam の空文字テストで担保）", () => {
     // GET 内: if (start && !isValidDateParam(start)) → start="" は falsy なので skip
     expect(isValidDateParam("")).toBe(false); // 空文字を直接渡せば false — GET では skip されることを確認
+  });
+});
+
+// ── GET handler — daily_logs CSV 出力（sleep times 含む） ──────────────────────
+
+/**
+ * supabase の chained query builder をモックする。
+ * select / order / gte / lte が連鎖可能で、await した際に result を返す。
+ */
+type QueryResult = { data: unknown[] | null; error: { message: string } | null };
+
+function makeChainableQuery(result: QueryResult): unknown {
+  // Promise を継承しつつメソッドチェーンも可能にする
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const p = Promise.resolve(result) as any;
+  for (const m of ["select", "order", "gte", "lte"]) {
+    p[m] = jest.fn().mockReturnValue(p);
+  }
+  return p;
+}
+
+const SAMPLE_LOG = {
+  log_date: "2026-04-01",
+  weight: 70.0,
+  calories: 2000,
+  protein: 140,
+  fat: 50,
+  carbs: 220,
+  note: null,
+  is_cheat_day: false,
+  is_refeed_day: false,
+  is_eating_out: false,
+  is_travel_day: false,
+  sleep_hours: 7.5,
+  had_bowel_movement: null,
+  training_type: null,
+  work_mode: null,
+  leg_flag: null,
+  last_meal_end_time: null,
+  step_count: null,
+};
+
+describe("GET /api/export — daily_logs CSV with sleep times", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("sleep_bed_time / sleep_wake_time が CSV ヘッダーとデータ行に含まれる", async () => {
+    const { createClient } = require("@/lib/supabase/server") as { createClient: jest.Mock };
+
+    const dailyLogsQuery = makeChainableQuery({ data: [SAMPLE_LOG], error: null });
+    const sleepQuery = makeChainableQuery({
+      data: [{
+        wake_date: "2026-04-01",
+        // UTC 14:30 = JST 23:30
+        bed_at:  "2026-03-31T14:30:00+00:00",
+        // UTC 22:00 = JST 07:00
+        wake_at: "2026-03-31T22:00:00+00:00",
+      }],
+      error: null,
+    });
+
+    createClient.mockReturnValue({
+      from: jest.fn((table: string) =>
+        table === "daily_logs" ? dailyLogsQuery : sleepQuery
+      ),
+    });
+
+    const res = await GET(makeRequest({ table: "daily_logs" }));
+    expect(res.status).toBe(200);
+    const csv = await res.text();
+    const lines = csv.split("\n");
+
+    // ヘッダーに sleep_hours / sleep_bed_time / sleep_wake_time が含まれること
+    expect(lines[0]).toContain("sleep_hours");
+    expect(lines[0]).toContain("sleep_bed_time");
+    expect(lines[0]).toContain("sleep_wake_time");
+
+    // データ行に JST HH:MM が含まれること
+    expect(lines[1]).toContain("23:30"); // bed_time JST
+    expect(lines[1]).toContain("07:00"); // wake_time JST
+  });
+
+  it("sleep_sessions がない日は sleep_bed_time / sleep_wake_time が空欄になる", async () => {
+    const { createClient } = require("@/lib/supabase/server") as { createClient: jest.Mock };
+
+    const dailyLogsQuery = makeChainableQuery({
+      data: [{ ...SAMPLE_LOG, sleep_hours: null }],
+      error: null,
+    });
+    const sleepQuery = makeChainableQuery({ data: [], error: null }); // セッションなし
+
+    createClient.mockReturnValue({
+      from: jest.fn((table: string) =>
+        table === "daily_logs" ? dailyLogsQuery : sleepQuery
+      ),
+    });
+
+    const res = await GET(makeRequest({ table: "daily_logs" }));
+    expect(res.status).toBe(200);
+    const csv = await res.text();
+    const lines = csv.split("\n");
+
+    const headers = lines[0]!.split(",");
+    const values  = lines[1]!.split(",");
+
+    expect(values[headers.indexOf("sleep_bed_time")]).toBe("");
+    expect(values[headers.indexOf("sleep_wake_time")]).toBe("");
   });
 });

--- a/src/app/api/export/route.ts
+++ b/src/app/api/export/route.ts
@@ -14,6 +14,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { extractJstHHMM } from "@/lib/utils/sleepSession";
 
 // ── バリデーション ────────────────────────────────────────────────────────────
 
@@ -81,13 +82,45 @@ export async function GET(req: NextRequest) {
     const { data, error } = await query;
     if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
+    // sleep_sessions から就寝・起床時刻を取得する。
+    // source of truth: sleep_sessions.bed_at / wake_at
+    // 対応付け: daily_logs.log_date = sleep_sessions.wake_date
+    let sleepQuery = supabase
+      .from("sleep_sessions")
+      .select("wake_date,bed_at,wake_at")
+      .order("wake_date", { ascending: true });
+    if (start) sleepQuery = sleepQuery.gte("wake_date", start);
+    if (end) sleepQuery = sleepQuery.lte("wake_date", end);
+    const { data: sleepData, error: sleepError } = await sleepQuery;
+    if (sleepError) return NextResponse.json({ error: sleepError.message }, { status: 500 });
+
+    // wake_date → session の O(1) 参照マップを構築する
+    type SleepRow = { wake_date: string; bed_at: string | null; wake_at: string | null };
+    const sleepByWakeDate = new Map<string, SleepRow>();
+    for (const s of (sleepData ?? []) as SleepRow[]) {
+      sleepByWakeDate.set(s.wake_date, s);
+    }
+
+    // 各ログ行に sleep_bed_time / sleep_wake_time (JST HH:MM) を付加する。
+    // sleep_sessions が存在しない日は null → toCSV で空欄になる。
+    const enrichedRows = (data ?? []).map((rawLog) => {
+      const log = rawLog as Record<string, unknown>;
+      const session = sleepByWakeDate.get(log["log_date"] as string);
+      return {
+        ...log,
+        sleep_bed_time:  session?.bed_at  ? (extractJstHHMM(session.bed_at)  ?? null) : null,
+        sleep_wake_time: session?.wake_at ? (extractJstHHMM(session.wake_at) ?? null) : null,
+      };
+    });
+
     const columns = [
       "log_date", "weight", "calories", "protein", "fat", "carbs", "note",
       "is_cheat_day", "is_refeed_day", "is_eating_out", "is_travel_day",
-      "sleep_hours", "had_bowel_movement", "training_type", "work_mode", "leg_flag",
+      "sleep_hours", "sleep_bed_time", "sleep_wake_time",
+      "had_bowel_movement", "training_type", "work_mode", "leg_flag",
       "last_meal_end_time", "step_count",
     ];
-    const csv = toCSV((data ?? []) as Record<string, unknown>[], columns);
+    const csv = toCSV(enrichedRows as Record<string, unknown>[], columns);
     const filename = `bodymake_log_${start || "all"}_${end || "all"}.csv`;
 
     return new NextResponse(csv, {


### PR DESCRIPTION
## 概要

`/api/export?table=daily_logs` の CSV 出力に `sleep_bed_time` / `sleep_wake_time` 列を追加する。

## 追加理由

現在の CSV は `daily_logs.sleep_hours`（projection 値）のみを含み、就寝・起床の source of truth である `sleep_sessions.bed_at` / `wake_at` の時刻情報が欠けていた。バックアップ / 手元分析用途で睡眠時刻も再利用できるようにする。

## 対応付け方法

`daily_logs.log_date = sleep_sessions.wake_date` を結合キーとして使用する（CLAUDE.md の設計方針に準拠）。`daily_logs` fetch と同じ日付範囲で `sleep_sessions` を取得し、`wake_date` をキーとするマップを構築。各ログ行にセッション情報を付加してから CSV 化する。

## 出力形式

- **時刻**: `extractJstHHMM()` で TIMESTAMPTZ → JST `HH:MM` に変換（人間可読性優先）
- **セッションなし日**: `null` → `toCSV` の既存ロジックで空欄に変換
- **列順**: `sleep_hours, sleep_bed_time, sleep_wake_time`（睡眠関連列をまとめて配置）

## 変更内容

| ファイル | 変更内容 |
|---|---|
| `src/app/api/export/route.ts` | `sleep_sessions` 取得・マップ化・行付加ロジック追加、`columns` に `sleep_bed_time` / `sleep_wake_time` 追加 |
| `src/app/api/export/route.test.ts` | CSV 出力テスト 2 件追加（睡眠時刻あり / なし） |

## テスト / 確認内容

- `sleep_bed_time` / `sleep_wake_time` がヘッダーとデータ行に含まれること
- UTC TIMESTAMPTZ が正しく JST `HH:MM` に変換されること（UTC 14:30 → JST 23:30 など）
- `sleep_sessions` がない日は両列が空欄になること
- 全 1407 テストパス、型エラーなし

## 補足

- `sleep_hours`（projection 値）は既存列として引き続き出力する
- CSV import 側の sleep_sessions 対応・複数睡眠セッション対応はスコープ外

Closes #538