### PR TITLE
chore: remove unused ParseResult import from step-import route.ts (#554)

### DIFF
--- a/src/app/api/step-import/route.ts
+++ b/src/app/api/step-import/route.ts
@@ -32,7 +32,6 @@ import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { revalidateAfterDailyLogMutation } from "@/lib/cache/revalidate";
 import { parseStepFile } from "./parsers";
-import type { ParseResult } from "./parsers";
 import type { Database } from "@/lib/supabase/types";
 
 type DailyLogInsert = Database["public"]["Tables"]["daily_logs"]["Insert"];


### PR DESCRIPTION
## 変更内容

`src/app/api/step-import/route.ts:35` にあった `import type { ParseResult } from "./parsers"` を削除。

`parseStepFile` の戻り値は `ParseResult` だが、route.ts 内でこの型名を明示的に参照している箇所はなく dead import だった。

## テスト

- `npx tsc --noEmit` clean
- 1437 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)