### PR TITLE
feat: add delete confirmation dialogs in food master

### DIFF
--- a/src/components/foods/FoodTable.integration.test.tsx
+++ b/src/components/foods/FoodTable.integration.test.tsx
@@ -196,19 +196,41 @@ describe("FoodTable — 削除", () => {
     jest.clearAllMocks();
   });
 
-  it("削除ボタンで deleteFood が呼ばれ食品がリストから消える", async () => {
+  it("削除ボタンで確認ダイアログが表示され、確認後に deleteFood が呼ばれ食品がリストから消える", async () => {
     render(<FoodTable initialFoods={[makeFoodMaster({ name: "削除対象" })]} />);
 
     // mobile/desktop 両方にボタンがあるので最初のものを使用
     const deleteButton = screen.getAllByLabelText("削除対象を削除")[0]!;
+    fireEvent.click(deleteButton);
+
+    // 確認ダイアログが表示される
+    expect(screen.getByText("食品『削除対象』を削除しますか？")).toBeInTheDocument();
+
+    // 「削除」ボタンをクリックして確認
     await act(async () => {
-      fireEvent.click(deleteButton);
+      fireEvent.click(screen.getByRole("button", { name: "削除" }));
     });
 
     await waitFor(() => {
       expect(mockDeleteFood).toHaveBeenCalledWith("削除対象");
     });
     expect(screen.queryByText("削除対象")).not.toBeInTheDocument();
+  });
+
+  it("削除ボタンで確認ダイアログが表示され、キャンセル時は deleteFood が呼ばれない", async () => {
+    render(<FoodTable initialFoods={[makeFoodMaster({ name: "削除対象" })]} />);
+
+    const deleteButton = screen.getAllByLabelText("削除対象を削除")[0]!;
+    fireEvent.click(deleteButton);
+
+    expect(screen.getByText("食品『削除対象』を削除しますか？")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "キャンセル" }));
+
+    expect(mockDeleteFood).not.toHaveBeenCalled();
+    expect(screen.queryByText("食品『削除対象』を削除しますか？")).not.toBeInTheDocument();
+    // 食品はリストに残る
+    expect(screen.getAllByText("削除対象").length).toBeGreaterThanOrEqual(1);
   });
 });
 

--- a/src/components/foods/FoodTable.tsx
+++ b/src/components/foods/FoodTable.tsx
@@ -6,6 +6,7 @@ import { mutate } from "swr";
 import type { FoodMaster, TablesInsert } from "@/lib/supabase/types";
 import { parseStrictNumber } from "@/lib/utils/parseNumber";
 import { insertFood, deleteFood } from "@/app/actions/foods";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 
 interface FoodTableProps {
   initialFoods: FoodMaster[];
@@ -54,6 +55,7 @@ export function FoodTable({ initialFoods }: FoodTableProps) {
   const [newCategoryMode, setNewCategoryMode] = useState(false);
   const [isPending, startTransition] = useTransition();
   const [visibleCount, setVisibleCount] = useState(15);
+  const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
 
   const categories = useMemo(() => {
     const cats = Array.from(
@@ -159,6 +161,10 @@ export function FoodTable({ initialFoods }: FoodTableProps) {
     });
   }
 
+  function confirmAndDelete(name: string) {
+    setConfirmDelete(name);
+  }
+
   // th 側: padding / font のみ。整列もクリック領域も button 側で担う
   const thSortCls = () =>
     "px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500";
@@ -174,6 +180,13 @@ export function FoodTable({ initialFoods }: FoodTableProps) {
 
   return (
     <div className="flex flex-col gap-4">
+      {confirmDelete !== null && (
+        <ConfirmDialog
+          message={`食品『${confirmDelete}』を削除しますか？`}
+          onConfirm={() => { handleDelete(confirmDelete); setConfirmDelete(null); }}
+          onCancel={() => setConfirmDelete(null)}
+        />
+      )}
       {/* ── 検索（mobile: 最上位 / desktop: 2番目）── */}
       <div className="relative order-1 md:order-2">
         <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 dark:text-slate-500" size={15} />
@@ -357,7 +370,7 @@ export function FoodTable({ initialFoods }: FoodTableProps) {
                   </div>
                 </div>
                 <button
-                  onClick={() => handleDelete(food.name)}
+                  onClick={() => confirmAndDelete(food.name)}
                   disabled={isPending}
                   className="flex-shrink-0 p-2 -mr-1 text-slate-300 dark:text-slate-600 hover:text-rose-500 disabled:opacity-40"
                   aria-label={`${food.name}を削除`}
@@ -438,7 +451,7 @@ export function FoodTable({ initialFoods }: FoodTableProps) {
                     <td className="px-4 py-2.5 text-slate-400 dark:text-slate-500 text-xs">{food.category ?? "—"}</td>
                     <td className="px-4 py-2.5 text-right">
                       <button
-                        onClick={() => handleDelete(food.name)}
+                        onClick={() => confirmAndDelete(food.name)}
                         disabled={isPending}
                         className="text-slate-300 dark:text-slate-600 hover:text-rose-500 disabled:opacity-40"
                         aria-label={`${food.name}を削除`}

--- a/src/components/foods/MenuTable.integration.test.tsx
+++ b/src/components/foods/MenuTable.integration.test.tsx
@@ -190,7 +190,51 @@ describe("MenuTable — 保存成功（更新）", () => {
   });
 });
 
-// ─── シナリオ 6: 削除 ─────────────────────────────────────────────────────
+// ─── シナリオ 6: セット内食品削除 ─────────────────────────────────────────
+
+describe("MenuTable — セット内食品削除", () => {
+  it("食品削除ボタンで確認ダイアログが表示され、確認後にレシピから食品が消える", async () => {
+    render(<MenuTable initialMenus={INITIAL_MENUS} foods={FOODS} />);
+
+    // 編集フォームを開く
+    const editButtons = screen.getAllByText("編集");
+    fireEvent.click(editButtons[0]!);
+
+    // レシピ内の食品削除ボタンをクリック
+    const itemDeleteButton = screen.getByLabelText("鶏むね肉を削除");
+    fireEvent.click(itemDeleteButton);
+
+    // 確認ダイアログが表示される
+    expect(screen.getByText("セットメニュー内の食品『鶏むね肉』を削除しますか？")).toBeInTheDocument();
+
+    // 「削除」ボタンをクリックして確認
+    fireEvent.click(screen.getByRole("button", { name: "削除" }));
+
+    // ダイアログが閉じ、レシピ内の削除ボタンが消える
+    expect(screen.queryByText("セットメニュー内の食品『鶏むね肉』を削除しますか？")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("鶏むね肉を削除")).not.toBeInTheDocument();
+  });
+
+  it("食品削除ボタンで確認ダイアログが表示され、キャンセル時は食品がレシピに残る", () => {
+    render(<MenuTable initialMenus={INITIAL_MENUS} foods={FOODS} />);
+
+    const editButtons = screen.getAllByText("編集");
+    fireEvent.click(editButtons[0]!);
+
+    const itemDeleteButton = screen.getByLabelText("鶏むね肉を削除");
+    fireEvent.click(itemDeleteButton);
+
+    expect(screen.getByText("セットメニュー内の食品『鶏むね肉』を削除しますか？")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "キャンセル" }));
+
+    // ダイアログが閉じ、食品はレシピに残る
+    expect(screen.queryByText("セットメニュー内の食品『鶏むね肉』を削除しますか？")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("鶏むね肉を削除")).toBeInTheDocument();
+  });
+});
+
+// ─── シナリオ 7: 削除 ─────────────────────────────────────────────────────
 
 describe("MenuTable — 削除", () => {
   beforeEach(() => {

--- a/src/components/foods/MenuTable.integration.test.tsx
+++ b/src/components/foods/MenuTable.integration.test.tsx
@@ -201,17 +201,39 @@ describe("MenuTable — 削除", () => {
     jest.clearAllMocks();
   });
 
-  it("削除ボタンで deleteMenu が呼ばれセットがリストから消える", async () => {
+  it("削除ボタンで確認ダイアログが表示され、確認後に deleteMenu が呼ばれセットがリストから消える", async () => {
     render(<MenuTable initialMenus={INITIAL_MENUS} foods={FOODS} />);
 
     const deleteButtons = screen.getAllByLabelText("鶏飯セットを削除");
+    fireEvent.click(deleteButtons[0]!);
+
+    // 確認ダイアログが表示される
+    expect(screen.getByText("セットメニュー『鶏飯セット』を削除しますか？")).toBeInTheDocument();
+
+    // 「削除」ボタンをクリックして確認
     await act(async () => {
-      fireEvent.click(deleteButtons[0]!);
+      fireEvent.click(screen.getByRole("button", { name: "削除" }));
     });
 
     await waitFor(() => {
       expect(mockDeleteMenu).toHaveBeenCalledWith("鶏飯セット");
     });
     expect(screen.queryByText("鶏飯セット")).not.toBeInTheDocument();
+  });
+
+  it("削除ボタンで確認ダイアログが表示され、キャンセル時は deleteMenu が呼ばれない", async () => {
+    render(<MenuTable initialMenus={INITIAL_MENUS} foods={FOODS} />);
+
+    const deleteButtons = screen.getAllByLabelText("鶏飯セットを削除");
+    fireEvent.click(deleteButtons[0]!);
+
+    expect(screen.getByText("セットメニュー『鶏飯セット』を削除しますか？")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "キャンセル" }));
+
+    expect(mockDeleteMenu).not.toHaveBeenCalled();
+    expect(screen.queryByText("セットメニュー『鶏飯セット』を削除しますか？")).not.toBeInTheDocument();
+    // セットはリストに残る
+    expect(screen.getAllByText("鶏飯セット").length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/src/components/foods/MenuTable.tsx
+++ b/src/components/foods/MenuTable.tsx
@@ -6,6 +6,7 @@ import { mutate } from "swr";
 import type { FoodMaster, RecipeItem } from "@/lib/supabase/types";
 import type { MenuEntry } from "@/lib/hooks/useMenuList";
 import { insertMenu, updateMenu, deleteMenu } from "@/app/actions/foods";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 
 interface MenuTableProps {
   initialMenus: MenuEntry[];
@@ -36,6 +37,8 @@ export function MenuTable({ initialMenus, foods }: MenuTableProps) {
   const [isSaving, setIsSaving] = useState(false);
   const [saveSuccess, setSaveSuccess] = useState(false);
   const [isPending, startTransition] = useTransition();
+  const [confirmDeleteMenu, setConfirmDeleteMenu] = useState<string | null>(null);
+  const [confirmRemoveItem, setConfirmRemoveItem] = useState<{ idx: number; name: string } | null>(null);
 
   const foodMap = useMemo(() => new Map(foods.map((f) => [f.name, f])), [foods]);
 
@@ -133,6 +136,20 @@ export function MenuTable({ initialMenus, foods }: MenuTableProps) {
 
   return (
     <div className="space-y-4">
+      {confirmDeleteMenu !== null && (
+        <ConfirmDialog
+          message={`セットメニュー『${confirmDeleteMenu}』を削除しますか？`}
+          onConfirm={() => { handleDelete(confirmDeleteMenu); setConfirmDeleteMenu(null); }}
+          onCancel={() => setConfirmDeleteMenu(null)}
+        />
+      )}
+      {confirmRemoveItem !== null && (
+        <ConfirmDialog
+          message={`セットメニュー内の食品『${confirmRemoveItem.name}』を削除しますか？`}
+          onConfirm={() => { removeItemFromEditing(confirmRemoveItem.idx); setConfirmRemoveItem(null); }}
+          onCancel={() => setConfirmRemoveItem(null)}
+        />
+      )}
       <div className="flex items-center justify-between">
         <div>
           <h2 className="text-sm font-semibold text-slate-700 dark:text-slate-200">セットメニュー</h2>
@@ -235,7 +252,11 @@ export function MenuTable({ initialMenus, foods }: MenuTableProps) {
                       <div className="flex items-center gap-3 text-xs text-gray-400 dark:text-slate-500">
                         <span>{ri.amount}g</span>
                         <span className="text-gray-600 font-medium dark:text-slate-300">{kcal} kcal</span>
-                        <button onClick={() => removeItemFromEditing(originalIdx)} className="text-gray-300 hover:text-rose-500 dark:text-slate-600 dark:hover:text-rose-400">
+                        <button
+                          onClick={() => setConfirmRemoveItem({ idx: originalIdx, name: ri.name })}
+                          className="text-gray-300 hover:text-rose-500 dark:text-slate-600 dark:hover:text-rose-400"
+                          aria-label={`${ri.name}を削除`}
+                        >
                           <Trash2 size={15} />
                         </button>
                       </div>
@@ -305,7 +326,7 @@ export function MenuTable({ initialMenus, foods }: MenuTableProps) {
                         編集
                       </button>
                       <button
-                        onClick={() => handleDelete(menu.name)}
+                        onClick={() => setConfirmDeleteMenu(menu.name)}
                         disabled={isPending}
                         className="p-2 -mr-1 text-slate-300 hover:text-rose-500 disabled:opacity-40 dark:text-slate-600 dark:hover:text-rose-400"
                         aria-label={`${menu.name}を削除`}
@@ -358,9 +379,10 @@ export function MenuTable({ initialMenus, foods }: MenuTableProps) {
                         編集
                       </button>
                       <button
-                        onClick={() => handleDelete(menu.name)}
+                        onClick={() => setConfirmDeleteMenu(menu.name)}
                         disabled={isPending}
                         className="text-gray-300 hover:text-rose-500 disabled:opacity-40 dark:text-slate-600 dark:hover:text-rose-400"
+                        aria-label={`${menu.name}を削除`}
                       >
                         <Trash2 size={15} />
                       </button>

--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -1,3 +1,7 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
 interface ConfirmDialogProps {
   message: string;
   onConfirm: () => void;
@@ -5,18 +9,66 @@ interface ConfirmDialogProps {
 }
 
 export function ConfirmDialog({ message, onConfirm, onCancel }: ConfirmDialogProps) {
+  const cancelRef = useRef<HTMLButtonElement>(null);
+  const confirmRef = useRef<HTMLButtonElement>(null);
+
+  // オープン時: キャンセルボタンにフォーカス（破壊的操作のデフォルトとして安全側）
+  // クローズ時: 呼び出し元の要素にフォーカスを戻す
+  useEffect(() => {
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    cancelRef.current?.focus();
+    return () => {
+      previouslyFocused?.focus();
+    };
+  }, []);
+
+  // Escape キーでキャンセル + ダイアログ内フォーカストラップ
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        onCancel();
+        return;
+      }
+      if (e.key === "Tab") {
+        const focusable = [cancelRef.current, confirmRef.current].filter(
+          (el): el is HTMLButtonElement => el !== null
+        );
+        if (focusable.length === 0) return;
+        const currentIdx = focusable.indexOf(document.activeElement as HTMLButtonElement);
+        const nextIdx = e.shiftKey
+          ? (currentIdx <= 0 ? focusable.length - 1 : currentIdx - 1)
+          : (currentIdx >= focusable.length - 1 ? 0 : currentIdx + 1);
+        focusable[nextIdx]?.focus();
+        e.preventDefault();
+      }
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onCancel]);
+
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 dark:bg-black/60">
-      <div className="mx-4 w-full max-w-sm rounded-2xl bg-white dark:bg-slate-800 p-5 shadow-lg">
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 dark:bg-black/60"
+      onClick={onCancel}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="削除の確認"
+        className="mx-4 w-full max-w-sm rounded-2xl bg-white dark:bg-slate-800 p-5 shadow-lg"
+        onClick={(e) => e.stopPropagation()}
+      >
         <p className="text-sm text-slate-700 dark:text-slate-200">{message}</p>
         <div className="mt-4 flex justify-end gap-2">
           <button
+            ref={cancelRef}
             onClick={onCancel}
             className="rounded-lg border border-slate-200 bg-white dark:border-slate-600 dark:bg-slate-700 dark:text-slate-300 px-4 py-1.5 text-sm hover:bg-slate-50 dark:hover:bg-slate-600"
           >
             キャンセル
           </button>
           <button
+            ref={confirmRef}
             onClick={onConfirm}
             className="rounded-lg bg-rose-500 px-4 py-1.5 text-sm font-semibold text-white hover:bg-rose-600"
           >

--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,29 @@
+interface ConfirmDialogProps {
+  message: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmDialog({ message, onConfirm, onCancel }: ConfirmDialogProps) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 dark:bg-black/60">
+      <div className="mx-4 w-full max-w-sm rounded-2xl bg-white dark:bg-slate-800 p-5 shadow-lg">
+        <p className="text-sm text-slate-700 dark:text-slate-200">{message}</p>
+        <div className="mt-4 flex justify-end gap-2">
+          <button
+            onClick={onCancel}
+            className="rounded-lg border border-slate-200 bg-white dark:border-slate-600 dark:bg-slate-700 dark:text-slate-300 px-4 py-1.5 text-sm hover:bg-slate-50 dark:hover:bg-slate-600"
+          >
+            キャンセル
+          </button>
+          <button
+            onClick={onConfirm}
+            className="rounded-lg bg-rose-500 px-4 py-1.5 text-sm font-semibold text-white hover:bg-rose-600"
+          >
+            削除
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要

食品マスタ画面の削除操作に確認ダイアログを追加し、誤操作による削除を防ぐ。

## 変更内容

- `src/components/ui/ConfirmDialog.tsx` — 新規作成: 対象名入り確認ダイアログ共通コンポーネント
- `src/components/foods/FoodTable.tsx` — 食品削除前に確認ダイアログを表示
- `src/components/foods/MenuTable.tsx` — セットメニュー削除・セット内食品削除前に確認ダイアログを表示
- `src/components/foods/FoodTable.integration.test.tsx` — 削除テストを確認ダイアログ経由フローに更新（+キャンセルケース追加）
- `src/components/foods/MenuTable.integration.test.tsx` — 同上

## 3箇所の対象

| 対象 | 表示文言 |
|---|---|
| 食品登録 | `食品『xxx』を削除しますか？` |
| セットメニュー自体 | `セットメニュー『xxx』を削除しますか？` |
| セット内食品（編集フォーム内） | `セットメニュー内の食品『xxx』を削除しますか？` |

## 実装方式の判断理由

- 既存に確認ダイアログ用コンポーネントなし → `ConfirmDialog` を新規作成
- 3箇所とも同一コンポーネントを使い、`message` prop で文言を切り替える方式を採用
- 削除 API / DB ロジックは無変更。フロント側に確認ステップを挟むのみ

## 確認内容

- 各ボタン押下時に対象名入りダイアログが表示される
- 「削除」クリック → 従来どおり削除処理が実行される
- 「キャンセル」クリック → ダイアログが閉じ、削除処理は実行されない
- `npx jest --no-coverage` 全 33 件通過（食品関連 +2 ケース追加）
- `npx tsc --noEmit` エラーなし

## 補足

- セット内食品の削除はフォーム内の in-memory 操作（保存前なので DB は未変更）だが、Issue #583 の対象として確認ダイアログを追加
- `ConfirmDialog` は将来他の削除導線にも流用可能な設計

Closes #583