### PR TITLE
feat: refine meal log modal copy and bowel movement layout

### DIFF
--- a/src/components/meal/MealLogger.tsx
+++ b/src/components/meal/MealLogger.tsx
@@ -569,9 +569,6 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
           ) : (
             <p className="mt-1 text-xs text-slate-400">新規入力</p>
           )}
-          <p className="mt-1 text-[10px] text-slate-400">
-            体重・睡眠はこの日の朝に起きた記録として保存します
-          </p>
         </div>
         <div>
           <label htmlFor="meal-log-weight" className="mb-1.5 block text-xs font-semibold uppercase tracking-wide text-slate-400">体重 (kg)</label>
@@ -663,11 +660,13 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
       {hydratedLog && (hydratedLog.calories !== null || hydratedLog.protein !== null) && (
         <div className="rounded-xl border border-amber-100 bg-amber-50 px-3 py-2 text-xs text-amber-700 dark:border-amber-700/40 dark:bg-amber-900/20 dark:text-amber-400">
           <span className="font-semibold">記録済みマクロ:</span>{" "}
-          {hydratedLog.calories !== null && <span>{hydratedLog.calories} kcal</span>}
-          {hydratedLog.protein  !== null && <span> / P {hydratedLog.protein}g</span>}
-          {hydratedLog.fat      !== null && <span> / F {hydratedLog.fat}g</span>}
-          {hydratedLog.carbs    !== null && <span> / C {hydratedLog.carbs}g</span>}
-          <span className="ml-1 text-amber-600">（更新する場合はカートから追加）</span>
+          <div>
+            {hydratedLog.calories !== null && <span>{hydratedLog.calories} kcal</span>}
+            {hydratedLog.protein  !== null && <span> / P {hydratedLog.protein}g</span>}
+            {hydratedLog.fat      !== null && <span> / F {hydratedLog.fat}g</span>}
+            {hydratedLog.carbs    !== null && <span> / C {hydratedLog.carbs}g</span>}
+          </div>
+          <div className="mt-0.5 text-amber-600">（更新する場合はカートから追加）</div>
         </div>
       )}
 
@@ -700,7 +699,6 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
           {/* 睡眠セクション（就寝時刻 + 起床時刻 + 推定時間）*/}
           <div className="sm:col-span-2 rounded-xl border border-slate-100 bg-slate-50/60 p-3 dark:border-slate-700 dark:bg-slate-800/40">
             <p className="mb-0.5 text-xs font-medium text-slate-500">睡眠</p>
-            <p className="mb-2 text-[10px] text-slate-400 dark:text-slate-500">起床後にこの日の欄へ入力。前日夜の就寝でも今日の画面に記録します。</p>
             {sleepSessionPendingDelete ? (
               /* 削除予定状態 */
               <div className="rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 dark:border-rose-700/50 dark:bg-rose-900/20">
@@ -781,7 +779,7 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
             )}
           </div>
           {/* 最終食事終了時刻 */}
-          <div>
+          <div className="sm:col-span-2">
             <label htmlFor="meal-log-last-meal-end-time" className="mb-1.5 block text-xs font-medium text-slate-500">最終食事終了</label>
             <input
               id="meal-log-last-meal-end-time"
@@ -792,7 +790,7 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
             />
           </div>
           {/* 便通 */}
-          <div>
+          <div className="sm:col-span-2">
             <label className="mb-1.5 block text-xs font-medium text-slate-500">便通</label>
             <div className="flex gap-2">
               <button


### PR DESCRIPTION
## 概要

食事ログ入力モーダルの文言整理とレイアウト調整（#569）。
補助文言2件を削除し、記録済みマクロの補足を改行表示へ変更、最終食事終了と便通を縦並び配置に変更する。

## 変更内容

### 文言整理（削除）

| 箇所 | 削除した文言 |
|---|---|
| 日付フィールド下 | 「体重・睡眠はこの日の朝に起きた記録として保存します」 |
| 睡眠セクション見出し下 | 「起床後にこの日の欄へ入力。前日夜の就寝でも今日の画面に記録します。」 |

### 記録済みマクロの補足改行

- 変更前: マクロ数値と「（更新する場合はカートから追加）」が同一行
- 変更後: マクロ数値を上段に、補足を `<div>` で改行して下段表示
- 色・意味づけ・強調ルールは変更なし

### レイアウト変更（最終食事終了 / 便通）

- 変更前: `sm:grid-cols-2` グリッド内で横並び（同一行）
- 変更後: 両 `div` に `sm:col-span-2` を追加し、縦並び（個別全幅）に変更
- モバイル（grid-cols-1）では元々縦並びのため影響なし

## 保存処理・入力ロジックへの影響

なし。変更はすべて表示層（JSX / Tailwind クラス）のみ。state 管理・保存ロジック・バリデーション・データモデルには一切触れていない。

## モバイル表示確認

- `最終食事終了` / `便通` はモバイル幅（grid-cols-1）では元々縦並びのため、sm+ での見た目が修正対象
- `sm:col-span-2` 追加後、sm 幅以上でも 2 項目が縦積みになり情報密度が下がる
- 型チェック・ビルド・MealLogger テスト（48件）すべて Pass 確認済み

## 補足

- 変更対象ファイル: `src/components/meal/MealLogger.tsx` のみ
- 差分: 9 insertions / 11 deletions（純減）

Closes #569