### PR TITLE
feat: add avg bed/wake time and weekly delta to WeeklyReviewCard (#548)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -190,6 +190,7 @@ export default async function DashboardPage() {
   const weeklyReview = calcWeeklyReview(logs, readinessMetrics, qualityReport, {
     enrichedTdeeMap,
     phase,
+    sleepSessions,
   });
 
   // 今月目標進捗の比較値: 最新体重優先 (単日ノイズ込みの実測値で進捗を把握する)

--- a/src/components/dashboard/WeeklyReviewCard.integration.test.tsx
+++ b/src/components/dashboard/WeeklyReviewCard.integration.test.tsx
@@ -53,6 +53,11 @@ function makeData(overrides: Partial<WeeklyReviewData> = {}): WeeklyReviewData {
     sleep: {
       avgSleepHours: null,
       sleepDaysLogged: 0,
+      avgBedTime: null,
+      avgWakeTime: null,
+      avgBedTimeDeltaMins: null,
+      avgWakeTimeDeltaMins: null,
+      timeDaysLogged: 0,
     },
     quality: {
       score: 90,
@@ -106,7 +111,7 @@ describe("WeeklyReviewCard", () => {
   it("avgSleepHours が非 null のとき睡眠セクションを表示し、ステータスラベルを付与する", () => {
     render(
       <WeeklyReviewCard
-        data={makeData({ sleep: { avgSleepHours: 7.5, sleepDaysLogged: 6 } })}
+        data={makeData({ sleep: { avgSleepHours: 7.5, sleepDaysLogged: 6, avgBedTime: null, avgWakeTime: null, avgBedTimeDeltaMins: null, avgWakeTimeDeltaMins: null, timeDaysLogged: 0 } })}
         phase="Cut"
       />
     );
@@ -121,7 +126,7 @@ describe("WeeklyReviewCard", () => {
   it("avgSleepHours < 7 のとき「短め」ラベルを表示する", () => {
     render(
       <WeeklyReviewCard
-        data={makeData({ sleep: { avgSleepHours: 6.0, sleepDaysLogged: 5 } })}
+        data={makeData({ sleep: { avgSleepHours: 6.0, sleepDaysLogged: 5, avgBedTime: null, avgWakeTime: null, avgBedTimeDeltaMins: null, avgWakeTimeDeltaMins: null, timeDaysLogged: 0 } })}
         phase="Cut"
       />
     );
@@ -131,21 +136,90 @@ describe("WeeklyReviewCard", () => {
   it("avgSleepHours > 9 のとき「長め」ラベルを表示する", () => {
     render(
       <WeeklyReviewCard
-        data={makeData({ sleep: { avgSleepHours: 9.5, sleepDaysLogged: 7 } })}
+        data={makeData({ sleep: { avgSleepHours: 9.5, sleepDaysLogged: 7, avgBedTime: null, avgWakeTime: null, avgBedTimeDeltaMins: null, avgWakeTimeDeltaMins: null, timeDaysLogged: 0 } })}
         phase="Cut"
       />
     );
     expect(screen.getByText("長め")).toBeInTheDocument();
   });
 
-  it("avgSleepHours が null のとき睡眠セクションを表示しない", () => {
+  it("avgSleepHours が null のとき睡眠セクションを表示しない (bed/wake も null)", () => {
     render(
       <WeeklyReviewCard
-        data={makeData({ sleep: { avgSleepHours: null, sleepDaysLogged: 0 } })}
+        data={makeData({ sleep: { avgSleepHours: null, sleepDaysLogged: 0, avgBedTime: null, avgWakeTime: null, avgBedTimeDeltaMins: null, avgWakeTimeDeltaMins: null, timeDaysLogged: 0 } })}
         phase="Cut"
       />
     );
     expect(screen.queryByText("平均睡眠時間")).not.toBeInTheDocument();
+  });
+
+  it("avgBedTime / avgWakeTime が非 null のとき就寝・起床時刻を表示する", () => {
+    render(
+      <WeeklyReviewCard
+        data={makeData({
+          sleep: {
+            avgSleepHours: 7.5,
+            sleepDaysLogged: 6,
+            avgBedTime: "23:30",
+            avgWakeTime: "07:00",
+            avgBedTimeDeltaMins: 15,
+            avgWakeTimeDeltaMins: -10,
+            timeDaysLogged: 6,
+          },
+        })}
+        phase="Cut"
+      />
+    );
+    expect(screen.getByText("就寝")).toBeInTheDocument();
+    expect(screen.getByText("23:30")).toBeInTheDocument();
+    expect(screen.getByText("(+15分)")).toBeInTheDocument();
+    expect(screen.getByText("起床")).toBeInTheDocument();
+    expect(screen.getByText("07:00")).toBeInTheDocument();
+    expect(screen.getByText("(-10分)")).toBeInTheDocument();
+  });
+
+  it("avgBedTimeDeltaMins が null のとき delta を表示しない", () => {
+    render(
+      <WeeklyReviewCard
+        data={makeData({
+          sleep: {
+            avgSleepHours: null,
+            sleepDaysLogged: 0,
+            avgBedTime: "23:30",
+            avgWakeTime: "07:00",
+            avgBedTimeDeltaMins: null,
+            avgWakeTimeDeltaMins: null,
+            timeDaysLogged: 3,
+          },
+        })}
+        phase="Cut"
+      />
+    );
+    expect(screen.getByText("就寝")).toBeInTheDocument();
+    expect(screen.getByText("23:30")).toBeInTheDocument();
+    // delta が null のときは delta テキストが出ない
+    const text = document.body.textContent ?? "";
+    expect(text).not.toMatch(/\+\d+分/);
+  });
+
+  it("sleepDaysLogged と timeDaysLogged のうち大きい方をヘッダーに表示する", () => {
+    render(
+      <WeeklyReviewCard
+        data={makeData({
+          sleep: {
+            avgSleepHours: 7.0,
+            sleepDaysLogged: 4,
+            avgBedTime: "23:00",
+            avgWakeTime: "07:00",
+            avgBedTimeDeltaMins: null,
+            avgWakeTimeDeltaMins: null,
+            timeDaysLogged: 6,
+          },
+        })}
+        phase="Cut"
+      />
+    );
+    expect(screen.getByText("睡眠 (6 日分)")).toBeInTheDocument();
   });
 
   it("必要値が欠けるときは — 表示にフォールバックし、該当所見カードを出さない", () => {

--- a/src/components/dashboard/WeeklyReviewCard.tsx
+++ b/src/components/dashboard/WeeklyReviewCard.tsx
@@ -393,13 +393,13 @@ export function WeeklyReviewCard({ data, phase, enrichedAvailability }: Props) {
           </div>
 
           {/* 睡眠 */}
-          {sleep.avgSleepHours !== null && (
+          {(sleep.avgSleepHours !== null || sleep.avgBedTime !== null || sleep.avgWakeTime !== null) && (
             <div>
               <SectionLabel icon={<Moon size={12} className="text-indigo-400" />}>
-                睡眠 ({sleep.sleepDaysLogged} 日分)
+                睡眠 ({Math.max(sleep.sleepDaysLogged, sleep.timeDaysLogged)} 日分)
               </SectionLabel>
               <div className="space-y-0.5">
-                {(() => {
+                {sleep.avgSleepHours !== null && (() => {
                   const status = calcSleepStatus(sleep.avgSleepHours);
                   const cfg = SLEEP_STATUS_CONFIG[status];
                   return (
@@ -421,6 +421,28 @@ export function WeeklyReviewCard({ data, phase, enrichedAvailability }: Props) {
                     </>
                   );
                 })()}
+                {sleep.avgBedTime !== null && (
+                  <StatRow
+                    label="就寝"
+                    value={sleep.avgBedTime}
+                    sub={
+                      sleep.avgBedTimeDeltaMins !== null
+                        ? `(${sleep.avgBedTimeDeltaMins >= 0 ? "+" : ""}${sleep.avgBedTimeDeltaMins}分)`
+                        : undefined
+                    }
+                  />
+                )}
+                {sleep.avgWakeTime !== null && (
+                  <StatRow
+                    label="起床"
+                    value={sleep.avgWakeTime}
+                    sub={
+                      sleep.avgWakeTimeDeltaMins !== null
+                        ? `(${sleep.avgWakeTimeDeltaMins >= 0 ? "+" : ""}${sleep.avgWakeTimeDeltaMins}分)`
+                        : undefined
+                    }
+                  />
+                )}
               </div>
             </div>
           )}

--- a/src/lib/utils/calcWeeklyReview.test.ts
+++ b/src/lib/utils/calcWeeklyReview.test.ts
@@ -1,5 +1,5 @@
 import { calcWeeklyReview } from "./calcWeeklyReview";
-import type { DashboardDailyLog } from "@/lib/supabase/types";
+import type { DashboardDailyLog, SleepSession } from "@/lib/supabase/types";
 import type { ReadinessMetrics } from "./calcReadiness";
 import type { DataQualityReport } from "./calcDataQuality";
 
@@ -129,6 +129,121 @@ describe("calcWeeklyReview", () => {
 
     expect(result.sleep.avgSleepHours).toBeNull();
     expect(result.sleep.sleepDaysLogged).toBe(0);
+  });
+
+  it("新フィールドのデフォルト: sleepSessions 未指定のとき全て null / 0", () => {
+    const result = calcWeeklyReview(
+      [makeLog("2026-04-02")],
+      makeMetrics(),
+      makeQualityReport(),
+      { today: "2026-04-02" }
+    );
+    expect(result.sleep.avgBedTime).toBeNull();
+    expect(result.sleep.avgWakeTime).toBeNull();
+    expect(result.sleep.avgBedTimeDeltaMins).toBeNull();
+    expect(result.sleep.avgWakeTimeDeltaMins).toBeNull();
+    expect(result.sleep.timeDaysLogged).toBe(0);
+  });
+
+  // ─── 就寝・起床平均時刻 ───────────────────────────────────────────────────────
+
+  function makeSleepSession(
+    wakeDate: string,
+    bedAtUtc: string,
+    wakeAtUtc: string
+  ): SleepSession {
+    return {
+      id: `session-${wakeDate}`,
+      wake_date: wakeDate,
+      bed_at: bedAtUtc,
+      wake_at: wakeAtUtc,
+      source: "manual",
+      note: null,
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    };
+  }
+
+  it("sleepSessions から就寝・起床平均時刻を算出する", () => {
+    // today = 2026-04-02, 当週: 2026-03-27〜2026-04-02
+    // セッション 1 (wake_date=2026-04-01): bed 23:00 JST, wake 7:00 JST
+    //   bed_at UTC: JST23:00=UTC14:00 → "2026-03-31T14:00:00Z"
+    //   wake_at UTC: JST07:00=UTC22:00(前日) → "2026-03-31T22:00:00Z"
+    // セッション 2 (wake_date=2026-04-02): bed 23:30 JST, wake 7:00 JST
+    //   bed_at UTC: JST23:30=UTC14:30 → "2026-04-01T14:30:00Z"
+    //   wake_at UTC: JST07:00=UTC22:00 → "2026-04-01T22:00:00Z"
+    const sessions = [
+      makeSleepSession("2026-04-01", "2026-03-31T14:00:00Z", "2026-03-31T22:00:00Z"),
+      makeSleepSession("2026-04-02", "2026-04-01T14:30:00Z", "2026-04-01T22:00:00Z"),
+    ];
+    const result = calcWeeklyReview(
+      [makeLog("2026-04-01"), makeLog("2026-04-02")],
+      makeMetrics(),
+      makeQualityReport(),
+      { today: "2026-04-02", sleepSessions: sessions }
+    );
+    // avg bed: (23:00=1380 + 23:30=1410) / 2 = 1395 → 23:15
+    expect(result.sleep.avgBedTime).toBe("23:15");
+    // avg wake: (7:00=420 + 7:00=420) / 2 = 420 → 07:00
+    expect(result.sleep.avgWakeTime).toBe("07:00");
+    expect(result.sleep.timeDaysLogged).toBe(2);
+  });
+
+  it("就寝時刻の日付越え補正: 0:30 と 23:30 の平均が 0:00", () => {
+    // 0:30 JST = UTC 15:30 前日 → timestampToJstMinutes → 30 → +1440 = 1470
+    // 23:30 JST = UTC 14:30 → 1410 → 補正なし
+    // avg = (1470 + 1410) / 2 = 1440 → minutesToHHMM(1440) = 1440%1440=0 → "00:00"
+    const sessions = [
+      makeSleepSession("2026-04-01", "2026-03-31T15:30:00Z", "2026-04-01T22:00:00Z"),
+      makeSleepSession("2026-04-02", "2026-04-01T14:30:00Z", "2026-04-01T22:00:00Z"),
+    ];
+    const result = calcWeeklyReview(
+      [makeLog("2026-04-01"), makeLog("2026-04-02")],
+      makeMetrics(),
+      makeQualityReport(),
+      { today: "2026-04-02", sleepSessions: sessions }
+    );
+    expect(result.sleep.avgBedTime).toBe("00:00");
+  });
+
+  it("前週データがある場合に就寝・起床時刻の前週比を算出する", () => {
+    // today = 2026-04-14
+    // 当週: 2026-04-08〜2026-04-14  前週: 2026-04-01〜2026-04-07
+    //
+    // 前週 (wake_date=2026-04-07): bed 23:00(1380), wake 07:00(420)
+    //   bed_at UTC: "2026-04-06T14:00:00Z", wake_at UTC: "2026-04-06T22:00:00Z"
+    // 当週 (wake_date=2026-04-14): bed 23:30(1410), wake 07:30(450)
+    //   bed_at UTC: "2026-04-13T14:30:00Z", wake_at UTC: "2026-04-13T22:30:00Z"
+    const sessions = [
+      makeSleepSession("2026-04-07", "2026-04-06T14:00:00Z", "2026-04-06T22:00:00Z"),
+      makeSleepSession("2026-04-14", "2026-04-13T14:30:00Z", "2026-04-13T22:30:00Z"),
+    ];
+    const result = calcWeeklyReview(
+      [makeLog("2026-04-07"), makeLog("2026-04-14")],
+      makeMetrics(),
+      makeQualityReport(),
+      { today: "2026-04-14", sleepSessions: sessions }
+    );
+    // bed delta: 1410 - 1380 = 30 分 (30分遅くなった)
+    expect(result.sleep.avgBedTimeDeltaMins).toBe(30);
+    // wake delta: 450 - 420 = 30 分 (30分遅くなった)
+    expect(result.sleep.avgWakeTimeDeltaMins).toBe(30);
+  });
+
+  it("前週データがない場合は delta が null", () => {
+    // 当週のみのセッション (前週は空)
+    const sessions = [
+      makeSleepSession("2026-04-02", "2026-04-01T14:30:00Z", "2026-04-01T22:00:00Z"),
+    ];
+    const result = calcWeeklyReview(
+      [makeLog("2026-04-02")],
+      makeMetrics(),
+      makeQualityReport(),
+      { today: "2026-04-02", sleepSessions: sessions }
+    );
+    expect(result.sleep.avgBedTime).toBe("23:30");
+    expect(result.sleep.avgBedTimeDeltaMins).toBeNull();
+    expect(result.sleep.avgWakeTimeDeltaMins).toBeNull();
   });
 
   it("基準体重や脂質/カロリーが欠けるときは null にフォールバックする", () => {

--- a/src/lib/utils/calcWeeklyReview.ts
+++ b/src/lib/utils/calcWeeklyReview.ts
@@ -15,7 +15,7 @@
  *   - generateFindings で「チートデイ後の水分増加の可能性」を注記
  */
 
-import type { DashboardDailyLog } from "@/lib/supabase/types";
+import type { DashboardDailyLog, SleepSession } from "@/lib/supabase/types";
 import type { ReadinessMetrics } from "./calcReadiness";
 import type { DataQualityReport } from "./calcDataQuality";
 import { addDaysStr, dateRangeStr, toJstDateStr } from "./date";
@@ -104,6 +104,28 @@ export interface WeeklySleep {
   avgSleepHours: number | null;
   /** sleep_hours が非 null の日数 */
   sleepDaysLogged: number;
+  /**
+   * 直近 7 暦日の平均就寝時刻 "HH:MM" (JST)。
+   * sleepSessions が渡されない場合、または当週のデータがない場合は null。
+   */
+  avgBedTime: string | null;
+  /**
+   * 直近 7 暦日の平均起床時刻 "HH:MM" (JST)。
+   * sleepSessions が渡されない場合、または当週のデータがない場合は null。
+   */
+  avgWakeTime: string | null;
+  /**
+   * 就寝時刻の前週比（分）。正=遅くなった、負=早くなった。
+   * 前週データが不足している場合は null。
+   */
+  avgBedTimeDeltaMins: number | null;
+  /**
+   * 起床時刻の前週比（分）。正=遅くなった、負=早くなった。
+   * 前週データが不足している場合は null。
+   */
+  avgWakeTimeDeltaMins: number | null;
+  /** 直近 7 日のうち bed_at / wake_at がある日数 */
+  timeDaysLogged: number;
 }
 
 /** 直近 7 日の特殊日集計 */
@@ -405,6 +427,78 @@ function generateFindings(
   return findings;
 }
 
+// ─── 睡眠時刻ヘルパー ─────────────────────────────────────────────────────────
+
+/**
+ * TIMESTAMPTZ 文字列を JST の深夜 0 時からの経過分 (0–1439) に変換する。
+ * 不正な入力は null を返す。
+ */
+function timestampToJstMinutes(ts: string): number | null {
+  const d = new Date(ts);
+  if (isNaN(d.getTime())) return null;
+  // UTC 時刻 + JST オフセット (+9h = +540min) → 1440 で剰余
+  return (d.getUTCHours() * 60 + d.getUTCMinutes() + 9 * 60) % (24 * 60);
+}
+
+/**
+ * 経過分数 (任意の実数) を "HH:MM" 形式に変換する。
+ * 1440 以上や負数は折り返し処理する。
+ */
+function minutesToHHMM(minutes: number): string {
+  const normalized = ((Math.round(minutes) % 1440) + 1440) % 1440;
+  const h = Math.floor(normalized / 60);
+  const m = normalized % 60;
+  return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
+}
+
+/**
+ * 就寝時刻の日付越え補正。
+ * 0:00–11:59 (0–719 分) の時刻は「翌朝の時刻（前日夜の延長）」として 1440 分を加算する。
+ * これにより 23:30 と 0:30 の平均が 0:00 になる。
+ */
+function applyBedTimeCrossing(mins: number): number {
+  return mins < 12 * 60 ? mins + 1440 : mins;
+}
+
+type AvgTimeResult = { avgMins: number; count: number };
+
+/**
+ * 指定した wake_date セットに対応する睡眠セッションの平均就寝時刻を計算する。
+ * 日付越え補正済みの生の avgMins を返す（minutesToHHMM で変換する前の値）。
+ */
+function computeAvgBedTime(
+  sessions: SleepSession[],
+  dateSet: Set<string>
+): AvgTimeResult | null {
+  const vals: number[] = [];
+  for (const s of sessions) {
+    if (!dateSet.has(s.wake_date)) continue;
+    const mins = timestampToJstMinutes(s.bed_at);
+    if (mins === null) continue;
+    vals.push(applyBedTimeCrossing(mins));
+  }
+  if (vals.length === 0) return null;
+  return { avgMins: vals.reduce((a, b) => a + b, 0) / vals.length, count: vals.length };
+}
+
+/**
+ * 指定した wake_date セットに対応する睡眠セッションの平均起床時刻を計算する。
+ */
+function computeAvgWakeTime(
+  sessions: SleepSession[],
+  dateSet: Set<string>
+): AvgTimeResult | null {
+  const vals: number[] = [];
+  for (const s of sessions) {
+    if (!dateSet.has(s.wake_date)) continue;
+    const mins = timestampToJstMinutes(s.wake_at);
+    if (mins === null) continue;
+    vals.push(mins);
+  }
+  if (vals.length === 0) return null;
+  return { avgMins: vals.reduce((a, b) => a + b, 0) / vals.length, count: vals.length };
+}
+
 // ─── メイン関数 ──────────────────────────────────────────────────────────────
 
 /**
@@ -416,6 +510,8 @@ function generateFindings(
  * @param options.enrichedTdeeMap  log_date → tdee_estimated の Map
  * @param options.phase  "Cut" | "Bulk" (デフォルト "Cut")
  * @param options.today  基準日 YYYY-MM-DD (省略時 JST 今日)
+ * @param options.sleepSessions  sleep_sessions テーブルの行。就寝・起床平均時刻の算出に使う。
+ *                               渡されない場合は avgBedTime / avgWakeTime が null になる。
  */
 export function calcWeeklyReview(
   logs: DashboardDailyLog[],
@@ -425,9 +521,10 @@ export function calcWeeklyReview(
     enrichedTdeeMap?: Map<string, number>;
     phase?: string;
     today?: string;
+    sleepSessions?: SleepSession[];
   } = {}
 ): WeeklyReviewData {
-  const { enrichedTdeeMap, phase = "Cut", today } = options;
+  const { enrichedTdeeMap, phase = "Cut", today, sleepSessions } = options;
   const todayStr = today ?? toJstDateStr(new Date());
 
   // ── 7 暦日リスト ──
@@ -507,19 +604,56 @@ export function calcWeeklyReview(
     fatCaloriesRatioPct,
   };
 
-  // ── Sleep (直近 7 暦日の平均睡眠時間) ──
-  // source of truth: daily_logs.sleep_hours
-  // (sleep_sessions の bed_at / wake_at から DB トリガーが自動同期する projection 値)
-  // null 日はスキップし、記録がある日のみで平均を算出する
+  // ── Sleep ──
+
+  // 平均睡眠時間: daily_logs.sleep_hours (sleep_sessions からの DB トリガー projection 値)
   const sleepVals = windowLogs
     .filter((l) => l.sleep_hours !== null)
     .map((l) => l.sleep_hours as number);
+
+  // 就寝・起床平均時刻: sleep_sessions.bed_at / wake_at から算出
+  // 前週比のため、前の 7 暦日 (8〜14 日前) も集計する
+  const d7DateSet = new Set(last7Dates);
+  const prevD14Start = addDaysStr(todayStr, -13) ?? todayStr;
+  const prevD8       = addDaysStr(todayStr, -7)  ?? todayStr;
+  const prev7DateSet = new Set(dateRangeStr(prevD14Start, prevD8));
+
+  let avgBedTime: string | null = null;
+  let avgWakeTime: string | null = null;
+  let avgBedTimeDeltaMins: number | null = null;
+  let avgWakeTimeDeltaMins: number | null = null;
+  let timeDaysLogged = 0;
+
+  if (sleepSessions && sleepSessions.length > 0) {
+    const currBed  = computeAvgBedTime(sleepSessions, d7DateSet);
+    const currWake = computeAvgWakeTime(sleepSessions, d7DateSet);
+    const prevBed  = computeAvgBedTime(sleepSessions, prev7DateSet);
+    const prevWake = computeAvgWakeTime(sleepSessions, prev7DateSet);
+
+    avgBedTime  = currBed  ? minutesToHHMM(currBed.avgMins)  : null;
+    avgWakeTime = currWake ? minutesToHHMM(currWake.avgMins) : null;
+    avgBedTimeDeltaMins =
+      currBed && prevBed
+        ? Math.round(currBed.avgMins - prevBed.avgMins)
+        : null;
+    avgWakeTimeDeltaMins =
+      currWake && prevWake
+        ? Math.round(currWake.avgMins - prevWake.avgMins)
+        : null;
+    timeDaysLogged = currBed?.count ?? currWake?.count ?? 0;
+  }
+
   const sleep: WeeklySleep = {
     avgSleepHours:
       sleepVals.length > 0
         ? sleepVals.reduce((a, b) => a + b, 0) / sleepVals.length
         : null,
     sleepDaysLogged: sleepVals.length,
+    avgBedTime,
+    avgWakeTime,
+    avgBedTimeDeltaMins,
+    avgWakeTimeDeltaMins,
+    timeDaysLogged,
   };
 
   // ── TDEE (直近 7 日の推定 TDEE 平均) ──

--- a/src/lib/utils/weeklyInsights.test.ts
+++ b/src/lib/utils/weeklyInsights.test.ts
@@ -47,6 +47,11 @@ function makeData(overrides: Partial<WeeklyReviewData> = {}): WeeklyReviewData {
     sleep: {
       avgSleepHours: null,
       sleepDaysLogged: 0,
+      avgBedTime: null,
+      avgWakeTime: null,
+      avgBedTimeDeltaMins: null,
+      avgWakeTimeDeltaMins: null,
+      timeDaysLogged: 0,
     },
     quality: {
       score: 90,


### PR DESCRIPTION
## Summary

- `WeeklySleep` 型に `avgBedTime` / `avgWakeTime` / `avgBedTimeDeltaMins` / `avgWakeTimeDeltaMins` / `timeDaysLogged` を追加
- `calcWeeklyReview` が `sleepSessions` を受け取り、`sleep_sessions.bed_at / wake_at` (source of truth) から平均就寝・起床時刻と前週比（分）を算出
- `WeeklyReviewCard` の睡眠セクションに「就寝 HH:MM (+N分)」「起床 HH:MM (-N分)」行を追加（前週データがある場合のみ delta 表示）
- `page.tsx` では既存の `sleepSessions` を `calcWeeklyReview` に渡すだけで追加フェッチなし
- 就寝時刻の日付越え補正（00:00–11:59 → +24h）により 23:30 と 0:30 の平均が 0:00 になる

## Test plan

- [x] `npx jest --no-coverage` — 1434 tests passed
- [x] `npx tsc --noEmit` — 型エラーなし
- [x] `calcWeeklyReview.test.ts` に単体テスト 4件追加（平均時刻算出・日付越え補正・前週比・前週データなし）
- [x] `WeeklyReviewCard.integration.test.tsx` に結合テスト 3件追加（時刻表示・delta 表示・ヘッダー日数）
- [x] `weeklyInsights.test.ts` の型エラーを修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)