### PR TITLE
fix: add console.error to fetchMacroTargets on DB fetch failure (#559)

### DIFF
--- a/src/lib/queries/settings.ts
+++ b/src/lib/queries/settings.ts
@@ -63,10 +63,13 @@ export async function fetchSettingsRows(): Promise<QueryResult<Setting[]>> {
 export async function fetchMacroTargets(): Promise<MacroTargets & { calTarget: number | null }> {
   const supabase = createClient();
   const keys = ["target_calories_kcal", "target_protein_g", "target_fat_g", "target_carbs_g", "goal_calories"];
-  const { data } = await supabase
+  const { data, error } = await supabase
     .from("settings")
     .select("key, value_num")
     .in("key", keys);
+  if (error) {
+    console.error("[fetchMacroTargets] settings fetch error:", error.message, { code: error.code });
+  }
   const map: Record<string, number | null> = {};
   for (const row of (data as { key: string; value_num: number | null }[]) ?? []) {
     map[row.key] = row.value_num;


### PR DESCRIPTION
## 問題

`fetchMacroTargets()` は `{ data }` のみ destructure しており、DB エラーが発生しても `console.error` すら出力せず完全に無音だった。

`fetchWeightLogs()` / `fetchFlaggedLogsForRun()` はどちらも `console.error` でログを残すのに対し、この関数だけ障害時の検知経路がなく不統一だった。

## 修正内容

`{ data, error }` に変更し、エラー時に `console.error("[fetchMacroTargets] settings fetch error:", error.message, { code: error.code })` を追加。

エラー後は従来通り全 null フォールバックを維持（ベストエフォート設計は変更なし）。

## テスト

- `npx tsc --noEmit`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)