### PR TITLE
fix: replace upsert with update in step import to fix NOT NULL constraint failures

### DIFF
--- a/src/app/api/step-import/route.test.ts
+++ b/src/app/api/step-import/route.test.ts
@@ -1,0 +1,297 @@
+/**
+ * /api/step-import route テスト
+ *
+ * ## テスト構成
+ *
+ * 1. classifyRecords — 分類ロジックの単体テスト
+ *    - 新規 / 上書き / スキップの正しい分類
+ *    - preflight で使う件数と import で使う件数が同じ分類源から得られることを保証
+ *
+ * 2. POST handler (preflight) — 件数集計の正確性
+ *    - newDays / overwriteDays / skippedDays が classifyRecords の結果と一致すること
+ *
+ * 3. POST handler (import) — 保存件数と実処理の整合
+ *    - savedCount が toUpdate.length と一致すること（全更新成功時）
+ *    - skippedCount が skippedRecords.length と一致すること（全更新成功時）
+ *    - update エラー時に skippedCount に計上されること
+ *    - upsert ではなく update を呼んでいること（INSERT 側制約を回避）
+ *
+ * ## モック方針
+ * - supabase/server の createClient をモック
+ * - makeMockSupabase() で select / update の両チェーンを統一管理する
+ *   - select: from().select().gte().lte() → { data, error: null }
+ *   - update: from().update().eq()        → { error: null | {...} }
+ */
+
+jest.mock("@/lib/supabase/server", () => ({ createClient: jest.fn() }));
+jest.mock("@/lib/cache/revalidate", () => ({ revalidateAfterDailyLogMutation: jest.fn() }));
+
+import { NextRequest } from "next/server";
+import { POST, classifyRecords } from "./route";
+import { createClient } from "@/lib/supabase/server";
+import type { StepRecord } from "./parsers";
+
+const mockCreateClient = createClient as jest.Mock;
+
+// ── モックヘルパー ────────────────────────────────────────────────────────────
+
+/**
+ * supabase クライアントのモックを生成する。
+ *
+ * from() → builder を返す。builder には select / update / upsert が生えており、
+ *   - select().gte().lte() の await → { data: selectData, error: null }
+ *   - update().eq()        の await → { error: updateError }
+ * のように動作する。
+ */
+function makeMockSupabase(opts: {
+  selectData: { log_date: string; step_count: number | null }[];
+  updateError?: { message: string } | null;
+}) {
+  // select チェーン
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const selectChain: any = Object.assign(
+    Promise.resolve({ data: opts.selectData, error: null }),
+    {
+      select: jest.fn().mockReturnThis(),
+      gte:    jest.fn().mockReturnThis(),
+      lte:    jest.fn().mockReturnThis(),
+    },
+  );
+
+  // update チェーン（eq を持つ Promise）
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const updateChain: any = Object.assign(
+    Promise.resolve({ error: opts.updateError ?? null }),
+    { eq: jest.fn().mockReturnThis() },
+  );
+
+  // builder: from() が返すオブジェクト
+  const builder = {
+    select: jest.fn().mockReturnValue(selectChain),
+    update: jest.fn().mockReturnValue(updateChain),
+    upsert: jest.fn(), // 呼ばれないことを確認するために用意
+  };
+
+  return {
+    client: { from: jest.fn().mockReturnValue(builder) },
+    builder,
+    updateChain,
+  };
+}
+
+function makeRequest(action: "preflight" | "import", csvText: string): NextRequest {
+  const url = new URL(`http://localhost/api/step-import?action=${action}`);
+  const formData = new FormData();
+  formData.append("file", new Blob([csvText], { type: "text/csv" }), "daily_steps.csv");
+  return new NextRequest(url.toString(), { method: "POST", body: formData });
+}
+
+const CSV_3ROWS = "date,step_count\n2024-01-01,8000\n2024-01-02,9000\n2024-01-03,7000";
+
+// ── classifyRecords ───────────────────────────────────────────────────────────
+
+describe("classifyRecords", () => {
+  const records: StepRecord[] = [
+    { date: "2024-01-01", stepCount: 8000 },
+    { date: "2024-01-02", stepCount: 9000 },
+    { date: "2024-01-03", stepCount: 7000 },
+  ];
+
+  it("新規 / 上書き / スキップを正しく分類する", () => {
+    const existingMap = new Map<string, number | null>([
+      ["2024-01-01", null],  // 既存行, step_count 未記録 → 新規書き込み
+      ["2024-01-02", 5000],  // 既存行, step_count あり → 上書き
+      // "2024-01-03" はなし → スキップ
+    ]);
+    const result = classifyRecords(records, existingMap);
+
+    expect(result.toUpdate).toEqual([records[0], records[1]]);
+    expect(result.newRecords).toEqual([records[0]]);
+    expect(result.overwriteRecords).toEqual([records[1]]);
+    expect(result.skippedRecords).toEqual([records[2]]);
+  });
+
+  it("全件 existingMap に存在する場合、skippedRecords は空", () => {
+    const existingMap = new Map<string, number | null>([
+      ["2024-01-01", null],
+      ["2024-01-02", 100],
+      ["2024-01-03", 200],
+    ]);
+    const result = classifyRecords(records, existingMap);
+
+    expect(result.toUpdate).toHaveLength(3);
+    expect(result.skippedRecords).toHaveLength(0);
+  });
+
+  it("existingMap が空の場合、全件スキップされる", () => {
+    const result = classifyRecords(records, new Map());
+
+    expect(result.toUpdate).toHaveLength(0);
+    expect(result.skippedRecords).toEqual(records);
+    expect(result.newRecords).toHaveLength(0);
+    expect(result.overwriteRecords).toHaveLength(0);
+  });
+
+  it("records が空の場合、全フィールドが空配列", () => {
+    const result = classifyRecords([], new Map([["2024-01-01", null]]));
+
+    expect(result.toUpdate).toHaveLength(0);
+    expect(result.skippedRecords).toHaveLength(0);
+    expect(result.newRecords).toHaveLength(0);
+    expect(result.overwriteRecords).toHaveLength(0);
+  });
+
+  it("preflight の newDays + overwriteDays = toUpdate.length（件数整合の保証）", () => {
+    const existingMap = new Map<string, number | null>([
+      ["2024-01-01", null],
+      ["2024-01-02", 5000],
+    ]);
+    const result = classifyRecords(records, existingMap);
+
+    expect(result.newRecords.length + result.overwriteRecords.length).toBe(result.toUpdate.length);
+  });
+});
+
+// ── POST handler: preflight ──────────────────────────────────────────────────
+
+describe("POST /api/step-import?action=preflight", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("newDays / overwriteDays / skippedDays / matchedDays を正しく返す", async () => {
+    const { client } = makeMockSupabase({
+      selectData: [
+        { log_date: "2024-01-01", step_count: null },  // 新規書き込み対象
+        { log_date: "2024-01-02", step_count: 5000 },  // 上書き対象
+        // 2024-01-03 は daily_logs になし → スキップ
+      ],
+    });
+    mockCreateClient.mockReturnValue(client);
+
+    const res = await POST(makeRequest("preflight", CSV_3ROWS));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.totalDays).toBe(3);
+    expect(body.newDays).toBe(1);
+    expect(body.overwriteDays).toBe(1);
+    expect(body.skippedDays).toBe(1);
+    expect(body.matchedDays).toBe(2); // newDays + overwriteDays
+  });
+});
+
+// ── POST handler: import ─────────────────────────────────────────────────────
+
+describe("POST /api/step-import?action=import", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("全件更新成功: savedCount = toUpdate.length, skippedCount = skippedRecords.length", async () => {
+    const { client } = makeMockSupabase({
+      selectData: [
+        { log_date: "2024-01-01", step_count: null },  // toUpdate に入る
+        { log_date: "2024-01-02", step_count: 5000 },  // toUpdate に入る
+        // 2024-01-03 はなし → skipped
+      ],
+      updateError: null,
+    });
+    mockCreateClient.mockReturnValue(client);
+
+    const res = await POST(makeRequest("import", CSV_3ROWS));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.ok).toBe(true);
+    expect(body.savedCount).toBe(2);   // 2024-01-01, 02 が更新成功
+    expect(body.skippedCount).toBe(1); // 2024-01-03 は daily_logs になし
+  });
+
+  it("update エラー時は savedCount が減り skippedCount が増える", async () => {
+    const { client } = makeMockSupabase({
+      selectData: [
+        { log_date: "2024-01-01", step_count: null },  // toUpdate に入るが update 失敗
+        // 2024-01-02, 03 はなし → skipped
+      ],
+      updateError: { message: "DB constraint violation" },
+    });
+    mockCreateClient.mockReturnValue(client);
+
+    const res = await POST(makeRequest("import", CSV_3ROWS));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.ok).toBe(true);
+    expect(body.savedCount).toBe(0);
+    // skippedCount = 2（2024-01-02, 03 は daily_logs になし）+ 1（2024-01-01 の update エラー）
+    expect(body.skippedCount).toBe(3);
+  });
+
+  it("update が呼ばれ upsert が呼ばれていない", async () => {
+    const { client, builder } = makeMockSupabase({
+      selectData: [{ log_date: "2024-01-01", step_count: null }],
+    });
+    mockCreateClient.mockReturnValue(client);
+
+    const csv = "date,step_count\n2024-01-01,8000";
+    await POST(makeRequest("import", csv));
+
+    expect(builder.update).toHaveBeenCalledWith({ step_count: 8000 });
+    expect(builder.upsert).not.toHaveBeenCalled();
+  });
+
+  it("update は対象日付ごとに eq('log_date', date) を呼ぶ", async () => {
+    const { client, updateChain } = makeMockSupabase({
+      selectData: [
+        { log_date: "2024-01-01", step_count: null },
+        { log_date: "2024-01-02", step_count: 5000 },
+      ],
+    });
+    mockCreateClient.mockReturnValue(client);
+
+    await POST(makeRequest("import", CSV_3ROWS));
+
+    // 2件の update に対して eq が呼ばれていること
+    expect(updateChain.eq).toHaveBeenCalledWith("log_date", "2024-01-01");
+    expect(updateChain.eq).toHaveBeenCalledWith("log_date", "2024-01-02");
+    expect(updateChain.eq).toHaveBeenCalledTimes(2);
+  });
+
+  it("ファイル内の有効行が 0 件 → 400 を返す", async () => {
+    mockCreateClient.mockReturnValue({ from: jest.fn() });
+
+    const url = new URL("http://localhost/api/step-import?action=import");
+    const formData = new FormData();
+    formData.append(
+      "file",
+      new Blob(["date,step_count\n"], { type: "text/csv" }),
+      "daily_steps.csv",
+    );
+    const req = new NextRequest(url.toString(), { method: "POST", body: formData });
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+  });
+
+  it("preflight と import で同じ分類ロジックを使うため件数が一致する（回帰テスト）", async () => {
+    // preflight で返す件数と、import で savedCount + skippedCount(fromUpdate) の合計が一致することを確認
+    const selectData = [
+      { log_date: "2024-01-01", step_count: null },
+      { log_date: "2024-01-02", step_count: 5000 },
+    ];
+
+    // preflight
+    const { client: pClient } = makeMockSupabase({ selectData });
+    mockCreateClient.mockReturnValue(pClient);
+    const preflightRes = await POST(makeRequest("preflight", CSV_3ROWS));
+    const preflightBody = await preflightRes.json();
+
+    // import
+    const { client: iClient } = makeMockSupabase({ selectData, updateError: null });
+    mockCreateClient.mockReturnValue(iClient);
+    const importRes = await POST(makeRequest("import", CSV_3ROWS));
+    const importBody = await importRes.json();
+
+    // preflight の matchedDays = import の savedCount（全更新成功時）
+    expect(importBody.savedCount).toBe(preflightBody.matchedDays);
+    // preflight の skippedDays = import の skippedCount（全更新成功時）
+    expect(importBody.skippedCount).toBe(preflightBody.skippedDays);
+  });
+});

--- a/src/app/api/step-import/route.ts
+++ b/src/app/api/step-import/route.ts
@@ -32,9 +32,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { revalidateAfterDailyLogMutation } from "@/lib/cache/revalidate";
 import { parseStepFile } from "./parsers";
-import type { Database } from "@/lib/supabase/types";
-
-type DailyLogInsert = Database["public"]["Tables"]["daily_logs"]["Insert"];
+import type { StepRecord } from "./parsers";
 
 // ── 型定義 ──────────────────────────────────────────────────────────────────
 
@@ -56,6 +54,51 @@ export type StepPreflightResult = {
 export type StepImportResult =
   | { ok: true; savedCount: number; skippedCount: number }
   | { ok: false; message: string };
+
+// ── 分類ロジック（preflight / import で共有） ───────────────────────────────
+
+/**
+ * パース済み歩数レコードを既存ログとの照合結果に基づいて分類する。
+ *
+ * preflight と import が同じロジックで分類することで、
+ * 事前確認の件数と実保存の件数が一致することを保証する。
+ */
+export type ClassifiedRecords = {
+  /** daily_logs に行が存在し、step_count を更新すべきレコード（新規 + 上書き） */
+  toUpdate: StepRecord[];
+  /** daily_logs に行が存在し、既に step_count が入っていないレコード（新規書き込み対象） */
+  newRecords: StepRecord[];
+  /** daily_logs に行が存在し、既に step_count が入っているレコード（上書き対象） */
+  overwriteRecords: StepRecord[];
+  /** daily_logs に対応行がないレコード（スキップ対象） */
+  skippedRecords: StepRecord[];
+};
+
+export function classifyRecords(
+  records: StepRecord[],
+  existingMap: Map<string, number | null>,
+): ClassifiedRecords {
+  const toUpdate: StepRecord[] = [];
+  const newRecords: StepRecord[] = [];
+  const overwriteRecords: StepRecord[] = [];
+  const skippedRecords: StepRecord[] = [];
+
+  for (const record of records) {
+    if (!existingMap.has(record.date)) {
+      skippedRecords.push(record);
+    } else {
+      toUpdate.push(record);
+      const existing = existingMap.get(record.date);
+      if (existing === null || existing === undefined) {
+        newRecords.push(record);
+      } else {
+        overwriteRecords.push(record);
+      }
+    }
+  }
+
+  return { toUpdate, newRecords, overwriteRecords, skippedRecords };
+}
 
 // ── ヘルパー ──────────────────────────────────────────────────────────────
 
@@ -102,7 +145,7 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  // 解析結果の日付一覧を取得（昇順ソート��み）
+  // 解析結果の日付一覧を取得（昇順ソート済み）
   const dates = parsed.records.map((r) => r.date).sort();
   const datesSet = new Set(dates);
   const minDate = dates[0]!;
@@ -111,7 +154,7 @@ export async function POST(req: NextRequest) {
   // DB から対象日付範囲の daily_logs を取得
   //
   // `.in("log_date", dates)` は PostgREST により URL クエリパラメータに展開されるため、
-  // 日付件数が多い（数百〜数千件）と URL 長制限を超���て 400 Bad Request になる。
+  // 日付件数が多い（数百〜数千件）と URL 長制限を超えて 400 Bad Request になる。
   // 代わりに minDate〜maxDate の範囲取得を使い、アプリ側で datesSet との突合を行う。
   // 範囲内に import 対象外の日付が含まれる場合があるが、datesSet フィルタで除外する。
   const supabase = createClient();
@@ -132,33 +175,17 @@ export async function POST(req: NextRequest) {
       .map((row) => [row.log_date, row.step_count as number | null]),
   );
 
+  // preflight と import で同じ classifyRecords を使うことで件数の一致を保証する
+  const classified = classifyRecords(parsed.records, existingMap);
+
   // ── preflight ──────────────────────────────────────────────────────────────
   if (action === "preflight") {
-    let matchedDays  = 0;
-    let overwriteDays = 0;
-    let newDays       = 0;
-    let skippedDays   = 0;
-
-    for (const { date } of parsed.records) {
-      if (!existingMap.has(date)) {
-        skippedDays++;
-      } else {
-        matchedDays++;
-        const existing = existingMap.get(date);
-        if (existing !== null && existing !== undefined) {
-          overwriteDays++;
-        } else {
-          newDays++;
-        }
-      }
-    }
-
     const result: StepPreflightResult = {
       totalDays:    parsed.records.length,
-      matchedDays,
-      overwriteDays,
-      newDays,
-      skippedDays,
+      matchedDays:  classified.toUpdate.length,
+      overwriteDays: classified.overwriteRecords.length,
+      newDays:      classified.newRecords.length,
+      skippedDays:  classified.skippedRecords.length,
       invalidRows:  parsed.invalidRows,
     };
     return NextResponse.json(result);
@@ -166,35 +193,41 @@ export async function POST(req: NextRequest) {
 
   // ── import ─────────────────────────────────────────────────────────────────
   let savedCount   = 0;
-  let skippedCount = 0;
+  let skippedCount = classified.skippedRecords.length;
 
-  // 既存 daily_logs がある日付だけ更新対象に絞る（新規行は生成しない）
-  const toUpdate = parsed.records.filter(({ date }) => existingMap.has(date));
-  skippedCount = parsed.records.length - toUpdate.length;
-
-  // チャンク単位で一括 upsert する
+  // step_count を日付ごとに UPDATE する
   //
-  // - toUpdate は existingMap.has() で絞り済みのため、upsert は既存行への UPDATE として動作する
-  // - log_date と step_count のみ指定することで、他カラムへの誤更新を防ぐ
-  //   (PostgREST upsert は ON CONFLICT DO UPDATE SET で指定カラムのみを更新する)
-  // - 逐次 RPC (O(N) round trips) に替えてチャンク単位の upsert (O(N/100) round trips) にすることで
-  //   数百〜千件規模でもタイムアウトに到達しにくくする (#450)
-  // - チャンク単位で失敗した場合はそのチャンクを skippedCount に計上して処理を継続する
-  const IMPORT_CHUNK_SIZE = 100;
+  // upsert（INSERT...ON CONFLICT）を使わない理由:
+  //   upsert は INSERT を試みるため、NOT NULL DEFAULT カラム（is_cheat_day 等）が
+  //   NULL と評価される場合に制約違反で全チャンクが失敗する。
+  //   UPDATE は既存行のみを対象にするため INSERT 側の制約に触れない。
+  //
+  // 並行実行（BATCH_CONCURRENCY 件ずつ Promise.allSettled）でタイムアウトを回避する。
+  // classified.toUpdate は existingMap.has() でフィルタ済みのため全行が既存行。
+  const BATCH_CONCURRENCY = 20;
+  const { toUpdate } = classified;
 
-  for (let i = 0; i < toUpdate.length; i += IMPORT_CHUNK_SIZE) {
-    const chunk = toUpdate.slice(i, i + IMPORT_CHUNK_SIZE);
-    const { error: upsertError } = await supabase
-      .from("daily_logs")
-      .upsert(
-        chunk.map(({ date, stepCount }) => ({ log_date: date, step_count: stepCount })) as unknown as DailyLogInsert[],
-        { onConflict: "log_date" },
-      );
-    if (upsertError) {
-      console.error("[step-import] upsert error:", upsertError.message);
-      skippedCount += chunk.length;
-    } else {
-      savedCount += chunk.length;
+  for (let i = 0; i < toUpdate.length; i += BATCH_CONCURRENCY) {
+    const batch = toUpdate.slice(i, i + BATCH_CONCURRENCY);
+    const results = await Promise.allSettled(
+      batch.map(({ date, stepCount }) =>
+        supabase
+          .from("daily_logs")
+          .update({ step_count: stepCount })
+          .eq("log_date", date)
+      ),
+    );
+    for (const result of results) {
+      if (result.status === "fulfilled" && !result.value.error) {
+        savedCount++;
+      } else {
+        const msg =
+          result.status === "rejected"
+            ? String(result.reason)
+            : (result.value.error?.message ?? "unknown error");
+        console.error("[step-import] update error:", msg);
+        skippedCount++;
+      }
     }
   }
 

--- a/src/app/api/step-import/route.ts
+++ b/src/app/api/step-import/route.ts
@@ -64,13 +64,9 @@ export type StepImportResult =
  * 事前確認の件数と実保存の件数が一致することを保証する。
  */
 export type ClassifiedRecords = {
-  /** daily_logs に行が存在し、step_count を更新すべきレコード（新規 + 上書き） */
   toUpdate: StepRecord[];
-  /** daily_logs に行が存在し、既に step_count が入っていないレコード（新規書き込み対象） */
   newRecords: StepRecord[];
-  /** daily_logs に行が存在し、既に step_count が入っているレコード（上書き対象） */
   overwriteRecords: StepRecord[];
-  /** daily_logs に対応行がないレコード（スキップ対象） */
   skippedRecords: StepRecord[];
 };
 
@@ -89,7 +85,7 @@ export function classifyRecords(
     } else {
       toUpdate.push(record);
       const existing = existingMap.get(record.date);
-      if (existing === null || existing === undefined) {
+      if (existing === null) {
         newRecords.push(record);
       } else {
         overwriteRecords.push(record);
@@ -175,7 +171,6 @@ export async function POST(req: NextRequest) {
       .map((row) => [row.log_date, row.step_count as number | null]),
   );
 
-  // preflight と import で同じ classifyRecords を使うことで件数の一致を保証する
   const classified = classifyRecords(parsed.records, existingMap);
 
   // ── preflight ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `step-import` の一括 upsert を日付ごとの UPDATE に置き換え、NOT NULL DEFAULT カラム（`is_cheat_day` 等）に起因する制約違反エラーを解消（#575）
- preflight と import で共通の `classifyRecords()` を導入し、プレビュー件数と実保存件数の不一致を構造的に防止
- `route.test.ts` を新規追加（12 テスト）：`classifyRecords` 単体 + POST ハンドラ統合テスト

## Root cause

`upsert`（`INSERT ... ON CONFLICT DO UPDATE`）は INSERT を試みるため、`is_cheat_day` 等の NOT NULL DEFAULT カラムを省略した payload で制約違反が発生していた。`UPDATE` は既存行のみを対象にするため INSERT 側の制約に触れない。

## Test plan

- [ ] `npx jest --no-coverage src/app/api/step-import/route.test.ts` — 12 tests pass
- [ ] Apple Health エクスポート CSV でプレビュー → 保存の件数が一致することを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)