### PR TITLE
feat: use 14-day average TDEE for dashboard and balance KPIs

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -179,16 +179,19 @@ export default async function DashboardPage() {
       ? readinessMetrics.days_to_contest - daysNeeded
       : null;
 
-  // enriched_logs から log_date → tdee_estimated の Map を構築
-  const enrichedTdeeMap = new Map<string, number>();
-  for (const row of enrichedRows) {
-    if (row.tdee_estimated !== null) {
-      enrichedTdeeMap.set(row.log_date, row.tdee_estimated);
-    }
-  }
+  // 判断用 KPI の基準 TDEE は canonical な avg_tdee_14d を参照する。
+  // canonical は enrich.py の avg_tdee_14d 最終値。旧バッチ互換のため
+  // tdee_estimated 末尾 14 件の平均にフォールバックする（/tdee ページと同じ閾値）。
+  const batchAvgTdee14d: number | null = enrichedRows.at(-1)?.avg_tdee_14d ?? null;
+  const avgTdee14d: number | null = batchAvgTdee14d ?? (() => {
+    const vals = enrichedRows.slice(-14)
+      .map((r) => r.tdee_estimated)
+      .filter((v): v is number => v !== null);
+    return vals.length >= 7 ? vals.reduce((a, b) => a + b, 0) / vals.length : null;
+  })();
 
   const weeklyReview = calcWeeklyReview(logs, readinessMetrics, qualityReport, {
-    enrichedTdeeMap,
+    avgTdee14d,
     phase,
     sleepSessions,
   });

--- a/src/app/tdee/page.tsx
+++ b/src/app/tdee/page.tsx
@@ -189,12 +189,14 @@ export default async function TdeePage() {
       : undefined;
 
   // 収支・理論変化・解釈
-  const balance = calcEnergyBalance(avgCalories7, avgTdee);
+  // 参照 TDEE は 14日平均（基準線）に揃える。7日平均は短期変化確認の補助指標であり、
+  // 判断用 KPI（収支差分・理論変化・収支の解釈）は日次ノイズに強い 14日平均を基準にする。
+  const balance = calcEnergyBalance(avgCalories7, avgTdee14d);
   const theoreticalWeightChange = calcTheoreticalWeightChangePerWeek(balance);
   const confidence = calcTdeeConfidence({
     calDays,
     weightDays,
-    hasTdeeEstimate: avgTdee !== null,
+    hasTdeeEstimate: avgTdee14d !== null,
     weightStdDev,
     tdeeStdDev,
   });

--- a/src/components/dashboard/WeeklyReviewCard.tsx
+++ b/src/components/dashboard/WeeklyReviewCard.tsx
@@ -377,7 +377,7 @@ export function WeeklyReviewCard({ data, phase, enrichedAvailability }: Props) {
             </SectionLabel>
             <div className="space-y-0.5">
               <StatRow
-                label="摂取 − 推定TDEE"
+                label="摂取 − 推定TDEE（14日平均）"
                 value={`${fmtSignedKcal(tdee.balancePerDay)} kcal/日`}
                 valueColor={balanceColor}
               />

--- a/src/components/tdee/TdeeKpiCard.tsx
+++ b/src/components/tdee/TdeeKpiCard.tsx
@@ -29,7 +29,7 @@ interface TdeeKpiCardProps {
   avgTdee14d:              number | null;
   theoreticalTdee:         number | null;
   avgCalories:             number | null;
-  balance:                 number | null;  // 収支差分 = 摂取 - TDEE (kcal/日)
+  balance:                 number | null;  // 収支差分 = 摂取 - 14日平均 TDEE (kcal/日)
   theoreticalWeightChange: number | null;  // kg/週 (収支ベース)
   measuredWeightChange:    number | null;  // kg/週 (実体重推移)
   confidence:              TdeeConfidence;
@@ -217,7 +217,7 @@ export function TdeeKpiCard({
           )}
         </div>
 
-        {/* 収支差分 */}
+        {/* 収支差分 — 消費は 14日平均 TDEE（基準線）を参照 */}
         <div className="rounded-2xl border border-gray-100 bg-white p-5 shadow-sm dark:border-slate-700 dark:bg-slate-900 dark:shadow-none">
           <p className="text-sm font-medium text-gray-500 dark:text-slate-400">収支差分（摂取 − 消費）</p>
           <p className="mt-2 text-3xl font-bold">
@@ -228,6 +228,7 @@ export function TdeeKpiCard({
              balance < -50 ? "マイナス = 減量方向" :
              balance >  50 ? "プラス = 増量方向" :
                              "概ね均衡"}
+            <span className="ml-1 text-gray-400 dark:text-slate-500">— 消費は 14日平均 TDEE 基準</span>
           </p>
         </div>
       </div>

--- a/src/lib/utils/calcTdee.ts
+++ b/src/lib/utils/calcTdee.ts
@@ -187,7 +187,8 @@ export function calcTheoreticalTdee(params: {
  *   マイナス = 消費が上回る = 減量方向
  *   プラス   = 摂取が上回る = 増量方向
  *
- * 入力に canonical 値 (avg_tdee_7d, avg_calories_7d) を渡すこと。
+ * 入力に canonical 値 (avg_tdee_14d, avg_calories_7d) を渡すこと。
+ * 消費側は基準線（14日平均）を参照し、日次ノイズに振られにくい判断 KPI にする。
  * TDEE ページの TdeeKpiCard に渡す収支表示に使用する。
  */
 export function calcEnergyBalance(

--- a/src/lib/utils/calcWeeklyReview.ts
+++ b/src/lib/utils/calcWeeklyReview.ts
@@ -89,9 +89,13 @@ export interface WeeklyWeight {
 }
 
 export interface WeeklyTdee {
-  /** 直近 7 日の推定 TDEE 平均 (kcal) */
+  /**
+   * 推定 TDEE の基準値 (kcal)。
+   * canonical は enrich.py の avg_tdee_14d（14日ローリング平均）最終値。
+   * 日次ノイズに強い基準線を判断 KPI に使う。
+   */
   avgEstimated: number | null;
-  /** 摂取 - TDEE = エネルギーバランス (kcal/日). 負 = 赤字 */
+  /** 摂取 - 基準 TDEE = エネルギーバランス (kcal/日). 負 = 赤字 */
   balancePerDay: number | null;
 }
 
@@ -311,7 +315,7 @@ function generateFindings(
           ? `余剰 +${fmt0(bal)} kcal / 日（摂取量の見直しを検討）`
           : `余剰 +${fmt0(bal)} kcal / 日`;
       }
-      findings.push(`摂取 ${calStr} kcal / 推定 TDEE ${tdeeStr} kcal → ${balNote}`);
+      findings.push(`摂取 ${calStr} kcal / 推定 TDEE ${tdeeStr} kcal（14日平均）→ ${balNote}`);
     } else {
       findings.push(
         `平均摂取 ${calStr} kcal（TDEE 未推定のためバランス算出不可）`
@@ -507,7 +511,8 @@ function computeAvgWakeTime(
  * @param logs           daily_logs 全件
  * @param metrics        calcReadiness の結果を再利用 (weight_7d_avg など)
  * @param qualityReport  calcDataQuality の結果を再利用 (period7 スコアなど)
- * @param options.enrichedTdeeMap  log_date → tdee_estimated の Map
+ * @param options.avgTdee14d  enrich.py の avg_tdee_14d 最終値（kcal）。判断用 KPI の基準 TDEE。
+ *                            未指定のときは WeeklyTdee.avgEstimated / balancePerDay が null になる。
  * @param options.phase  "Cut" | "Bulk" (デフォルト "Cut")
  * @param options.today  基準日 YYYY-MM-DD (省略時 JST 今日)
  * @param options.sleepSessions  sleep_sessions テーブルの行。就寝・起床平均時刻の算出に使う。
@@ -518,13 +523,13 @@ export function calcWeeklyReview(
   metrics: ReadinessMetrics,
   qualityReport: DataQualityReport,
   options: {
-    enrichedTdeeMap?: Map<string, number>;
+    avgTdee14d?: number | null;
     phase?: string;
     today?: string;
     sleepSessions?: SleepSession[];
   } = {}
 ): WeeklyReviewData {
-  const { enrichedTdeeMap, phase = "Cut", today, sleepSessions } = options;
+  const { avgTdee14d, phase = "Cut", today, sleepSessions } = options;
   const todayStr = today ?? toJstDateStr(new Date());
 
   // ── 7 暦日リスト ──
@@ -656,19 +661,15 @@ export function calcWeeklyReview(
     timeDaysLogged,
   };
 
-  // ── TDEE (直近 7 日の推定 TDEE 平均) ──
-  const tdee7vals = last7Dates
-    .map((d) => enrichedTdeeMap?.get(d) ?? null)
-    .filter((v): v is number => v !== null);
-  const avgTdee7 =
-    tdee7vals.length > 0
-      ? tdee7vals.reduce((a, b) => a + b, 0) / tdee7vals.length
-      : null;
+  // ── TDEE (14日平均 TDEE を基準線として参照) ──
+  // canonical は enrich.py の avg_tdee_14d 最終値。日次ノイズに強く、判断用 KPI に適する。
+  // フロントで 7日平均を再集計すると短期ノイズに引きずられるため、ここでは再計算しない。
+  const avgTdeeRef: number | null = avgTdee14d ?? null;
   const balancePerDay =
-    avgCalories !== null && avgTdee7 !== null ? avgCalories - avgTdee7 : null;
+    avgCalories !== null && avgTdeeRef !== null ? avgCalories - avgTdeeRef : null;
 
   const tdee: WeeklyTdee = {
-    avgEstimated: avgTdee7,
+    avgEstimated: avgTdeeRef,
     balancePerDay,
   };
 

--- a/src/lib/utils/weeklyInsights.ts
+++ b/src/lib/utils/weeklyInsights.ts
@@ -154,7 +154,7 @@ export function deriveWeeklyInsightItems(
 
       const detail =
         tdee.avgEstimated !== null
-          ? `摂取 ${fmt0(nutrition.avgCalories)} kcal / 推定TDEE ${fmt0(tdee.avgEstimated)} kcal`
+          ? `摂取 ${fmt0(nutrition.avgCalories)} kcal / 推定TDEE ${fmt0(tdee.avgEstimated)} kcal（14日平均）`
           : undefined;
 
       items.push({ status, title, detail });


### PR DESCRIPTION
## 概要

ダッシュボードの直近7日サマリー「摂取 − 推定TDEE」と TDEE ページの「収支差分（摂取 − 消費）」KPI について、参照する推定 TDEE を 14日平均へ統一する。TDEE 画面で既に整理済みの「14日平均 = 基準線」「7日平均 = 短期変化確認」の役割分担に、判断用 KPI を揃える。

Closes #589

## 変更内容

### Dashboard（WeeklyReviewCard / calcWeeklyReview）
- `src/app/page.tsx`
  - `enrichedTdeeMap`（log_date → tdee_estimated の Map）の構築を廃止。
  - 代わりに `avgTdee14d` スカラを算出して `calcWeeklyReview` に渡す。
  - 旧バッチ互換として `tdee_estimated` 末尾 14 件の平均（≥7 件必須）にフォールバック。閾値は `/tdee` ページと同一。
- `src/lib/utils/calcWeeklyReview.ts`
  - `options.enrichedTdeeMap` を `options.avgTdee14d: number | null` に置換。
  - TDEE 集計ブロックを「map から 7日平均を再集計」ではなく「canonical 14日平均をそのまま採用」に変更。
  - `WeeklyTdee.avgEstimated` / `balancePerDay` の JSDoc / 生成ロジックを 14日基準線に差し替え。
  - 所見テキスト "推定 TDEE … kcal" に "（14日平均）" を併記。
- `src/components/dashboard/WeeklyReviewCard.tsx`
  - StatRow のラベルを「摂取 − 推定TDEE」→「摂取 − 推定TDEE（14日平均）」に変更。
- `src/lib/utils/weeklyInsights.ts`
  - InsightCard 用 detail の TDEE 表示に "（14日平均）" を併記。

### TDEE ページ（TdeeKpiCard）
- `src/app/tdee/page.tsx`
  - `balance` / `confidence.hasTdeeEstimate` の参照を `avgTdee` → `avgTdee14d` に切替。
  - `theoreticalWeightChange` は `balance` 経由で 14日平均ベースに切り替わる。
- `src/components/tdee/TdeeKpiCard.tsx`
  - 「収支差分」カードの補足行に「消費は 14日平均 TDEE 基準」を併記。JSDoc / コメントも更新。
- `src/lib/utils/calcTdee.ts`
  - `calcEnergyBalance` の JSDoc を `avg_tdee_14d` を入力とするよう更新。

## 参照TDEEの切り替え内容

| 箇所 | 旧参照 | 新参照 |
|---|---|---|
| Dashboard 直近7日サマリー「摂取 − 推定TDEE」 | last7 暦日の `tdee_estimated` を map aggregation で平均（実質 7日平均） | canonical `avg_tdee_14d` 最終値（旧バッチ時は末尾14件平均, ≥7 件） |
| /tdee 収支差分（摂取 − 消費）KPI | `avgTdee`（7日平均） | `avgTdee14d`（14日平均） |

7日平均は `/tdee` 画面の 2 段目（「7日平均 … kcal（短期変化）」）でそのまま表示されており、短期変化確認の用途は壊れていない。

## 判断理由

- 主眼は新指標追加ではなく、**判断用 KPI の参照値の意味論を UI 全体で揃えること**。
- `/tdee` は #585 ですでに 14日平均を基準線として整理済み。残る 2 箇所（Dashboard / 収支差分）も同じ基準に寄せることで、ユーザの読み手負担を下げる。
- canonical な `avg_tdee_14d` をそのまま参照し、フロント側で再平均しない方針（CLAUDE.md の「batch canonical を参照する。フロントで再計算しない」原則）を維持。
- 7日平均を残すのは「短期変化確認」の役割がある `/tdee` 画面のみ。Dashboard 側では単一の基準線に一本化した方が読み誤りが減る。

## 影響範囲

- Dashboard の「摂取 − 推定TDEE」は **値が変わる**（7日平均→14日平均）。日次ノイズが減り、より安定した値を表示。
- /tdee の「収支差分」「理論体重変化」「収支の解釈」「信頼度判定の hasTdeeEstimate」は **値が変わる**（7日平均→14日平均ベース）。
- TDEE 算出ロジック（`enrich.py` / `calcTdee` / `smoothTdeeSeries`）は **無変更**。
- DB スキーマ・RLS・migration への変更なし。
- 表示文言の変更は最小限（ラベルに「（14日平均）」併記、補足行の一言注記）。
- `calcWeeklyReview` の options 互換性: `enrichedTdeeMap` を `avgTdee14d` に置換（破壊的変更）。現状の caller は `src/app/page.tsx` のみで同時更新済み。単体テストは TDEE 集計ブロックを対象にしていないため影響なし。

## テスト / 確認内容

- [x] `npx jest --no-coverage` → 1488 tests passed（60 suites）
- [x] `npx tsc --noEmit` → clean
- [x] `npm run lint` → clean
- [x] `npm run build` → success（`/` `/tdee` ともに SSG+ISR, revalidate 1h のまま）

## 補足

- `WeeklyTdee.avgEstimated` のフィールド名はそのまま（「推定 TDEE の基準値」という意味で継続）。ただし JSDoc で canonical が `avg_tdee_14d` であることを明示。
- `avg_tdee_14d` が旧バッチで欠ける場合のフォールバックは `/tdee` ページと同一仕様（`tdee_estimated` 末尾 14 件, ≥7 件）。サンプル不足時は `null` を返し、KPI は「データ不足」表示になる。
- Bias 補正・予測モデル改善・TDEE 算出式の変更などはスコープ外。今回は参照値の意味論統一のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)