### PR TITLE
fix: improve error handling for partial sleep save failure

### DIFF
--- a/src/app/actions/saveSleepSession.ts
+++ b/src/app/actions/saveSleepSession.ts
@@ -55,76 +55,91 @@ export type SaveSleepSessionOptions = {
 /**
  * 睡眠セッションを保存 (upsert) する。
  * wake_date が既存なら上書き、なければ新規作成。
+ *
+ * ## エラーハンドリング方針
+ * Server Action として呼ばれるため、Supabase の fetch 失敗など
+ * 想定外の例外が発生した場合に throw が外部へ伝播すると
+ * 呼び出し元 (MealLogger) の generic catch に落ちる。
+ * 関数全体を try/catch で囲み、想定内外のすべての失敗を
+ * `{ ok: false }` に正規化して返す (#544)。
  */
 export async function saveSleepSession(
   input: SaveSleepSessionInput,
   options?: SaveSleepSessionOptions
 ): Promise<SaveSleepSessionResult> {
-  // ── バリデーション ──
-  if (parseLocalDateStr(input.wake_date) === null) {
-    return { ok: false, message: "wake_date の形式が正しくありません (YYYY-MM-DD)" };
-  }
-
-  const timePattern = /^\d{2}:\d{2}$/;
-  if (!timePattern.test(input.bed_time)) {
-    return { ok: false, message: "bed_time の形式が正しくありません (HH:MM)" };
-  }
-  if (!timePattern.test(input.wake_time)) {
-    return { ok: false, message: "wake_time の形式が正しくありません (HH:MM)" };
-  }
-
-  // HH:MM 値域チェック
-  for (const [label, value] of [["bed_time", input.bed_time], ["wake_time", input.wake_time]] as const) {
-    const [hStr, mStr] = value.split(":");
-    const h = parseInt(hStr ?? "", 10);
-    const m = parseInt(mStr ?? "", 10);
-    if (h < 0 || h > 23 || m < 0 || m > 59) {
-      return { ok: false, message: `${label} の値が不正です (時: 0-23、分: 0-59)` };
+  try {
+    // ── バリデーション ──
+    if (parseLocalDateStr(input.wake_date) === null) {
+      return { ok: false, message: "wake_date の形式が正しくありません (YYYY-MM-DD)" };
     }
-  }
 
-  if (input.note !== undefined && input.note !== null && input.note.length > 500) {
-    return { ok: false, message: "メモは 500 文字以内で入力してください" };
-  }
+    const timePattern = /^\d{2}:\d{2}$/;
+    if (!timePattern.test(input.bed_time)) {
+      return { ok: false, message: "bed_time の形式が正しくありません (HH:MM)" };
+    }
+    if (!timePattern.test(input.wake_time)) {
+      return { ok: false, message: "wake_time の形式が正しくありません (HH:MM)" };
+    }
 
-  // ── TIMESTAMPTZ 組み立て ──
-  const datetimes = buildSleepSessionDatetimes(
-    input.wake_date,
-    input.bed_time,
-    input.wake_time
-  );
-  if (datetimes === null) {
-    return { ok: false, message: "就寝・起床時刻の変換に失敗しました" };
-  }
+    // HH:MM 値域チェック
+    for (const [label, value] of [["bed_time", input.bed_time], ["wake_time", input.wake_time]] as const) {
+      const [hStr, mStr] = value.split(":");
+      const h = parseInt(hStr ?? "", 10);
+      const m = parseInt(mStr ?? "", 10);
+      if (h < 0 || h > 23 || m < 0 || m > 59) {
+        return { ok: false, message: `${label} の値が不正です (時: 0-23、分: 0-59)` };
+      }
+    }
 
-  // ── upsert ──
-  const supabase = createClient();
-  const { error } = await supabase
-    .from("sleep_sessions")
-    .upsert(
-      {
-        wake_date: input.wake_date,
-        bed_at:    datetimes.bedAt,
-        wake_at:   datetimes.wakeAt,
-        source:    "manual",
-        note:      input.note ?? null,
-      },
-      { onConflict: "wake_date" }
+    if (input.note !== undefined && input.note !== null && input.note.length > 500) {
+      return { ok: false, message: "メモは 500 文字以内で入力してください" };
+    }
+
+    // ── TIMESTAMPTZ 組み立て ──
+    const datetimes = buildSleepSessionDatetimes(
+      input.wake_date,
+      input.bed_time,
+      input.wake_time
     );
+    if (datetimes === null) {
+      return { ok: false, message: "就寝・起床時刻の変換に失敗しました" };
+    }
 
-  if (error) {
-    console.error("[saveSleepSession] upsert error:", error.message);
-    return { ok: false, message: "保存に失敗しました: " + error.message };
+    // ── upsert ──
+    const supabase = createClient();
+    const { error } = await supabase
+      .from("sleep_sessions")
+      .upsert(
+        {
+          wake_date: input.wake_date,
+          bed_at:    datetimes.bedAt,
+          wake_at:   datetimes.wakeAt,
+          source:    "manual",
+          note:      input.note ?? null,
+        },
+        { onConflict: "wake_date" }
+      );
+
+    if (error) {
+      console.error("[saveSleepSession] upsert error:", error.message);
+      return { ok: false, message: "保存に失敗しました: " + error.message };
+    }
+
+    // DB トリガーが daily_logs.sleep_hours を自動更新するため
+    // ダッシュボード等が依存するキャッシュを再検証する
+    // skipRevalidate: true の場合は呼び出し元で一括 revalidate するため省略する
+    if (!options?.skipRevalidate) {
+      revalidateAfterDailyLogMutation();
+    }
+
+    return { ok: true };
+  } catch (e) {
+    // Supabase の fetch 失敗など、想定外の例外が発生した場合のフォールバック。
+    // throw をそのまま外部に伝播させると MealLogger の generic catch に落ちて
+    // 「予期しないエラーが発生しました」が表示されるため、ここで { ok: false } に正規化する (#544)。
+    console.error("[saveSleepSession] unexpected error:", e);
+    return { ok: false, message: "睡眠記録の保存に失敗しました" };
   }
-
-  // DB トリガーが daily_logs.sleep_hours を自動更新するため
-  // ダッシュボード等が依存するキャッシュを再検証する
-  // skipRevalidate: true の場合は呼び出し元で一括 revalidate するため省略する
-  if (!options?.skipRevalidate) {
-    revalidateAfterDailyLogMutation();
-  }
-
-  return { ok: true };
 }
 
 /**

--- a/src/components/meal/MealLogger.integration.test.tsx
+++ b/src/components/meal/MealLogger.integration.test.tsx
@@ -53,9 +53,10 @@ jest.mock("./FoodPicker", () => ({
   FoodPicker: () => null,
 }));
 
-// Toast のモック
+// Toast のモック（visible=true のとき message を DOM に出力してテスト可能にする）
 jest.mock("@/components/ui/Toast", () => ({
-  Toast: () => null,
+  Toast: ({ message, visible }: { message: string; visible: boolean }) =>
+    visible ? <div data-testid="toast-message">{message}</div> : null,
 }));
 
 // lucide-react のモック（アイコンを span に差し替えてレンダリングを安定させる）
@@ -265,5 +266,90 @@ describe("MealLogger handleSave — 保存順序 (#528 回帰)", () => {
     expect(mockSaveDailyLog).not.toHaveBeenCalled();
     expect(mockSaveSleepSession).not.toHaveBeenCalled();
     expect(callOrder).toEqual([]);
+  });
+
+  /**
+   * saveDailyLog 成功後に saveSleepSession が throw したとき (#544 回帰)。
+   *
+   * saveSleepSession が Server Action 境界で throw した場合でも、
+   * MealLogger の inner try-catch が捕捉して generic error に落とさず、
+   * 「日次ログは保存されたが睡眠は未保存」の partial save メッセージを表示する。
+   * また保存順序 (saveDailyLog → saveSleepSession) が維持されることを確認する。
+   */
+  it("saveDailyLog 成功後に saveSleepSession が throw したとき、partial save メッセージが表示される", async () => {
+    mockSaveSleepSession.mockImplementationOnce(async () => {
+      callOrder.push("saveSleepSession");
+      throw new Error("Network error");
+    });
+
+    render(<MealLogger />);
+
+    const weightInput = screen.getByLabelText(/体重/);
+    fireEvent.change(weightInput, { target: { value: "70.0" } });
+
+    const bedTimeInput = screen.getByLabelText(/就寝時刻/);
+    fireEvent.change(bedTimeInput, { target: { value: "23:00" } });
+
+    const wakeTimeInput = screen.getByLabelText(/起床時刻/);
+    fireEvent.change(wakeTimeInput, { target: { value: "07:00" } });
+
+    const saveButton = screen.getByRole("button", { name: /保存/ });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockSaveDailyLog).toHaveBeenCalledTimes(1);
+      expect(mockSaveSleepSession).toHaveBeenCalledTimes(1);
+    });
+
+    // 保存順序: saveDailyLog → saveSleepSession (#528)
+    expect(callOrder).toEqual(["saveDailyLog", "saveSleepSession"]);
+
+    // inner try-catch が捕捉 → partial save メッセージが表示される
+    await waitFor(() => {
+      const toast = screen.queryByTestId("toast-message");
+      expect(toast).not.toBeNull();
+      expect(toast?.textContent).toContain("日次ログは保存されましたが");
+    });
+  });
+
+  /**
+   * saveDailyLog 成功後に saveSleepSession が { ok: false } を返したとき (#544 回帰)。
+   *
+   * saveSleepSession が { ok: false } で返った場合も、dailyLogSaved=true のとき
+   * partial save メッセージを優先して表示する。
+   */
+  it("saveDailyLog 成功後に saveSleepSession が { ok: false } を返したとき、partial save メッセージが表示される", async () => {
+    mockSaveSleepSession.mockImplementationOnce(async () => {
+      callOrder.push("saveSleepSession");
+      return { ok: false, message: "保存に失敗しました: network timeout" };
+    });
+
+    render(<MealLogger />);
+
+    const weightInput = screen.getByLabelText(/体重/);
+    fireEvent.change(weightInput, { target: { value: "68.5" } });
+
+    const bedTimeInput = screen.getByLabelText(/就寝時刻/);
+    fireEvent.change(bedTimeInput, { target: { value: "22:30" } });
+
+    const wakeTimeInput = screen.getByLabelText(/起床時刻/);
+    fireEvent.change(wakeTimeInput, { target: { value: "06:30" } });
+
+    const saveButton = screen.getByRole("button", { name: /保存/ });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockSaveDailyLog).toHaveBeenCalledTimes(1);
+      expect(mockSaveSleepSession).toHaveBeenCalledTimes(1);
+    });
+
+    expect(callOrder).toEqual(["saveDailyLog", "saveSleepSession"]);
+
+    // partial save メッセージが表示される（sleepResult.message ではなく日次ログ保存済み文言）
+    await waitFor(() => {
+      const toast = screen.queryByTestId("toast-message");
+      expect(toast).not.toBeNull();
+      expect(toast?.textContent).toContain("日次ログは保存されましたが");
+    });
   });
 });

--- a/src/components/meal/MealLogger.tsx
+++ b/src/components/meal/MealLogger.tsx
@@ -301,6 +301,11 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
 
     setStatus("saving");
 
+    // daily_logs 保存済みフラグ。
+    // sleep_sessions 保存が失敗した場合に partial save（日次ログは保存済み/睡眠は未保存）を
+    // ユーザーへ正確に伝えるために使用する (#544)。
+    let dailyLogSaved = false;
+
     try {
       // ── 睡眠入力の事前妥当性チェック ──
       // saveDailyLog より先に実行する (#528)。
@@ -383,6 +388,8 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
           setTimeout(() => { setStatus("idle"); setErrorMessage(""); }, 5000);
           return;
         }
+        // saveDailyLog 成功。以降の sleep 保存失敗時に partial save を検知するために記録する (#544)。
+        dailyLogSaved = true;
       }
 
       // ── 睡眠セッション保存（sleep_sessions が source of truth）──
@@ -392,25 +399,47 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
       // 既存日はどちらの順序でも動作するが、新規日でも正しく動作するよう
       // daily_logs を先に保存する順序を維持すること。
       if (sleepSessionTouched) {
-        let sleepResult: { ok: boolean; message?: string };
-        if (sleepSessionPendingDelete && hydratedSleepSession) {
-          // セッション削除
-          sleepResult = await deleteSleepSession(date);
-        } else if (sleepBedTime && sleepWakeTime) {
-          // セッション保存（新規 or 上書き）
-          sleepResult = await saveSleepSession({
-            wake_date: date,
-            bed_time:  sleepBedTime,
-            wake_time: sleepWakeTime,
+        if (process.env.NODE_ENV !== "production") {
+          console.log("[MealLogger] sleep save attempt:", {
+            date, sleepBedTime, sleepWakeTime,
+            sleepSessionPendingDelete,
+            hasHydratedSession: hydratedSleepSession !== null,
           });
-        } else {
-          // 両方空 (操作なし) → スキップ
-          // 片側入力は tryブロック冒頭の事前チェックで弾いているため、ここには到達しない。
-          sleepResult = { ok: true };
         }
+
+        let sleepResult: { ok: boolean; message?: string };
+        try {
+          if (sleepSessionPendingDelete && hydratedSleepSession) {
+            // セッション削除
+            sleepResult = await deleteSleepSession(date);
+          } else if (sleepBedTime && sleepWakeTime) {
+            // セッション保存（新規 or 上書き）
+            sleepResult = await saveSleepSession({
+              wake_date: date,
+              bed_time:  sleepBedTime,
+              wake_time: sleepWakeTime,
+            });
+          } else {
+            // 両方空 (操作なし) → スキップ
+            // 片側入力は tryブロック冒頭の事前チェックで弾いているため、ここには到達しない。
+            sleepResult = { ok: true };
+          }
+        } catch (sleepError) {
+          // Server Action 境界の想定外例外（ネットワーク障害など）のフォールバック。
+          // saveSleepSession.ts 側の try/catch で通常は捕捉されるが、
+          // 万一 throw が伝播した場合でも generic catch に落とさずここで止める (#544)。
+          console.error("[MealLogger] sleep session action threw:", sleepError);
+          sleepResult = { ok: false, message: "睡眠記録の保存に失敗しました" };
+        }
+
         if (!sleepResult.ok) {
-          console.error("[MealLogger] sleep save error:", sleepResult.message);
-          setErrorMessage(sleepResult.message ?? "睡眠記録の保存に失敗しました");
+          // partial save（日次ログは保存済み / 睡眠記録は未保存）のとき、
+          // ユーザーに実態を伝えるメッセージを優先する (#544)。
+          const sleepErrorMsg = dailyLogSaved
+            ? "日次ログは保存されましたが、睡眠記録の保存に失敗しました。再度睡眠時刻を入力して保存できます。"
+            : (sleepResult.message ?? "睡眠記録の保存に失敗しました");
+          console.error("[MealLogger] sleep save failed:", { dailyLogSaved, message: sleepResult.message });
+          setErrorMessage(sleepErrorMsg);
           setStatus("error");
           setTimeout(() => { setStatus("idle"); setErrorMessage(""); }, 5000);
           return;


### PR DESCRIPTION
## 概要

食事ログ保存時に睡眠入力ありで「予期しないエラーが発生しました」が表示されることがある不具合（#544）に対する改善。

恒常的な再現バグではなく、断続的な失敗時のエラーハンドリング改善・観測性向上を主目的とする。

## 今回の位置づけ

- 同様の入力で現在は正常保存できているため「再現済みの恒常バグ修正」ではない
- `saveSleepSession`（Server Action）が Supabase の fetch 失敗などで throw した場合に、
  MealLogger の generic catch に落ちて「予期しないエラーが発生しました」が表示されていた
- **エラーハンドリング改善・partial save の適切な扱い・観測性向上**が目的

## 原因の分析

`@supabase/supabase-js` v2 は Supabase の fetch 失敗（ネットワーク障害など）を
`{ error }` に包まず throw するケースがある。
この throw が Server Action 境界を越えて MealLogger の外側 catch に伝播すると
generic な「予期しないエラーが発生しました」が表示される。

一方 `saveDailyLog` は同一処理内で先に成功しているため、
`daily_logs` は保存済み・`sleep_sessions` は未保存という partial save 状態が残る。

## エラーハンドリング改善内容

### `saveSleepSession.ts`

- 関数全体を `try/catch` で囲み、想定外の例外（Supabase fetch 失敗など）を
  `{ ok: false }` に正規化して返す
- throw が外部に伝播して generic error になるのを防ぐ
- catch 内で `console.error("[saveSleepSession] unexpected error:", e)` でログを残す

### `MealLogger.tsx`

- `dailyLogSaved` フラグを追加：`saveDailyLog` 成功後に `true` にセット
- sleep セクションに inner `try/catch` を追加：
  - Server Action 境界の throw（`saveSleepSession.ts` の catch をすり抜けた場合）も捕捉
  - `sleepResult = { ok: false }` に変換して generic catch に落とさない
- **partial save 時のメッセージ改善**：`dailyLogSaved === true` のとき
  > 「日次ログは保存されましたが、睡眠記録の保存に失敗しました。再度睡眠時刻を入力して保存できます。」
  を表示（睡眠のみ保存失敗の場合は従来の「睡眠記録の保存に失敗しました」）
- dev-only ログ追加：sleep save 前に `date / sleepBedTime / sleepWakeTime` などを出力

## ユーザー影響

| 状況 | 修正前 | 修正後 |
|------|--------|--------|
| daily_logs 保存済み + sleep 保存失敗 | 「予期しないエラーが発生しました」 | 「日次ログは保存されましたが、睡眠記録の保存に失敗しました。再度睡眠時刻を入力して保存できます。」 |
| sleep のみ保存失敗 | 「予期しないエラーが発生しました」（generic） | 「睡眠記録の保存に失敗しました」（sleep 固有） |
| 正常保存 | 変わらず成功 | 変わらず成功 |

## テスト追加

`MealLogger.integration.test.tsx`:
- Toast モックを `visible=true` 時にメッセージを DOM に出力するよう更新（toast 内容アサーション対応）
- 追加テスト 2 件:
  1. `saveSleepSession` が throw したとき → partial save メッセージが表示される
  2. `saveSleepSession` が `{ ok: false }` を返したとき → partial save メッセージが表示される

全テスト: 1422 件 pass / TypeScript check: pass

## 補足

- `saveDailyLog → saveSleepSession` の順序 (#528) は維持
- `sleep_sessions` を source of truth とする設計は変更なし
- 無関係な MealLogger リファクタは混ぜていない
- 再実行すると daily_logs は UPDATE（冪等）、sleep 入力欄はそのまま残るため retry 可能

Closes #544