### PR TITLE
fix: replace parseInt with Number() in JSON step import parser (#550)

### DIFF
--- a/src/app/api/step-import/parsers.test.ts
+++ b/src/app/api/step-import/parsers.test.ts
@@ -227,6 +227,35 @@ describe("parseJson", () => {
     });
   });
 
+  it("step_count が \"123abc\" のとき invalidRows にカウントしてスキップする (#550)", () => {
+    // parseInt では 123 に部分パースされてしまうバグの回帰テスト
+    const result = parseJson('[{"date":"2024-01-15","step_count":"123abc"},{"date":"2024-01-16","step_count":5000}]');
+    expect(result).toEqual({
+      ok: true,
+      records: [{ date: "2024-01-16", stepCount: 5000 }],
+      invalidRows: 1,
+    });
+  });
+
+  it("step_count が文字列の小数点（\"10.5\"）のとき invalidRows にカウントしてスキップする (#550)", () => {
+    // parseInt では 10 に切り捨てられてしまうバグの回帰テスト
+    const result = parseJson('[{"date":"2024-01-15","step_count":"10.5"},{"date":"2024-01-16","step_count":5000}]');
+    expect(result).toEqual({
+      ok: true,
+      records: [{ date: "2024-01-16", stepCount: 5000 }],
+      invalidRows: 1,
+    });
+  });
+
+  it("step_count が null のとき invalidRows にカウントしてスキップする", () => {
+    const result = parseJson('[{"date":"2024-01-15","step_count":null},{"date":"2024-01-16","step_count":5000}]');
+    expect(result).toEqual({
+      ok: true,
+      records: [{ date: "2024-01-16", stepCount: 5000 }],
+      invalidRows: 1,
+    });
+  });
+
   it("重複日付は後勝ちで上書きする", () => {
     const json = '[{"date":"2024-01-15","step_count":8432},{"date":"2024-01-15","step_count":9999}]';
     const result = parseJson(json);

--- a/src/app/api/step-import/parsers.ts
+++ b/src/app/api/step-import/parsers.ts
@@ -121,14 +121,18 @@ export function parseJson(text: string): ParseResult {
 
     const stepRaw = obj["step_count"];
 
-    // 浮動小数点数（例: 1234.9）は無効行としてスキップする。
-    // Math.trunc で暗黙的に整数化しない。
+    // 数値型の浮動小数点（例: 1234.9）は無効行としてスキップする。
     if (typeof stepRaw === "number" && !Number.isInteger(stepRaw)) { invalidRows++; continue; }
 
+    // 文字列の場合は Number() で厳密に変換する。
+    // parseInt() は "123abc" → 123、"10.5" → 10 のように部分パースするため使わない。
+    // 数値型・文字列型以外（null / undefined / object 等）は NaN として後続のガードで弾く。
     const stepCount =
       typeof stepRaw === "number"
         ? stepRaw
-        : parseInt(String(stepRaw ?? ""), 10);
+        : typeof stepRaw === "string"
+        ? Number(stepRaw.trim())
+        : NaN;
 
     if (!Number.isInteger(stepCount) || stepCount < 0 || isNaN(stepCount)) { invalidRows++; continue; }
 


### PR DESCRIPTION
## 問題

`src/app/api/step-import/parsers.ts` の JSON パーサーで `parseInt()` を使っていたため、不正な数値文字列を黙って切り捨てて保存していた。

| 入力 | 修正前 (parseInt) | 修正後 (Number) |
|------|-------------------|-----------------|
| `"123abc"` | **123** (通過・サイレント破壊) | NaN → スキップ ✓ |
| `"10.5"` | **10** (通過・切り捨て) | 10.5 → !isInteger → スキップ ✓ |
| `null` | NaN → スキップ (偶然OK) | NaN → スキップ ✓ |
| `"8432"` | 8432 (正常) | 8432 (正常) ✓ |

CSV パーサーは `Number() + Number.isInteger()` で正しく弾いており挙動が不一致だった。

## 修正内容

- `parseInt(String(stepRaw ?? ""), 10)` を `Number(stepRaw.trim())` (文字列の場合) / `NaN` (それ以外の型) に置き換え
- CSV パーサーと挙動を統一
- `null` / `undefined` / object 等の非数値・非文字列型も NaN として後続ガードで確実にスキップ

## テスト

- `"123abc"` → invalidRows、`"10.5"` (文字列) → invalidRows、`null` → invalidRows の回帰テスト 3件を追加
- 既存テスト含め 1437 tests passed / `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)