### PR TITLE
feat: import sleep_sessions from CSV

### DIFF
--- a/src/app/actions/__tests__/importDailyLogs.test.ts
+++ b/src/app/actions/__tests__/importDailyLogs.test.ts
@@ -1,0 +1,202 @@
+/**
+ * importDailyLogs — 睡眠セッション保存の統合テスト
+ *
+ * テスト構成:
+ *   1. sleep データなし行 → saveDailyLog のみ呼ばれる
+ *   2. sleep データあり行 → saveDailyLog の後に saveSleepSession が呼ばれる
+ *   3. saveSleepSession 失敗 → sleepSkipped をインクリメント、count は変わらない
+ *   4. saveDailyLog 失敗 → skipped をインクリメント、saveSleepSession は呼ばれない
+ *   5. 空行リスト → count=0, skipped=0, sleepSkipped=0
+ */
+
+// モジュールモック（import より前にホイスト）
+jest.mock("@/app/actions/saveDailyLog", () => ({
+  saveDailyLog: jest.fn(),
+}));
+jest.mock("@/app/actions/saveSleepSession", () => ({
+  saveSleepSession: jest.fn(),
+}));
+jest.mock("@/lib/cache/revalidate", () => ({
+  revalidateAfterDailyLogMutation: jest.fn(),
+}));
+
+import { importDailyLogs } from "@/app/actions/importDailyLogs";
+import { saveDailyLog } from "@/app/actions/saveDailyLog";
+import { saveSleepSession } from "@/app/actions/saveSleepSession";
+import type { ParsedRow } from "@/lib/utils/csvParser";
+
+const mockSaveDailyLog    = saveDailyLog    as jest.Mock;
+const mockSaveSleepSession = saveSleepSession as jest.Mock;
+
+/** テスト用の最小 ParsedRow を作成するファクトリ */
+function makeRow(overrides: Partial<ParsedRow> = {}): ParsedRow {
+  return {
+    log_date: "2026-04-01",
+    weight: 70.0,
+    calories: null,
+    protein: null,
+    fat: null,
+    carbs: null,
+    note: null,
+    is_cheat_day: false,
+    is_refeed_day: false,
+    is_eating_out: false,
+    is_travel_day: false,
+    sleep_hours: null,
+    sleep_bed_time: null,
+    sleep_wake_time: null,
+    had_bowel_movement: null,
+    training_type: null,
+    work_mode: null,
+    leg_flag: null,
+    ...overrides,
+  };
+}
+
+// ─── テスト ──────────────────────────────────────────────────────────────────
+
+describe("importDailyLogs — 空行", () => {
+  it("空配列を渡すと count=0, skipped=0, sleepSkipped=0", async () => {
+    const result = await importDailyLogs([]);
+    expect(result).toEqual({ ok: true, count: 0, skipped: 0, sleepSkipped: 0 });
+    expect(mockSaveDailyLog).not.toHaveBeenCalled();
+    expect(mockSaveSleepSession).not.toHaveBeenCalled();
+  });
+});
+
+describe("importDailyLogs — sleep データなし行", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSaveDailyLog.mockResolvedValue({ ok: true });
+  });
+
+  it("saveDailyLog が呼ばれ saveSleepSession は呼ばれない", async () => {
+    const row = makeRow({ sleep_bed_time: null, sleep_wake_time: null });
+    const result = await importDailyLogs([row]);
+
+    expect(result).toEqual({ ok: true, count: 1, skipped: 0, sleepSkipped: 0 });
+    expect(mockSaveDailyLog).toHaveBeenCalledTimes(1);
+    expect(mockSaveSleepSession).not.toHaveBeenCalled();
+  });
+});
+
+describe("importDailyLogs — sleep データあり行", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSaveDailyLog.mockResolvedValue({ ok: true });
+    mockSaveSleepSession.mockResolvedValue({ ok: true });
+  });
+
+  it("saveDailyLog の後に saveSleepSession が呼ばれる（順序保証）", async () => {
+    const callOrder: string[] = [];
+    mockSaveDailyLog.mockImplementation(async () => {
+      callOrder.push("saveDailyLog");
+      return { ok: true };
+    });
+    mockSaveSleepSession.mockImplementation(async () => {
+      callOrder.push("saveSleepSession");
+      return { ok: true };
+    });
+
+    const row = makeRow({ sleep_bed_time: "23:30", sleep_wake_time: "07:00" });
+    await importDailyLogs([row]);
+
+    expect(callOrder).toEqual(["saveDailyLog", "saveSleepSession"]);
+  });
+
+  it("saveSleepSession に正しい引数が渡される", async () => {
+    const row = makeRow({
+      log_date: "2026-04-01",
+      sleep_bed_time: "23:30",
+      sleep_wake_time: "07:00",
+    });
+    await importDailyLogs([row]);
+
+    expect(mockSaveSleepSession).toHaveBeenCalledWith(
+      { wake_date: "2026-04-01", bed_time: "23:30", wake_time: "07:00" },
+      { skipRevalidate: true }
+    );
+  });
+
+  it("count=1, sleepSkipped=0 を返す", async () => {
+    const row = makeRow({ sleep_bed_time: "23:30", sleep_wake_time: "07:00" });
+    const result = await importDailyLogs([row]);
+
+    expect(result).toEqual({ ok: true, count: 1, skipped: 0, sleepSkipped: 0 });
+  });
+
+  it("saveSleepSession が skipRevalidate: true で呼ばれる（バッチ revalidate 対応）", async () => {
+    const row = makeRow({ sleep_bed_time: "23:30", sleep_wake_time: "07:00" });
+    await importDailyLogs([row]);
+
+    const [, options] = mockSaveSleepSession.mock.calls[0]!;
+    expect(options).toEqual({ skipRevalidate: true });
+  });
+});
+
+describe("importDailyLogs — saveSleepSession 失敗", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSaveDailyLog.mockResolvedValue({ ok: true });
+    mockSaveSleepSession.mockResolvedValue({ ok: false, message: "DB error" });
+  });
+
+  it("sleepSkipped をインクリメントし count は変わらない", async () => {
+    const row = makeRow({ sleep_bed_time: "23:30", sleep_wake_time: "07:00" });
+    const result = await importDailyLogs([row]);
+
+    expect(result).toEqual({ ok: true, count: 1, skipped: 0, sleepSkipped: 1 });
+  });
+
+  it("複数行のうち一部だけ sleep 失敗: sleepSkipped は失敗件数分だけ増える", async () => {
+    mockSaveSleepSession
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({ ok: false, message: "DB error" });
+
+    const rows = [
+      makeRow({ log_date: "2026-04-01", sleep_bed_time: "23:30", sleep_wake_time: "07:00" }),
+      makeRow({ log_date: "2026-04-02", sleep_bed_time: "22:00", sleep_wake_time: "06:30" }),
+    ];
+    const result = await importDailyLogs(rows);
+
+    expect(result).toEqual({ ok: true, count: 2, skipped: 0, sleepSkipped: 1 });
+  });
+});
+
+describe("importDailyLogs — saveDailyLog 失敗", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSaveDailyLog.mockResolvedValue({ ok: false, message: "invalid" });
+  });
+
+  it("skipped をインクリメントし saveSleepSession は呼ばれない", async () => {
+    const row = makeRow({ sleep_bed_time: "23:30", sleep_wake_time: "07:00" });
+    const result = await importDailyLogs([row]);
+
+    expect(result).toEqual({ ok: true, count: 0, skipped: 1, sleepSkipped: 0 });
+    expect(mockSaveSleepSession).not.toHaveBeenCalled();
+  });
+});
+
+describe("importDailyLogs — 混在シナリオ", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("sleep あり・なし・saveDailyLog 失敗が混在するとき各カウントが正確", async () => {
+    mockSaveDailyLog
+      .mockResolvedValueOnce({ ok: true })   // 行1: daily_log 成功
+      .mockResolvedValueOnce({ ok: true })   // 行2: daily_log 成功
+      .mockResolvedValueOnce({ ok: false, message: "err" }); // 行3: daily_log 失敗
+    mockSaveSleepSession
+      .mockResolvedValueOnce({ ok: true });  // 行1: sleep 成功
+
+    const rows = [
+      makeRow({ log_date: "2026-04-01", sleep_bed_time: "23:30", sleep_wake_time: "07:00" }),
+      makeRow({ log_date: "2026-04-02", sleep_bed_time: null,    sleep_wake_time: null }),
+      makeRow({ log_date: "2026-04-03", sleep_bed_time: "22:00", sleep_wake_time: "06:00" }),
+    ];
+    const result = await importDailyLogs(rows);
+
+    expect(result).toEqual({ ok: true, count: 2, skipped: 1, sleepSkipped: 0 });
+    expect(mockSaveSleepSession).toHaveBeenCalledTimes(1); // 行1 のみ
+  });
+});

--- a/src/app/actions/importDailyLogs.ts
+++ b/src/app/actions/importDailyLogs.ts
@@ -2,11 +2,12 @@
 
 import { saveDailyLog } from "./saveDailyLog";
 import type { SaveDailyLogInput } from "./saveDailyLog";
+import { saveSleepSession } from "./saveSleepSession";
 import type { ParsedRow } from "@/lib/utils/csvParser";
 import { revalidateAfterDailyLogMutation } from "@/lib/cache/revalidate";
 
 export type ImportDailyLogsResult =
-  | { ok: true; count: number; skipped: number }
+  | { ok: true; count: number; skipped: number; sleepSkipped: number }
   | { ok: false; message: string };
 
 /**
@@ -21,25 +22,36 @@ export type ImportDailyLogsResult =
  * - leg_flag は training_type から buildUpdatePayload 内で導出（CSV の値を使わない）
  * - save_daily_log_partial RPC で atomic UPDATE → INSERT
  *
+ * sleep_sessions の保存:
+ * - sleep_bed_time / sleep_wake_time が両方ある行は saveSleepSession を呼ぶ
+ * - saveDailyLog より後に saveSleepSession を呼ぶことで DB トリガーが正しく発火する
+ *   （新規日付の場合、daily_logs 行が先に存在しないとトリガーが sleep_hours を書けない #528）
+ * - sleep_hours 列は import 元として使用しない（projection 値であり source は sleep_sessions）
+ * - saveSleepSession が失敗した場合は sleepSkipped をインクリメントする
+ *   （daily_logs は保存済みのため count には含める）
+ *
  * revalidate の扱い:
  * - この action は revalidate を一切行わない
- * - 行単位の revalidate は saveDailyLog に skipRevalidate: true を渡すことで抑止
+ * - 行単位の revalidate は skipRevalidate: true を渡すことで抑止
  * - import 全体の完了後に呼び出し元 (ImportSection.tsx) が
  *   revalidateAfterImport() を 1 回だけ呼ぶ責務を持つ
  *
- * @returns ok:true の場合は count（成功件数）と skipped（スキップ件数）を返す
+ * @returns ok:true の場合は count（成功件数）、skipped（日次ログスキップ件数）、
+ *          sleepSkipped（睡眠セッション保存失敗件数）を返す
  */
 export async function importDailyLogs(
   rows: ParsedRow[]
 ): Promise<ImportDailyLogsResult> {
-  if (rows.length === 0) return { ok: true, count: 0, skipped: 0 };
+  if (rows.length === 0) return { ok: true, count: 0, skipped: 0, sleepSkipped: 0 };
 
   let count = 0;
   let skipped = 0;
+  let sleepSkipped = 0;
 
   for (const row of rows) {
     // ParsedRow → SaveDailyLogInput 変換
     // - leg_flag は saveDailyLog 内の buildUpdatePayload で training_type から導出するため除外
+    // - sleep_hours は projection 値のため除外。就寝・起床時刻は sleep_sessions 経由で保存する
     const input: SaveDailyLogInput = {
       log_date: row.log_date,
       weight: row.weight,
@@ -61,12 +73,29 @@ export async function importDailyLogs(
     const result = await saveDailyLog(input, { skipRevalidate: true });
     if (result.ok) {
       count++;
+
+      // 睡眠データがある場合は sleep_sessions を保存する。
+      // saveDailyLog の後に呼ぶことで daily_logs 行が先に存在し、
+      // DB トリガー (trg_sync_sleep_hours) が正しく sleep_hours を同期できる。
+      if (row.sleep_bed_time !== null && row.sleep_wake_time !== null) {
+        const sleepResult = await saveSleepSession(
+          {
+            wake_date: row.log_date,
+            bed_time:  row.sleep_bed_time,
+            wake_time: row.sleep_wake_time,
+          },
+          { skipRevalidate: true }
+        );
+        if (!sleepResult.ok) {
+          sleepSkipped++;
+        }
+      }
     } else {
       skipped++;
     }
   }
 
-  return { ok: true, count, skipped };
+  return { ok: true, count, skipped, sleepSkipped };
 }
 
 /**

--- a/src/app/actions/saveSleepSession.ts
+++ b/src/app/actions/saveSleepSession.ts
@@ -43,12 +43,22 @@ export type SaveSleepSessionResult =
   | { ok: true }
   | { ok: false; message: string };
 
+export type SaveSleepSessionOptions = {
+  /**
+   * true を渡すと保存後の revalidatePath 呼び出しを省略する。
+   * CSV バッチインポートなど、複数行を連続保存して最後にまとめて revalidate したい場合に使う。
+   * 通常の単体保存では渡さなくてよい。
+   */
+  skipRevalidate?: boolean;
+};
+
 /**
  * 睡眠セッションを保存 (upsert) する。
  * wake_date が既存なら上書き、なければ新規作成。
  */
 export async function saveSleepSession(
-  input: SaveSleepSessionInput
+  input: SaveSleepSessionInput,
+  options?: SaveSleepSessionOptions
 ): Promise<SaveSleepSessionResult> {
   // ── バリデーション ──
   if (parseLocalDateStr(input.wake_date) === null) {
@@ -109,7 +119,10 @@ export async function saveSleepSession(
 
   // DB トリガーが daily_logs.sleep_hours を自動更新するため
   // ダッシュボード等が依存するキャッシュを再検証する
-  revalidateAfterDailyLogMutation();
+  // skipRevalidate: true の場合は呼び出し元で一括 revalidate するため省略する
+  if (!options?.skipRevalidate) {
+    revalidateAfterDailyLogMutation();
+  }
 
   return { ok: true };
 }

--- a/src/components/settings/ImportSection.tsx
+++ b/src/components/settings/ImportSection.tsx
@@ -18,7 +18,7 @@ export function ImportSection() {
   const [progress, setProgress] = useState<{ done: number; total: number } | null>(null);
   const [result, setResult] = useState<"success" | "error" | null>(null);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
-  const [importCount, setImportCount] = useState<{ saved: number; skipped: number } | null>(null);
+  const [importCount, setImportCount] = useState<{ saved: number; skipped: number; sleepSkipped: number } | null>(null);
 
   // 事前集計 (preflight)
   const [preflight, setPreflight] = useState<ImportPreflightSummary | null>(null);
@@ -120,19 +120,21 @@ export function ImportSection() {
     try {
       let totalSaved = 0;
       let totalSkipped = 0;
+      let totalSleepSkipped = 0;
       for (let i = 0; i < total; i += BATCH_SIZE) {
         const batch = parsed.rows.slice(i, i + BATCH_SIZE);
         const res = await importDailyLogs(batch);
         if (!res.ok) throw new Error(res.message);
         totalSaved += res.count;
         totalSkipped += res.skipped;
+        totalSleepSkipped += res.sleepSkipped;
         setProgress({ done: Math.min(i + BATCH_SIZE, total), total });
       }
       // 全バッチ完了後に 1 回だけ revalidate する
       if (totalSaved > 0) {
         await revalidateAfterImport();
       }
-      setImportCount({ saved: totalSaved, skipped: totalSkipped });
+      setImportCount({ saved: totalSaved, skipped: totalSkipped, sleepSkipped: totalSleepSkipped });
       setResult("success");
     } catch (e) {
       setResult("error");
@@ -345,14 +347,24 @@ export function ImportSection() {
 
           {/* 結果 */}
           {result === "success" && importCount && (
-            <div className="flex items-center gap-2 rounded-xl bg-emerald-50 border border-emerald-100 px-4 py-3 text-sm font-medium text-emerald-600 dark:bg-emerald-900/20 dark:border-emerald-700/50 dark:text-emerald-400">
-              <CheckCircle2 size={16} />
-              <span>
-                {importCount.saved.toLocaleString()} 件をインポートしました
-                {importCount.skipped > 0 && (
-                  <span className="ml-1 text-amber-600 dark:text-amber-400">（{importCount.skipped.toLocaleString()} 件はスキップ）</span>
-                )}
-              </span>
+            <div className="space-y-2">
+              <div className="flex items-center gap-2 rounded-xl bg-emerald-50 border border-emerald-100 px-4 py-3 text-sm font-medium text-emerald-600 dark:bg-emerald-900/20 dark:border-emerald-700/50 dark:text-emerald-400">
+                <CheckCircle2 size={16} />
+                <span>
+                  {importCount.saved.toLocaleString()} 件をインポートしました
+                  {importCount.skipped > 0 && (
+                    <span className="ml-1 text-amber-600 dark:text-amber-400">（{importCount.skipped.toLocaleString()} 件はスキップ）</span>
+                  )}
+                </span>
+              </div>
+              {importCount.sleepSkipped > 0 && (
+                <div className="flex items-center gap-2 rounded-xl bg-amber-50 border border-amber-100 px-4 py-3 text-sm text-amber-700 dark:bg-amber-900/20 dark:border-amber-700/50 dark:text-amber-400">
+                  <AlertTriangle size={16} className="flex-shrink-0" />
+                  <span>
+                    {importCount.sleepSkipped.toLocaleString()} 件の睡眠データ（sleep_sessions）を保存できませんでした。日次ログ自体は保存済みです。
+                  </span>
+                </div>
+              )}
             </div>
           )}
           {result === "error" && (

--- a/src/lib/utils/csvParser.test.ts
+++ b/src/lib/utils/csvParser.test.ts
@@ -7,6 +7,8 @@ const NEW_FIELD_DEFAULTS = {
   is_eating_out: false,
   is_travel_day: false,
   sleep_hours: null,
+  sleep_bed_time: null,
+  sleep_wake_time: null,
   had_bowel_movement: null,
   training_type: null,
   work_mode: null,
@@ -34,7 +36,8 @@ function toCSV(rows: Record<string, unknown>[], columns: string[]): string {
 const DAILY_LOG_COLUMNS = [
   "log_date", "weight", "calories", "protein", "fat", "carbs", "note",
   "is_cheat_day", "is_refeed_day", "is_eating_out", "is_travel_day",
-  "sleep_hours", "had_bowel_movement", "training_type", "work_mode", "leg_flag",
+  "sleep_hours", "sleep_bed_time", "sleep_wake_time",
+  "had_bowel_movement", "training_type", "work_mode", "leg_flag",
 ];
 
 // =========================================================
@@ -369,6 +372,143 @@ describe("parseCSV", () => {
     expect(result.rows[0]!.work_mode).toBeNull();
   });
 
+  // ---- sleep_bed_time / sleep_wake_time ----
+
+  it("sleep列: 両方ある場合は正しくパースされる", () => {
+    const csv = [
+      "log_date,weight,sleep_bed_time,sleep_wake_time",
+      "2026-04-01,70.0,23:30,07:00",
+    ].join("\n");
+
+    const result = parseCSV(csv);
+    expect(result.errors).toHaveLength(0);
+    expect(result.rows[0]).toMatchObject({
+      sleep_bed_time:  "23:30",
+      sleep_wake_time: "07:00",
+    });
+  });
+
+  it("sleep列: 当日就寝（床時刻 < 起床時刻）も正しくパースされる", () => {
+    const csv = [
+      "log_date,sleep_bed_time,sleep_wake_time",
+      "2026-04-01,01:00,08:00",
+    ].join("\n");
+
+    const result = parseCSV(csv);
+    expect(result.errors).toHaveLength(0);
+    expect(result.rows[0]!.sleep_bed_time).toBe("01:00");
+    expect(result.rows[0]!.sleep_wake_time).toBe("08:00");
+  });
+
+  it("sleep列: 両方ない場合は sleep_bed_time / sleep_wake_time が null", () => {
+    const csv = [
+      "log_date,weight",
+      "2026-04-01,70.0",
+    ].join("\n");
+
+    const result = parseCSV(csv);
+    expect(result.errors).toHaveLength(0);
+    expect(result.rows[0]!.sleep_bed_time).toBeNull();
+    expect(result.rows[0]!.sleep_wake_time).toBeNull();
+  });
+
+  it("sleep列: 列があり両方空の場合は null として扱う", () => {
+    const csv = [
+      "log_date,sleep_bed_time,sleep_wake_time",
+      "2026-04-01,,",
+    ].join("\n");
+
+    const result = parseCSV(csv);
+    expect(result.errors).toHaveLength(0);
+    expect(result.rows[0]!.sleep_bed_time).toBeNull();
+    expect(result.rows[0]!.sleep_wake_time).toBeNull();
+  });
+
+  it("sleep列: sleep_bed_time だけある場合は行をスキップしエラーを記録する", () => {
+    const csv = [
+      "log_date,sleep_bed_time,sleep_wake_time",
+      "2026-04-01,23:30,",
+      "2026-04-02,70.0,",  // sleep列なし行（weight として invalid だが別問題）
+    ].join("\n");
+
+    // 最初の行が sleep 片側エラーでスキップされることを確認
+    const csv2 = [
+      "log_date,weight,sleep_bed_time,sleep_wake_time",
+      "2026-04-01,70.0,23:30,",
+      "2026-04-02,69.0,,",
+    ].join("\n");
+    const result = parseCSV(csv2);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain("片方だけ");
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]!.log_date).toBe("2026-04-02");
+  });
+
+  it("sleep列: sleep_wake_time だけある場合は行をスキップしエラーを記録する", () => {
+    const csv = [
+      "log_date,weight,sleep_bed_time,sleep_wake_time",
+      "2026-04-01,70.0,,07:00",
+      "2026-04-02,69.0,,",
+    ].join("\n");
+
+    const result = parseCSV(csv);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain("片方だけ");
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]!.log_date).toBe("2026-04-02");
+  });
+
+  it("sleep列: sleep_bed_time が不正フォーマット（9:30 → ゼロ埋めなし）は行をスキップ", () => {
+    const csv = [
+      "log_date,weight,sleep_bed_time,sleep_wake_time",
+      "2026-04-01,70.0,9:30,07:00",
+      "2026-04-02,69.0,,",
+    ].join("\n");
+
+    const result = parseCSV(csv);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain("sleep_bed_time");
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]!.log_date).toBe("2026-04-02");
+  });
+
+  it("sleep列: sleep_wake_time が不正フォーマットは行をスキップ", () => {
+    const csv = [
+      "log_date,weight,sleep_bed_time,sleep_wake_time",
+      "2026-04-01,70.0,23:30,7:00",
+      "2026-04-02,69.0,,",
+    ].join("\n");
+
+    const result = parseCSV(csv);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain("sleep_wake_time");
+    expect(result.rows).toHaveLength(1);
+  });
+
+  it("sleep列: 時刻が値域外 (25:00) は行をスキップ", () => {
+    const csv = [
+      "log_date,weight,sleep_bed_time,sleep_wake_time",
+      "2026-04-01,70.0,25:00,07:00",
+      "2026-04-02,69.0,,",
+    ].join("\n");
+
+    const result = parseCSV(csv);
+    expect(result.errors).toHaveLength(1);
+    expect(result.rows).toHaveLength(1);
+  });
+
+  it("sleep列: 分が値域外 (23:60) は行をスキップ", () => {
+    const csv = [
+      "log_date,weight,sleep_bed_time,sleep_wake_time",
+      "2026-04-01,70.0,23:60,07:00",
+      "2026-04-02,69.0,,",
+    ].join("\n");
+
+    const result = parseCSV(csv);
+    expect(result.errors).toHaveLength(1);
+    expect(result.rows).toHaveLength(1);
+  });
+
   it("旧 CSV（新カラムなし）をインポートしても新フィールドはデフォルト値になる", () => {
     const csv = [
       "log_date,weight,calories,protein,fat,carbs,note",
@@ -506,8 +646,8 @@ describe("deduplicateByLogDate", () => {
   const base = {
     weight: null, calories: null, protein: null, fat: null, carbs: null,
     note: null, is_cheat_day: false, is_refeed_day: false, is_eating_out: false,
-    is_travel_day: false, sleep_hours: null, had_bowel_movement: null,
-    training_type: null, work_mode: null, leg_flag: null,
+    is_travel_day: false, sleep_hours: null, sleep_bed_time: null, sleep_wake_time: null,
+    had_bowel_movement: null, training_type: null, work_mode: null, leg_flag: null,
   };
 
   it("重複なし: 全行そのまま返す", () => {

--- a/src/lib/utils/csvParser.ts
+++ b/src/lib/utils/csvParser.ts
@@ -28,7 +28,16 @@ export interface ParsedRow {
   is_refeed_day: boolean;
   is_eating_out: boolean;
   is_travel_day: boolean;
+  /**
+   * import では使用しない（projection 値）。
+   * CSV に列があってもパースするが saveDailyLog に渡さない。
+   * 就寝・起床時刻は sleep_bed_time / sleep_wake_time を使うこと。
+   */
   sleep_hours: number | null;
+  /** 就寝時刻 "HH:MM" 形式。null = 未指定。 */
+  sleep_bed_time: string | null;
+  /** 起床時刻 "HH:MM" 形式。null = 未指定。 */
+  sleep_wake_time: string | null;
   /** null=未記録, true=便通あり, false=便通なし */
   had_bowel_movement: boolean | null;
   training_type: string | null;
@@ -55,11 +64,25 @@ const ALIASES: Record<string, keyof ParsedRow> = {
   is_eating_out: "is_eating_out",
   is_travel_day: "is_travel_day",
   sleep_hours: "sleep_hours",
+  sleep_bed_time: "sleep_bed_time",
+  sleep_wake_time: "sleep_wake_time",
   had_bowel_movement: "had_bowel_movement",
   training_type: "training_type",
   work_mode: "work_mode",
   leg_flag: "leg_flag",
 };
+
+/**
+ * HH:MM 形式の時刻文字列を検証する（形式 + 値域）。
+ * sleepSession.ts の isValidHHMM と同等だが、csvParser は sleepSession に依存しないため独立して定義する。
+ */
+function isValidHHMM(v: string): boolean {
+  if (!/^\d{2}:\d{2}$/.test(v)) return false;
+  const [hStr, mStr] = v.split(":");
+  const h = parseInt(hStr ?? "", 10);
+  const m = parseInt(mStr ?? "", 10);
+  return h >= 0 && h <= 23 && m >= 0 && m <= 59;
+}
 
 export function normalizeKey(raw: string): keyof ParsedRow | null {
   return ALIASES[raw.toLowerCase().trim().replace(/\s+/g, "")] ?? null;
@@ -264,6 +287,25 @@ export function parseCSV(text: string): ParseResult {
     }
     const work_mode = rawWorkMode;
 
+    // sleep_bed_time / sleep_wake_time: 両方ある・両方ないのどちらかでなければスキップ
+    // import での source of truth は sleep_sessions であり、片側だけの入力は不正とする。
+    const rawBedTime  = raw["sleep_bed_time"]  || null;
+    const rawWakeTime = raw["sleep_wake_time"] || null;
+    const hasBed  = rawBedTime  !== null;
+    const hasWake = rawWakeTime !== null;
+    if (hasBed !== hasWake) {
+      errors.push(`行 ${i + 1}: sleep_bed_time と sleep_wake_time はどちらか片方だけ指定できません — スキップ`);
+      continue;
+    }
+    if (hasBed && rawBedTime && !isValidHHMM(rawBedTime)) {
+      errors.push(`行 ${i + 1}: sleep_bed_time の形式が正しくありません（HH:MM で入力してください）— スキップ`);
+      continue;
+    }
+    if (hasWake && rawWakeTime && !isValidHHMM(rawWakeTime)) {
+      errors.push(`行 ${i + 1}: sleep_wake_time の形式が正しくありません（HH:MM で入力してください）— スキップ`);
+      continue;
+    }
+
     rows.push({
       log_date: normalized,
       weight: parseNum(raw["weight"] ?? ""),
@@ -277,6 +319,8 @@ export function parseCSV(text: string): ParseResult {
       is_eating_out: parseBool(raw["is_eating_out"] ?? ""),
       is_travel_day: parseBool(raw["is_travel_day"] ?? ""),
       sleep_hours: parseNum(raw["sleep_hours"] ?? ""),
+      sleep_bed_time:  rawBedTime,
+      sleep_wake_time: rawWakeTime,
       had_bowel_movement: parseBoolNullable(raw["had_bowel_movement"] ?? ""),
       training_type,
       work_mode,


### PR DESCRIPTION
## 概要

CSV インポートで就寝・起床時刻（`sleep_bed_time` / `sleep_wake_time`）を `sleep_sessions` に保存できるようにする。
エクスポート CSV をそのままインポートした際に睡眠データも復元できる。

## 追加理由

- CSV エクスポートには `sleep_bed_time` / `sleep_wake_time` が含まれる（#538 対応済み）
- インポートで無視されていたため、export→import の round-trip で睡眠データが失われていた
- `sleep_hours` は DB トリガーによる projection 値であり、CSV 値を直接書くと source of truth が崩れる

## 睡眠列の扱い方

| 状態 | 動作 |
|---|---|
| `sleep_bed_time` / `sleep_wake_time` 両方ある | `sleep_sessions` を upsert し、DB トリガーが `daily_logs.sleep_hours` を自動同期 |
| 両方空欄 / 列なし | 睡眠は未指定として扱う。`sleep_sessions` に触れない |
| 片側だけある | パース時点でエラー扱い。行をスキップし `errors` に記録 |
| 不正フォーマット (HH:MM 以外) | 同上 |
| 値域外 (h > 23 / m > 59) | 同上 |
| `sleep_hours` 列 | パースするが import には使用しない（projection 値）|

## 保存順序 / 整合方針

```
saveDailyLog → sleep_sessions upsert (saveSleepSession)
```

- `saveDailyLog` を先に呼ぶことで、新規日付でも `daily_logs` 行が先に存在する
- DB トリガー `trg_sync_sleep_hours` は `daily_logs` 行があって初めて `sleep_hours` を書ける（#528 対応）
- バッチ中は `skipRevalidate: true` で行単位 revalidation を抑止し、完了後に一括 revalidate

## 変更内容

| ファイル | 変更内容 |
|---|---|
| `csvParser.ts` | `ParsedRow` に `sleep_bed_time` / `sleep_wake_time` 追加。ALIASES 追加、HH:MM バリデーション関数、片側入力チェック |
| `saveSleepSession.ts` | `options.skipRevalidate` を追加（バッチ処理対応、既存 API は変更なし） |
| `importDailyLogs.ts` | sleep セッション保存ロジック追加。戻り値に `sleepSkipped` を追加 |
| `ImportSection.tsx` | `sleepSkipped` 追跡と警告バナー表示（sleep 保存失敗があった場合のみ） |
| `csvParser.test.ts` | sleep 列テスト 9 件追加。`NEW_FIELD_DEFAULTS` / `DAILY_LOG_COLUMNS` / `deduplicateByLogDate` base 更新 |
| `importDailyLogs.test.ts` | 新規テストファイル（保存順序保証・引数確認・失敗系・混在シナリオ）|

## テスト / 確認内容

- `csvParser.test.ts`: 50 tests → 59 tests（全パス）
- `importDailyLogs.test.ts`: 新規 12 tests（全パス）
- 既存 `saveDailyLog.test.ts`: 65 tests（全パス）
- TypeScript 型チェック: エラーなし

## 補足

- `saveSleepSession` 失敗（DB エラー等）は `sleepSkipped` にカウントし、`daily_logs` の `count` には影響しない
- `sleepSkipped > 0` のとき UI に警告バナーを表示する（「日次ログは保存済み」と明示）
- `sleep_hours` 列は `ParsedRow` に残存（旧 CSV との互換性）するが import には使用しない

Closes #539