### PR TITLE
fix: variable name typos, unused test var, and SWR cache invalidation (#564)

### DIFF
--- a/src/components/foods/FoodTable.tsx
+++ b/src/components/foods/FoodTable.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo, useTransition } from "react";
 import { Trash2, Plus, Search, ChevronUp, ChevronDown, ChevronsUpDown } from "lucide-react";
+import { mutate } from "swr";
 import type { FoodMaster, TablesInsert } from "@/lib/supabase/types";
 import { parseStrictNumber } from "@/lib/utils/parseNumber";
 import { insertFood, deleteFood } from "@/app/actions/foods";
@@ -136,6 +137,7 @@ export function FoodTable({ initialFoods }: FoodTableProps) {
 
     // 成功パス: リストを更新し、成功を表示してから1.2秒後に閉じる
     setFoods((prev) => [...prev, payload as FoodMaster].sort((a, b) => a.name.localeCompare(b.name)));
+    void mutate("food_master"); // FoodPicker (useFoodList) の SWR キャッシュを無効化
     setSaveSuccess(true);
     setTimeout(() => {
       setShowForm(false);
@@ -150,7 +152,10 @@ export function FoodTable({ initialFoods }: FoodTableProps) {
   function handleDelete(name: string) {
     startTransition(async () => {
       const { error: err } = await deleteFood(name);
-      if (!err) setFoods((prev) => prev.filter((f) => f.name !== name));
+      if (!err) {
+        setFoods((prev) => prev.filter((f) => f.name !== name));
+        void mutate("food_master"); // FoodPicker (useFoodList) の SWR キャッシュを無効化
+      }
     });
   }
 

--- a/src/components/foods/MenuTable.tsx
+++ b/src/components/foods/MenuTable.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo, useTransition } from "react";
 import { Plus, Trash2, Save, ChevronDown, ChevronUp, X } from "lucide-react";
+import { mutate } from "swr";
 import type { FoodMaster, RecipeItem } from "@/lib/supabase/types";
 import type { MenuEntry } from "@/lib/hooks/useMenuList";
 import { insertMenu, updateMenu, deleteMenu } from "@/app/actions/foods";
@@ -110,6 +111,7 @@ export function MenuTable({ initialMenus, foods }: MenuTableProps) {
         a.name.localeCompare(b.name)
       );
     });
+    void mutate("menu_master"); // MenuPicker (useMenuList) の SWR キャッシュを無効化
     setSaveSuccess(true);
     // 成功メッセージを表示してから閉じる
     setTimeout(() => {
@@ -122,7 +124,10 @@ export function MenuTable({ initialMenus, foods }: MenuTableProps) {
   function handleDelete(name: string) {
     startTransition(async () => {
       const { error } = await deleteMenu(name);
-      if (!error) setMenus((prev) => prev.filter((m) => m.name !== name));
+      if (!error) {
+        setMenus((prev) => prev.filter((m) => m.name !== name));
+        void mutate("menu_master"); // MenuPicker (useMenuList) の SWR キャッシュを無効化
+      }
     });
   }
 

--- a/src/lib/utils/calendarUtils.ts
+++ b/src/lib/utils/calendarUtils.ts
@@ -88,9 +88,9 @@ export function calcFastingHours(
     return h * 60 + m;
   };
   const lastMins  = parseMins(lastMealEndTime);
-  const weighMins = parseMins(wakeUpTime);
-  if (lastMins === null || weighMins === null) return null;
-  let delta = weighMins - lastMins;
+  const wakeMins = parseMins(wakeUpTime);
+  if (lastMins === null || wakeMins === null) return null;
+  let delta = wakeMins - lastMins;
   // delta < 0: 日またぎ（例: 前日 22:30 → 翌朝 07:00）→ +24h で正値に補正
   // delta = 0: 同時刻 → +24h で 1440 になり、次行の >= 1440 判定で null を返す
   if (delta <= 0) delta += 24 * 60;

--- a/src/lib/utils/csvParser.test.ts
+++ b/src/lib/utils/csvParser.test.ts
@@ -425,13 +425,7 @@ describe("parseCSV", () => {
   });
 
   it("sleep列: sleep_bed_time だけある場合は行をスキップしエラーを記録する", () => {
-    const csv = [
-      "log_date,sleep_bed_time,sleep_wake_time",
-      "2026-04-01,23:30,",
-      "2026-04-02,70.0,",  // sleep列なし行（weight として invalid だが別問題）
-    ].join("\n");
-
-    // 最初の行が sleep 片側エラーでスキップされることを確認
+    // sleep_bed_time は値あり・sleep_wake_time が空の場合にスキップされることを確認
     const csv2 = [
       "log_date,weight,sleep_bed_time,sleep_wake_time",
       "2026-04-01,70.0,23:30,",

--- a/src/lib/utils/sleep.ts
+++ b/src/lib/utils/sleep.ts
@@ -74,14 +74,14 @@ export function deriveSleepHours(
   wakeUpTime: string
 ): number | null {
   const bedMin = timeToMinutes(bedTime);
-  const weighMin = timeToMinutes(wakeUpTime);
+  const wakeMin = timeToMinutes(wakeUpTime);
 
-  if (bedMin === null || weighMin === null) return null;
+  if (bedMin === null || wakeMin === null) return null;
 
   // 日またぎ補正: wakeUpTime <= bedTime → 前日夜就寝（log_date の朝が bedTime の翌朝）
-  const adjustedWeighMin = weighMin <= bedMin ? weighMin + 24 * 60 : weighMin;
+  const adjustedWakeMin = wakeMin <= bedMin ? wakeMin + 24 * 60 : wakeMin;
 
-  const diffHours = (adjustedWeighMin - bedMin) / 60;
+  const diffHours = (adjustedWakeMin - bedMin) / 60;
 
   // 有効範囲: (0, 24) — 境界値は異常値として除外
   if (diffHours <= 0 || diffHours >= 24) return null;


### PR DESCRIPTION
## 修正内容

### 1. 変数名タイポ修正（`weigh` → `wake`）

起床時刻を格納する変数に「体重」を意味する `weigh` が混入していた。

- `src/lib/utils/sleep.ts` — `weighMin` / `adjustedWeighMin` → `wakeMin` / `adjustedWakeMin`
- `src/lib/utils/calendarUtils.ts` — `weighMins` → `wakeMins`

ロジック変更なし。

### 2. `csvParser.test.ts` 未使用変数 `csv` を削除

`const csv = [...]` を定義したが `csv2` に差し替えたままになっており、ESLint warning の唯一の残存原因だった。変数を削除しコメントを整理。

### 3. `FoodTable` / `MenuTable` の変更後に SWR キャッシュを invalidate

foods ページで食品・セットメニューを追加・更新・削除しても、MealLogger の `FoodPicker`（`useFoodList` SWR キー `"food_master"`）と `MenuPicker`（`useMenuList` SWR キー `"menu_master"`）に反映されず最大 5 分のズレが生じていた。

insert / update / delete 成功時に `mutate("food_master")` / `mutate("menu_master")` を呼び、即時反映されるよう修正。

## テスト

- 全 1437 テスト通過
- `npx tsc --noEmit`: clean
- `npm run lint`: warning 0 件（プロジェクトの既存 warning も含めて完全クリア）

🤖 Generated with [Claude Code](https://claude.com/claude-code)