### PR TITLE
fix: add planStartMonth / planStartWeight to useMemo deps in MonthlyGoalPlanSection (#552)

### DIFF
--- a/src/components/settings/MonthlyGoalPlanSection.tsx
+++ b/src/components/settings/MonthlyGoalPlanSection.tsx
@@ -217,7 +217,7 @@ function PlanContent({
         monthlyActuals: [],
         overrides,
       }),
-    [currentWeight, today, goalWeight, contestDate, overrides]
+    [currentWeight, today, goalWeight, contestDate, overrides, planStartMonth, planStartWeight]
   );
 
   // plan.entries の month + targetWeight の両方を含む signature を作成する。


### PR DESCRIPTION
## 問題

`MonthlyGoalPlanSection.tsx` の `plan` 計算 (`useMemo`) が `planStartMonth` と `planStartWeight` を内部で使っているのに dependency array に含まれておらず、設定画面でこれらの値を変更してもプレビューが再計算されなかった。`react-hooks/exhaustive-deps` の lint warning も出ていた。

## 修正内容

dependency array に `planStartMonth` と `planStartWeight` を追加（1行変更）。

```diff
- [currentWeight, today, goalWeight, contestDate, overrides]
+ [currentWeight, today, goalWeight, contestDate, overrides, planStartMonth, planStartWeight]
```

## テスト

- 1437 tests passed
- `npx tsc --noEmit` clean
- `npm run lint` で MonthlyGoalPlanSection の exhaustive-deps warning が消えたことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)