### PR TITLE
fix: make /tdee reflect manual batch runs immediately

### DIFF
--- a/src/app/tdee/actions.ts
+++ b/src/app/tdee/actions.ts
@@ -1,0 +1,17 @@
+"use server";
+
+import { revalidateAfterEnrichedLogsMutation } from "@/lib/cache/revalidate";
+
+/**
+ * /tdee の ISR キャッシュを再検証する Server Action。
+ *
+ * ml-daily バッチ（enrich.py）は GitHub Actions から Supabase を直接更新するため、
+ * Next.js の ISR キャッシュは自動で無効化されない。
+ * ユーザーが "表示を更新" ボタンを押したときにこのアクションを呼び、
+ * 定期バッチ・手動バッチの双方で同じ経路で即時反映を可能にする。
+ *
+ * enrich.py 再実行などのバッチ再計算は行わない（表示の再検証のみ）。
+ */
+export async function revalidateTdee(): Promise<void> {
+  revalidateAfterEnrichedLogsMutation();
+}

--- a/src/app/tdee/page.tsx
+++ b/src/app/tdee/page.tsx
@@ -11,6 +11,7 @@ import { StatusNotice } from "@/components/ui/StatusNotice";
 import { TdeeKpiCard } from "@/components/tdee/TdeeKpiCard";
 import { TdeeDetailChart } from "@/components/tdee/TdeeDetailChart";
 import { TdeeDailyTable } from "@/components/tdee/TdeeDailyTable";
+import { TdeeRefreshButton } from "@/components/tdee/TdeeRefreshButton";
 import {
   calcTheoreticalTdee,
   calcEnergyBalance,
@@ -211,7 +212,14 @@ export default async function TdeePage() {
   }));
 
   return (
-    <PageShell title="TDEE">
+    <PageShell
+      titleSlot={
+        <div className="mb-4 flex flex-wrap items-center gap-x-2 gap-y-1.5 md:mb-6">
+          <h1 className="text-xl font-bold text-slate-800 dark:text-slate-300">TDEE</h1>
+          <TdeeRefreshButton />
+        </div>
+      }
+    >
 
       {/* Read error banners — graceful degradation: コンテンツはブロックしない */}
       {rawLogsResult.kind === "error" && (

--- a/src/app/tdee/page.tsx
+++ b/src/app/tdee/page.tsx
@@ -252,7 +252,7 @@ export default async function TdeePage() {
         <StatusNotice status="caution" className="mb-5">
           実測 TDEE は再計算前のデータを表示しています（最終更新: {enrichedAvailability.lastUpdatedDate}、
           {enrichedAvailability.staleDays}日前の計算）。
-          直近入力が反映されるのは次回バッチ実行後（毎日 AM 3:00 JST）です。
+          直近入力が反映されるのは次回バッチ実行後です。手動バッチ実行後は「表示を更新」で最新表示にできます。
         </StatusNotice>
       )}
 

--- a/src/components/tdee/TdeeRefreshButton.tsx
+++ b/src/components/tdee/TdeeRefreshButton.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { RefreshCw } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { revalidateTdee } from "@/app/tdee/actions";
+
+/**
+ * /tdee の ISR キャッシュを即時反映するボタン。
+ *
+ * 動作:
+ *   1. Server Action で revalidatePath("/tdee") を実行
+ *   2. router.refresh() でクライアントキャッシュをクリアして再レンダリング
+ *
+ * 想定ユースケース:
+ *   - ml-daily の手動実行 (workflow_dispatch) 直後に DB 反映を画面で確認したいとき
+ *   - 過去日ログを編集したあとに enriched_logs 再計算を反映させたいとき
+ *
+ * これは enrich.py の再実行ではなく、既に保存済みの analytics_cache 値の再表示のみ。
+ */
+export function TdeeRefreshButton() {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [done, setDone] = useState(false);
+
+  function handleRefresh() {
+    startTransition(async () => {
+      await revalidateTdee();
+      router.refresh();
+      setDone(true);
+      setTimeout(() => setDone(false), 3000);
+    });
+  }
+
+  return (
+    <div className="ml-auto flex items-center gap-2">
+      {done && (
+        <span className="text-xs text-emerald-600 font-medium">✓ 表示を更新しました</span>
+      )}
+      <button
+        onClick={handleRefresh}
+        disabled={isPending}
+        title="ML バッチ実行後の最新データを即時反映します（再計算ではありません）"
+        className="flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs text-slate-600 hover:bg-slate-50 disabled:opacity-50 disabled:cursor-not-allowed dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
+      >
+        <RefreshCw size={13} className={isPending ? "animate-spin" : ""} />
+        {isPending ? "更新中..." : "表示を更新"}
+      </button>
+    </div>
+  );
+}

--- a/src/lib/cache/revalidate.ts
+++ b/src/lib/cache/revalidate.ts
@@ -30,6 +30,12 @@
  *
  * forecast backtest 更新:
  *   /forecast-accuracy  fetchLatestRuns / fetchMetrics
+ *
+ * analytics_cache (enriched_logs) 更新:
+ *   /tdee         fetchEnrichedLogs
+ *   ※ GitHub Actions の ml-daily バッチは Supabase を直接更新するため、
+ *     Next.js 側の ISR キャッシュは自動で無効化されない。
+ *     /tdee の手動 refresh ボタンがこの関数を呼び、バッチ後の即時反映を可能にする。
  */
 
 import { revalidatePath } from "next/cache";
@@ -64,4 +70,16 @@ export function revalidateAfterSettingsMutation(): void {
  */
 export function revalidateAfterForecastMutation(): void {
   revalidatePath("/forecast-accuracy");
+}
+
+/**
+ * analytics_cache の enriched_logs 更新後に呼ぶ（手動 refresh ボタン経由）。
+ *
+ * ml-daily バッチは GitHub Actions から Supabase を直接更新するため、
+ * Next.js の ISR キャッシュ（/tdee は revalidate=3600）は自動で無効化されない。
+ * 定期バッチ・手動バッチのどちらでも、ユーザーが "表示を更新" ボタンを
+ * 押した時点でこの関数が呼ばれ、/tdee の ISR キャッシュを再検証する。
+ */
+export function revalidateAfterEnrichedLogsMutation(): void {
+  revalidatePath("/tdee");
 }


### PR DESCRIPTION
## 概要

ml-daily バッチ（enrich.py）の手動実行 (workflow_dispatch) 直後でも `/tdee` 画面に結果が即時反映されるよう、「表示を更新」ボタンを追加する。`/forecast-accuracy` で先行導入済みの refresh ボタンパターンに揃える。

Closes #587

## 原因

- `/tdee` は `export const revalidate = 3600` で ISR キャッシュされており、Next.js は最大 1 時間同じ HTML を返す。
- ml-daily バッチは GitHub Actions から **Supabase を直接** 更新するため、Next.js の revalidate 経路を通らずキャッシュは無効化されない。
- 結果として、手動バッチ実行直後にページを開いても古い TDEE 値・古い「最終更新」が表示されるケースがあった。
- 表示ソース自体（TDEE 時系列・「最終更新」の両方）は `analytics_cache["enriched_logs"]` の同一行を参照しており、データの食い違いはない。**キャッシュ再検証だけが必要** だった。

## 変更内容

- `src/lib/cache/revalidate.ts`
  - `revalidateAfterEnrichedLogsMutation()` を追加（`revalidatePath("/tdee")` を実行）
  - ヘッダコメントに「ml-daily バッチは Supabase を直接更新するため Next.js の ISR は自動で無効化されない」旨を追記
- `src/app/tdee/actions.ts`（新規）
  - `revalidateTdee()` Server Action を追加し、上記関数を呼ぶ
- `src/components/tdee/TdeeRefreshButton.tsx`（新規）
  - `/forecast-accuracy` の `ForecastAccuracyRefreshButton` と同じパターン
  - `useTransition` + Server Action + `router.refresh()` + 「✓ 表示を更新しました」3秒表示
- `src/app/tdee/page.tsx`
  - `<PageShell title="TDEE">` を `titleSlot` に差し替え、見出し横に `<TdeeRefreshButton />` を配置

## 手動実行時の反映改善内容

- ユーザーが GitHub Actions で `ml-daily` を `workflow_dispatch` 実行 → バッチが `analytics_cache` を更新。
- `/tdee` を開き「表示を更新」ボタンをクリック → `revalidateTdee()` が `revalidatePath("/tdee")` を実行し ISR キャッシュを即座に破棄。
- `router.refresh()` でクライアント側も再取得 → 最新の TDEE 値・最終更新日時が反映される。

## 定期実行との整合性

- 定期バッチ（毎日 AM 3:00 JST cron）も同じ経路（Supabase 直接書き込み）を通るため、このボタンは **定期・手動の区別なく同じように動く**。
- 分岐ロジックは追加していない（batch 起動元に応じた特別処理はゼロ）。
- enrich.py の再実行・再計算は行わず、あくまで「既に保存済みの analytics_cache 値の再表示」だけを行う。

## 影響範囲

- 追加: `/tdee` ページに refresh ボタン1つ。既存の KPI カード・チャート・テーブルの描画ロジックは無変更。
- `src/lib/cache/revalidate.ts` に関数1つ追加（既存関数は無変更）。
- 他ページ（`/`, `/macro`, `/history`, `/settings`, `/forecast-accuracy`）には変更なし。
- DB スキーマ・RLS・migration への変更なし。
- ml-pipeline 側への変更なし。

## テスト / 確認内容

- [x] `npx jest --no-coverage` → 1488 tests passed
- [x] `npx tsc --noEmit` → clean
- [x] `npm run lint` → clean
- [x] `npm run build` → success（`/tdee` は引き続き `○ 1h 1y` / SSG+ISR として扱われ、refresh ボタン経由で on-demand invalidation が可能）

## 補足

- `/forecast-accuracy` の先行実装（`ForecastAccuracyRefreshButton` + `revalidateForecastAccuracy`）と同一のパターンを踏襲している。
- 将来的に ml-daily バッチ側から webhook で revalidate を叩く構成に移行しても、本 PR のユーザー起点 refresh ボタンは不要化こそすれ壊れない。
- 本対応はあくまで「表示の再検証」であり、enrich.py の再実行や再計算は行わない（CLAUDE.md の「batch canonical を参照する。フロントで再計算しない」原則を維持）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)