### PR TITLE
fix: move eslint-disable-next-line to deps array line in MealLogger (#558)

### DIFF
--- a/src/components/meal/MealLogger.tsx
+++ b/src/components/meal/MealLogger.tsx
@@ -261,12 +261,12 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
       lastMealEndTimeTouched || touchedTags.size > 0 || cartEverHadItems
     ) return;
     hydrateForm(date);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     // touched 系フラグ・hydrateForm・date は deps から意図的に除外する。
     // touched 系: logs/sleepSessions 変化時のスナップショットとして読むだけで、
     //   deps に含めるとユーザー操作ごとに再実行されてしまう。
     // hydrateForm: 毎レンダーで新しい関数参照になるため deps に含めると無限ループになる。
     // date: 初回ロード時点の selectedDate で固定するため除外。
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [logs, sleepSessions]);
 
   function toggleTag(tag: DayTag) {


### PR DESCRIPTION
## 問題

#555 で追加した `useEffect` の `eslint-disable-next-line react-hooks/exhaustive-deps` コメントが、deps 配列行（`}, [logs, sleepSessions]);`）の直前ではなく、`hydrateForm(date)` の直後に置かれていた。

`eslint-disable-next-line` は直後の1行にしか効かないため、コメント行の次の行（説明コメント）に適用されてしまい、deps 配列行には届いていなかった。結果として 2 件の warning が発生していた：

- `264:5 warning Unused eslint-disable directive`
- `270:6 warning React Hook useEffect has missing dependencies`

## 修正内容

`eslint-disable-next-line react-hooks/exhaustive-deps` を `}, [logs, sleepSessions]);` の直前に移動。

## テスト

- `npm run lint`: 2 件の warning が解消（残る 1 件は既存の無関係な warning）
- `npx tsc --noEmit`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)