### PR TITLE
fix: reject non-integer step counts in extract_steps.py (#560)

### DIFF
--- a/ml-pipeline/extract_steps.py
+++ b/ml-pipeline/extract_steps.py
@@ -113,10 +113,15 @@ def extract_daily_steps(zip_path: str) -> dict[str, int]:
             value_str = elem.get("value", "0")
 
             try:
-                steps = int(float(value_str))
+                steps_float = float(value_str)
             except (ValueError, TypeError):
                 elem.clear()
                 continue
+            # 小数歩数は無効値としてスキップする（API 側 parsers.ts の Number.isInteger チェックと同方針）
+            if not steps_float.is_integer() or steps_float < 0:
+                elem.clear()
+                continue
+            steps = int(steps_float)
 
             date_key = parse_date_local(start_date)
             daily[date_key] += steps


### PR DESCRIPTION
## 問題

`ml-pipeline/extract_steps.py` は Apple Health XML の歩数値を `int(float(value_str))` で取り込んでいたため、小数値（例: `"8432.9"`）を黙って 8432 に切り捨てていた。

API 側の `src/app/api/step-import/parsers.ts` が `Number.isInteger` で小数を invalidRows として弾く厳格さと比べて、同じ「歩数インポート」機能内での不整合があった。

## 修正内容

`float()` 変換後に `float.is_integer()` で整数かどうかを確認し、小数の場合はスキップするよう変更。

- `"8432"` → 8432（通過）
- `"8432.0"` → 8432（通過: 整数値の float は有効）
- `"8432.9"` → スキップ（小数のため無効）
- `"-1"` → スキップ（負値のため無効）

`"8432.0"` が通過するのは JS 側の `Number.isInteger(8432.0) === true` と同じ挙動。

## テスト

- Python 動作確認（全ケースパス）

🤖 Generated with [Claude Code](https://claude.com/claude-code)