### PR TITLE
fix: improve meal log modal mobile layout and datetime reset behavior

### DIFF
--- a/src/components/dashboard/MobileMealLoggerSheet.tsx
+++ b/src/components/dashboard/MobileMealLoggerSheet.tsx
@@ -77,7 +77,7 @@ export function MobileMealLoggerSheet() {
           aria-label="食事・体重ログ入力"
           className={[
             // 共通
-            "fixed z-50 bg-white shadow-2xl dark:bg-slate-900",
+            "fixed z-50 overflow-hidden bg-white shadow-2xl dark:bg-slate-900",
             // モバイル: bottom sheet
             "bottom-0 left-0 right-0 max-h-[88svh] rounded-t-2xl",
             // PC (lg+): centered modal — bottom/right をリセットして中央配置

--- a/src/components/meal/MealLogger.tsx
+++ b/src/components/meal/MealLogger.tsx
@@ -569,14 +569,14 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
           ) : (
             <p className="mt-1 text-xs text-slate-400">新規入力</p>
           )}
-          {/* 今日以外の日付を選んだときに「今日に戻す」を表示 */}
-          {date !== todayStr() && (
+          {/* 日付が入力済みのときにクリアボタンを表示 */}
+          {date !== "" && (
             <button
               type="button"
-              onClick={() => handleDateChange(todayStr())}
-              className="mt-1 text-[10px] text-blue-500 underline hover:text-blue-700 transition-colors"
+              onClick={() => handleDateChange("")}
+              className="mt-1 text-[10px] text-slate-400 underline hover:text-rose-400 transition-colors"
             >
-              今日に戻す
+              日付をクリア
             </button>
           )}
         </div>
@@ -925,7 +925,7 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
       <div className="flex items-center justify-end">
         <button
           onClick={handleSave}
-          disabled={status === "saving" || !hasContent}
+          disabled={status === "saving" || !hasContent || !date}
           className="flex w-full items-center justify-center gap-2 rounded-xl bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition-all hover:bg-blue-700 hover:shadow-md disabled:opacity-40"
         >
           {status === "saving"

--- a/src/components/meal/MealLogger.tsx
+++ b/src/components/meal/MealLogger.tsx
@@ -744,23 +744,47 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
                 <div className="grid grid-cols-1 gap-2">
                   <div>
                     <label htmlFor="meal-log-sleep-bed-time" className="mb-1 block text-[10px] text-slate-400">就寝時刻（昨夜〜深夜）</label>
-                    <input
-                      id="meal-log-sleep-bed-time"
-                      type="time"
-                      value={sleepBedTime}
-                      onChange={(e) => { setSleepBedTime(e.target.value); setSleepSessionTouched(true); }}
-                      className={inputCls}
-                    />
+                    <div className="relative">
+                      <input
+                        id="meal-log-sleep-bed-time"
+                        type="time"
+                        value={sleepBedTime}
+                        onChange={(e) => { setSleepBedTime(e.target.value); setSleepSessionTouched(true); }}
+                        className={`${inputCls} ${sleepBedTime !== "" ? "pr-8" : ""}`}
+                      />
+                      {sleepBedTime !== "" && (
+                        <button
+                          type="button"
+                          onClick={() => { setSleepBedTime(""); setSleepSessionTouched(true); }}
+                          aria-label="就寝時刻をクリア"
+                          className="absolute right-1.5 top-1/2 -translate-y-1/2 p-1 text-slate-300 hover:text-rose-400 transition-colors"
+                        >
+                          <X size={15} />
+                        </button>
+                      )}
+                    </div>
                   </div>
                   <div>
                     <label htmlFor="meal-log-sleep-wake-time" className="mb-1 block text-[10px] text-slate-400">起床時刻（今朝）</label>
-                    <input
-                      id="meal-log-sleep-wake-time"
-                      type="time"
-                      value={sleepWakeTime}
-                      onChange={(e) => { setSleepWakeTime(e.target.value); setSleepSessionTouched(true); }}
-                      className={inputCls}
-                    />
+                    <div className="relative">
+                      <input
+                        id="meal-log-sleep-wake-time"
+                        type="time"
+                        value={sleepWakeTime}
+                        onChange={(e) => { setSleepWakeTime(e.target.value); setSleepSessionTouched(true); }}
+                        className={`${inputCls} ${sleepWakeTime !== "" ? "pr-8" : ""}`}
+                      />
+                      {sleepWakeTime !== "" && (
+                        <button
+                          type="button"
+                          onClick={() => { setSleepWakeTime(""); setSleepSessionTouched(true); }}
+                          aria-label="起床時刻をクリア"
+                          className="absolute right-1.5 top-1/2 -translate-y-1/2 p-1 text-slate-300 hover:text-rose-400 transition-colors"
+                        >
+                          <X size={15} />
+                        </button>
+                      )}
+                    </div>
                   </div>
                 </div>
                 {/* 片方だけ入力時の警告 */}

--- a/src/components/meal/MealLogger.tsx
+++ b/src/components/meal/MealLogger.tsx
@@ -569,6 +569,16 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
           ) : (
             <p className="mt-1 text-xs text-slate-400">新規入力</p>
           )}
+          {/* 今日以外の日付を選んだときに「今日に戻す」を表示 */}
+          {date !== todayStr() && (
+            <button
+              type="button"
+              onClick={() => handleDateChange(todayStr())}
+              className="mt-1 text-[10px] text-blue-500 underline hover:text-blue-700 transition-colors"
+            >
+              今日に戻す
+            </button>
+          )}
         </div>
         <div>
           <label htmlFor="meal-log-weight" className="mb-1.5 block text-xs font-semibold uppercase tracking-wide text-slate-400">体重 (kg)</label>
@@ -731,7 +741,7 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
             ) : (
               /* 通常入力状態 */
               <div className="flex flex-col gap-2">
-                <div className="grid grid-cols-2 gap-2">
+                <div className="grid grid-cols-1 gap-2">
                   <div>
                     <label htmlFor="meal-log-sleep-bed-time" className="mb-1 block text-[10px] text-slate-400">就寝時刻（昨夜〜深夜）</label>
                     <input
@@ -781,13 +791,25 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
           {/* 最終食事終了時刻 */}
           <div className="sm:col-span-2">
             <label htmlFor="meal-log-last-meal-end-time" className="mb-1.5 block text-xs font-medium text-slate-500">最終食事終了</label>
-            <input
-              id="meal-log-last-meal-end-time"
-              type="time"
-              value={lastMealEndTime}
-              onChange={(e) => { setLastMealEndTime(e.target.value); setLastMealEndTimeTouched(true); }}
-              className={inputCls}
-            />
+            <div className="relative">
+              <input
+                id="meal-log-last-meal-end-time"
+                type="time"
+                value={lastMealEndTime}
+                onChange={(e) => { setLastMealEndTime(e.target.value); setLastMealEndTimeTouched(true); }}
+                className={`${inputCls} ${lastMealEndTime !== "" ? "pr-8" : ""}`}
+              />
+              {lastMealEndTime !== "" && (
+                <button
+                  type="button"
+                  onClick={() => { setLastMealEndTime(""); setLastMealEndTimeTouched(true); }}
+                  aria-label="最終食事終了時刻をクリア"
+                  className="absolute right-1.5 top-1/2 -translate-y-1/2 p-1 text-slate-300 hover:text-rose-400 transition-colors"
+                >
+                  <X size={15} />
+                </button>
+              )}
+            </div>
           </div>
           {/* 便通 */}
           <div className="sm:col-span-2">


### PR DESCRIPTION
## 概要

食事ログ入力モーダルのモバイル表示改善・日時リセット不具合修正（#571）。

## 変更ファイル

- `src/components/dashboard/MobileMealLoggerSheet.tsx`
- `src/components/meal/MealLogger.tsx`

## 変更内容

### モバイル幅・余白（日付入力はみ出し修正）

| 項目 | 内容 |
|---|---|
| 原因 | パネルに `overflow-hidden` がなく、`rounded-t-2xl` 外に `input[type=date]` のネイティブ UI がはみ出していた |
| 修正 | `MobileMealLoggerSheet` パネル div に `overflow-hidden` を追加 |

### 睡眠時刻入力欄の重なり修正

- `grid grid-cols-2 gap-2` → `grid grid-cols-1 gap-2` に変更し、就寝・起床時刻入力を縦積みに
- モバイル幅（iPhone mini 等）でも重ならない

### 日付入力リセット

- 日付入力の下に「日付をクリア」ボタンを追加（`date !== ""` のときのみ表示）
- クリック時: `handleDateChange("")` → `date = ""`、`hydrateForm("")` でフォーム全体リセット
- 保存ボタン disabled 条件に `|| !date` を追加し、空日付での保存をガード

### 時刻入力リセット（最終食事終了・睡眠時刻）

3 つの time input すべてに X クリアボタンを追加（ネイティブ picker に依存しない明示クリア）:

| 入力欄 | クリア時の動作 |
|---|---|
| 最終食事終了 | `setLastMealEndTime("")` + `setLastMealEndTimeTouched(true)` → 保存時 `null` 送信 |
| 就寝時刻 | `setSleepBedTime("")` + `setSleepSessionTouched(true)` |
| 起床時刻 | `setSleepWakeTime("")` + `setSleepSessionTouched(true)` |

- 値が `""` のときボタン非表示（未入力状態）
- 片側クリア後 → `sleepInputIsPartial` 警告が表示（既存ロジック）
- 推定睡眠時間 → `!sleepBedTime || !sleepWakeTime` で自動非表示（既存ロジック）
- 「記録を削除」ボタンは引き続き既存セッション全体削除に使用

## 保存処理・計算ロジックへの影響

なし。state 管理・touched フラグ・推定睡眠時間計算・保存ペイロード生成のロジックは変更なし。

## 確認

- 型チェック: Pass
- ビルド: Pass（Next.js 16.2.3）
- MealLogger テスト: 48件 Pass

Closes #571