### PR TITLE
refactor: remove dead sleep_hours input path from saveDailyLog

### DIFF
--- a/src/app/actions/__tests__/saveDailyLog.test.ts
+++ b/src/app/actions/__tests__/saveDailyLog.test.ts
@@ -125,23 +125,6 @@ describe("buildUpdatePayload — undefined/null/値の区別", () => {
 });
 
 describe("buildUpdatePayload — Phase 2.5 新規フィールド", () => {
-  test("sleep_hours を指定するとペイロードに含まれる", () => {
-    const payload = buildUpdatePayload({ sleep_hours: 7.5 });
-    expect(payload.sleep_hours).toBe(7.5);
-    expect("weight" in payload).toBe(false);
-  });
-
-  test("sleep_hours: null → 明示的クリア", () => {
-    const payload = buildUpdatePayload({ sleep_hours: null });
-    expect("sleep_hours" in payload).toBe(true);
-    expect(payload.sleep_hours).toBeNull();
-  });
-
-  test("sleep_hours: undefined → ペイロードに含まれない", () => {
-    const payload = buildUpdatePayload({});
-    expect("sleep_hours" in payload).toBe(false);
-  });
-
   test("had_bowel_movement: true → ペイロードに含まれる", () => {
     const payload = buildUpdatePayload({ had_bowel_movement: true });
     expect(payload.had_bowel_movement).toBe(true);
@@ -221,12 +204,10 @@ describe("buildUpdatePayload — Phase 2.5 新規フィールド", () => {
 
   test("Phase 2.5 全フィールドを同時指定", () => {
     const payload = buildUpdatePayload({
-      sleep_hours: 6.5,
       had_bowel_movement: true,
       training_type: "back",
       work_mode: "remote",
     });
-    expect(payload.sleep_hours).toBe(6.5);
     expect(payload.had_bowel_movement).toBe(true);
     expect(payload.training_type).toBe("back");
     expect(payload.leg_flag).toBe(false);
@@ -468,20 +449,19 @@ describe("saveDailyLog — 連続保存シナリオ（体重→macro）", () => 
     expect(capture.p_fields?.leg_flag).toBeNull();
   });
 
-  test("sleep_hours・had_bowel_movement・work_mode のみ保存: 他フィールドは含まれない", async () => {
+  test("had_bowel_movement・work_mode のみ保存: 他フィールドは含まれない", async () => {
     const capture = makeRpcMock();
     const result = await saveDailyLog({
       log_date: "2026-03-13",
-      sleep_hours: 7.0,
       had_bowel_movement: true,
       work_mode: "office",
     });
 
     expect(result.ok).toBe(true);
-    expect(capture.p_fields?.sleep_hours).toBe(7.0);
     expect(capture.p_fields?.had_bowel_movement).toBe(true);
     expect(capture.p_fields?.work_mode).toBe("office");
     expect("weight"        in (capture.p_fields ?? {})).toBe(false);
+    expect("sleep_hours"   in (capture.p_fields ?? {})).toBe(false);
     expect("training_type" in (capture.p_fields ?? {})).toBe(false);
     expect("leg_flag"      in (capture.p_fields ?? {})).toBe(false);
   });
@@ -574,23 +554,6 @@ describe("saveDailyLog — log_date バリデーション", () => {
 });
 
 describe("saveDailyLog — Phase 2.5 バリデーション", () => {
-  test("sleep_hours が 25 → ok: false", async () => {
-    const result = await saveDailyLog({ log_date: "2026-03-13", sleep_hours: 25 });
-    expect(result.ok).toBe(false);
-  });
-
-  test("sleep_hours が -1 → ok: false", async () => {
-    const result = await saveDailyLog({ log_date: "2026-03-13", sleep_hours: -1 });
-    expect(result.ok).toBe(false);
-  });
-
-  test("sleep_hours が 0 → ok: true (境界値)", async () => {
-    const capture = makeRpcMock();
-    const result = await saveDailyLog({ log_date: "2026-03-13", sleep_hours: 0 });
-    expect(result.ok).toBe(true);
-    expect(capture.p_fields?.sleep_hours).toBe(0);
-  });
-
   test("training_type: 'off' → ok: true (有効値)", async () => {
     const capture = makeRpcMock();
     const result = await saveDailyLog({ log_date: "2026-03-13", training_type: "off" });
@@ -644,18 +607,6 @@ describe("saveDailyLog — 既存行 partial update (fix: INSERT NOT NULL 回避
 
     expect(result.ok).toBe(true);
     expect(capture.p_fields?.work_mode).toBe("remote");
-    expect("weight" in (capture.p_fields ?? {})).toBe(false);
-  });
-
-  test("既存行に sleep_hours だけ更新: weight なしでも ok: true", async () => {
-    const capture = makeRpcMock();
-    const result = await saveDailyLog({
-      log_date: "2026-03-13",
-      sleep_hours: 6.5,
-    });
-
-    expect(result.ok).toBe(true);
-    expect(capture.p_fields?.sleep_hours).toBe(6.5);
     expect("weight" in (capture.p_fields ?? {})).toBe(false);
   });
 

--- a/src/app/actions/buildUpdatePayload.ts
+++ b/src/app/actions/buildUpdatePayload.ts
@@ -30,7 +30,6 @@ export function buildUpdatePayload(
   if (input.is_travel_day !== undefined) payload.is_travel_day = input.is_travel_day;
 
   // Phase 2.5 新規フィールド
-  if (input.sleep_hours !== undefined)         payload.sleep_hours         = input.sleep_hours;
   if (input.had_bowel_movement !== undefined)  payload.had_bowel_movement  = input.had_bowel_movement;
   if (input.work_mode !== undefined)           payload.work_mode           = input.work_mode;
 

--- a/src/app/actions/importDailyLogs.ts
+++ b/src/app/actions/importDailyLogs.ts
@@ -52,7 +52,6 @@ export async function importDailyLogs(
       is_refeed_day: row.is_refeed_day,
       is_eating_out: row.is_eating_out,
       is_travel_day: row.is_travel_day,
-      sleep_hours: row.sleep_hours,
       had_bowel_movement: row.had_bowel_movement,
       training_type: row.training_type,
       work_mode: row.work_mode,

--- a/src/app/actions/saveDailyLog.ts
+++ b/src/app/actions/saveDailyLog.ts
@@ -27,7 +27,6 @@ export type SaveDailyLogInput = {
   is_eating_out?: boolean;
   is_travel_day?: boolean;
   // ── Phase 2.5 追加 ──
-  sleep_hours?: number | null;
   /** null = 明示クリア（未記録に戻す） */
   had_bowel_movement?: boolean | null;
   /** 'off' | 'chest' | 'back' | 'shoulders' | 'glutes_hamstrings' | 'quads' */
@@ -90,12 +89,6 @@ export async function saveDailyLog(
 
   if (input.note !== undefined && input.note !== null && input.note.length > 500) {
     return { ok: false, message: "メモは 500 文字以内で入力してください" };
-  }
-
-  if (input.sleep_hours !== undefined && input.sleep_hours !== null) {
-    if (!isFinite(input.sleep_hours) || input.sleep_hours < 0 || input.sleep_hours > 24) {
-      return { ok: false, message: "睡眠時間は 0〜24 時間の範囲で入力してください" };
-    }
   }
 
   if (input.training_type !== undefined && input.training_type !== null) {


### PR DESCRIPTION
## 概要

`saveDailyLog` 系に残っていた `sleep_hours` の dead code を削除するリファクタリング。
「sleep_hours は直接書き込まない」という設計方針と実装を一致させる。

## 削除理由

`sleep_hours` は DB トリガー `trg_sync_sleep_hours` が `sleep_sessions.bed_at` / `wake_at` から自動同期する **projection 値**。`sleep_sessions` が source of truth であり、`saveDailyLog` 経由での直接書き込みは設計上不要かつ誤用リスクがある。

## 呼び出し元確認結果

`sleep_hours` を `saveDailyLog` に渡していた箇所が 1 件発見された：

- `importDailyLogs.ts:55` — `sleep_hours: row.sleep_hours`

CSV インポート経由でも `sleep_hours` を直接書き込むべきでない（トリガーが唯一の更新経路）ため、この行もスコープ内として削除した。`csvParser.ts` の `ParsedRow.sleep_hours` パースは残存しているが、インポート時に `SaveDailyLogInput` へ渡されなくなる。

## 変更内容

| ファイル | 変更内容 |
|---|---|
| `saveDailyLog.ts` | `SaveDailyLogInput` から `sleep_hours?: number \| null` を削除。sleep_hours バリデーション (0〜24h) を削除 |
| `buildUpdatePayload.ts` | `payload.sleep_hours = input.sleep_hours` の行を削除 |
| `importDailyLogs.ts` | `sleep_hours: row.sleep_hours` を削除 |
| `saveDailyLog.test.ts` | sleep_hours 関連テスト 8 件を削除・更新 |

## 影響範囲

**削除対象（saveDailyLog 入力経路）:**
- `SaveDailyLogInput.sleep_hours`
- `saveDailyLog.ts` のバリデーション
- `buildUpdatePayload.ts` の書き込みロジック
- `importDailyLogs.ts` の呼び出し

**非対象（変更なし）:**
- `daily_logs.sleep_hours` カラム（DB には引き続き存在）
- `sleep_sessions` の保存フロー (`saveSleepSession`)
- DB トリガー `trg_sync_sleep_hours`（唯一の更新経路として維持）
- `WeeklyReviewCard` / `MonthlyCalendar` / カレンダーなどの表示・集計用途
- CSV エクスポートの `sleep_hours` 列
- `csvParser.ts` の `ParsedRow.sleep_hours`（パースは残る）

## テスト

- `buildUpdatePayload — Phase 2.5` の sleep_hours テスト 3 件削除
- `Phase 2.5 全フィールドを同時指定` から sleep_hours を除去
- `sleep_hours・had_bowel_movement・work_mode のみ保存` → `had_bowel_movement・work_mode のみ保存` に変更（sleep_hours がペイロードに含まれないことも追加検証）
- sleep_hours バリデーションテスト 3 件削除
- `既存行に sleep_hours だけ更新` テスト削除
- 型チェック・65 テスト全パス確認済み

## 補足

`importDailyLogs.ts` の呼び出し元発見により、「本当に呼び出し元がないことを確認してから削除」という要件に対して追加論点が生じたが、CSV インポート経由の直接書き込みも同様に設計方針違反であるため、同一スコープで削除した。

Closes #541