### PR TITLE
fix: add min-w-0 to input containers to prevent mobile overflow

### DIFF
--- a/src/components/meal/MealLogger.tsx
+++ b/src/components/meal/MealLogger.tsx
@@ -544,7 +544,7 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
     (!!sleepBedTime !== !!sleepWakeTime);
 
   const inputCls =
-    "w-full rounded-xl border border-slate-200 bg-slate-50 px-3 py-2.5 text-sm text-slate-800 outline-none transition-colors focus:border-blue-400 focus:bg-white focus:ring-2 focus:ring-blue-100 placeholder:text-slate-400 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus:bg-slate-800 dark:focus:border-blue-500 dark:focus:ring-blue-900/40";
+    "w-full min-w-0 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2.5 text-sm text-slate-800 outline-none transition-colors focus:border-blue-400 focus:bg-white focus:ring-2 focus:ring-blue-100 placeholder:text-slate-400 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus:bg-slate-800 dark:focus:border-blue-500 dark:focus:ring-blue-900/40";
   // 明示的クリア状態（null）のときの入力欄スタイル（pr-8 不要 — オーバーレイボタンは外に出す）
   const inputClearedCls =
     "w-full rounded-xl border border-rose-200 bg-rose-50 px-3 py-2.5 text-sm text-rose-400 placeholder:text-rose-300 outline-none opacity-75 cursor-default dark:border-rose-700/50 dark:bg-rose-900/20 dark:text-rose-400 dark:placeholder:text-rose-700/70";
@@ -560,7 +560,7 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
     <div className={sidebar ? "flex flex-col gap-4" : "border-t border-slate-100 px-5 pb-5 pt-4"}>
       {/* 日付・体重・メモ */}
       <div className={`grid gap-3 ${sidebar ? "grid-cols-1" : "grid-cols-1 sm:grid-cols-3"}`}>
-        <div>
+        <div className="min-w-0">
           <label htmlFor="meal-log-date" className="mb-1.5 block text-xs font-semibold uppercase tracking-wide text-slate-400">日付</label>
           <input id="meal-log-date" type="date" value={date} onChange={(e) => handleDateChange(e.target.value)} className={inputCls} />
           {/* 既存ログあり / 新規入力 バッジ */}
@@ -707,7 +707,7 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
         <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">コンディション</p>
         <div className={`grid gap-3 ${sidebar ? "grid-cols-1" : "grid-cols-1 sm:grid-cols-2"}`}>
           {/* 睡眠セクション（就寝時刻 + 起床時刻 + 推定時間）*/}
-          <div className="sm:col-span-2 rounded-xl border border-slate-100 bg-slate-50/60 p-3 dark:border-slate-700 dark:bg-slate-800/40">
+          <div className="sm:col-span-2 min-w-0 rounded-xl border border-slate-100 bg-slate-50/60 p-3 dark:border-slate-700 dark:bg-slate-800/40">
             <p className="mb-0.5 text-xs font-medium text-slate-500">睡眠</p>
             {sleepSessionPendingDelete ? (
               /* 削除予定状態 */
@@ -742,9 +742,9 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
               /* 通常入力状態 */
               <div className="flex flex-col gap-2">
                 <div className="grid grid-cols-1 gap-2">
-                  <div>
+                  <div className="min-w-0">
                     <label htmlFor="meal-log-sleep-bed-time" className="mb-1 block text-[10px] text-slate-400">就寝時刻（昨夜〜深夜）</label>
-                    <div className="relative">
+                    <div className="relative w-full min-w-0">
                       <input
                         id="meal-log-sleep-bed-time"
                         type="time"
@@ -764,9 +764,9 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
                       )}
                     </div>
                   </div>
-                  <div>
+                  <div className="min-w-0">
                     <label htmlFor="meal-log-sleep-wake-time" className="mb-1 block text-[10px] text-slate-400">起床時刻（今朝）</label>
-                    <div className="relative">
+                    <div className="relative w-full min-w-0">
                       <input
                         id="meal-log-sleep-wake-time"
                         type="time"
@@ -813,9 +813,9 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
             )}
           </div>
           {/* 最終食事終了時刻 */}
-          <div className="sm:col-span-2">
+          <div className="sm:col-span-2 min-w-0">
             <label htmlFor="meal-log-last-meal-end-time" className="mb-1.5 block text-xs font-medium text-slate-500">最終食事終了</label>
-            <div className="relative">
+            <div className="relative w-full min-w-0">
               <input
                 id="meal-log-last-meal-end-time"
                 type="time"


### PR DESCRIPTION
## 概要

食事ログモーダルで日付・睡眠時刻・最終食事終了の各入力欄がモバイル表示でパネル右端からはみ出す問題を根本修正（#571 追加対応）。

## 原因

`input[type=date]` / `input[type=time]` はブラウザがデフォルトの最小幅（min-width: auto 相当）を持つ。
`grid` / `flex` アイテムも `min-width: auto` がデフォルトのため、コンテナが幅を制約できず input がパネル外にはみ出していた。

`overflow-hidden` では視覚的にクリップされるだけで根本解決にならない。

## 修正内容

| 変更箇所 | 追加クラス |
|---|---|
| `inputCls`（全 input 共通） | `min-w-0`（ブラウザ default min-width を上書き） |
| 日付フィールド grid cell div | `min-w-0` |
| 睡眠パネル div（`sm:col-span-2`） | `min-w-0` |
| 就寝時刻 field wrapper div | `min-w-0` |
| 就寝時刻 `relative` ラッパー | `w-full min-w-0` |
| 起床時刻 field wrapper div | `min-w-0` |
| 起床時刻 `relative` ラッパー | `w-full min-w-0` |
| 最終食事終了 outer div | `min-w-0` |
| 最終食事終了 `relative` ラッパー | `w-full min-w-0` |

## 影響範囲

- クリア動作・保存ロジック・推定睡眠時間計算への変更なし
- `inputCls` への `min-w-0` 追加は全 input に適用されるが、`w-full` との組み合わせで安全（コンテナ内に収まる動作に変わるだけ）
- 型チェック・ビルド・MealLogger テスト（48件）すべて Pass

Closes #571