### PR TITLE
feat: add calendar-month countdown to dashboard KPI

### DIFF
--- a/src/components/dashboard/KpiCards.tsx
+++ b/src/components/dashboard/KpiCards.tsx
@@ -5,7 +5,7 @@ import type { DashboardDailyLog } from "@/lib/supabase/types";
 import type { AppSettings } from "@/lib/domain/settings";
 import type { GoalReachResult } from "@/lib/utils/calcReadiness";
 import { calcWeightTrend } from "@/lib/utils/calcTrend";
-import { toJstDateStr, calcDaysLeft, addDaysStr, dateRangeStr } from "@/lib/utils/date";
+import { toJstDateStr, calcDaysLeft, calcMonthsLeft, addDaysStr, dateRangeStr } from "@/lib/utils/date";
 
 interface KpiCardsProps {
   logs: DashboardDailyLog[];
@@ -74,12 +74,18 @@ export function KpiCards({ logs, settings, currentWeight, currentSeason, goalRea
   // 以降の全暦日計算で共通して使う。JST 固定で UTC サーバー上でもズレない。
   const todayStr = toJstDateStr();
 
-  // --- 残り日数 + 残り週数 ---
+  // --- 残り日数 + 残り週数 + 残り月数 ---
   // calcDaysLeft を使い GoalNavigator / calcReadiness と定義を統一する。
+  // 月数は「カレンダー上の実月差ベース」（calcMonthsLeft）。30日換算/4週換算は使わない。
   const contestDate = settings.contestDate;
   const daysLeft = contestDate ? calcDaysLeft(todayStr, contestDate) : null;
   const weeksLeft =
     daysLeft !== null && daysLeft > 0 ? (daysLeft / 7).toFixed(1) : null;
+  const monthsLeftNum =
+    contestDate && daysLeft !== null && daysLeft > 0
+      ? calcMonthsLeft(todayStr, contestDate)
+      : null;
+  const monthsLeft = monthsLeftNum !== null ? monthsLeftNum.toFixed(1) : null;
 
   // --- 現在体重カードの週次トレンド表示 (14暦日回帰) ---
   // 目標到達予定日の計算 (7日平均 + 30日回帰) は page.tsx で一元計算した goalReachResult を使う
@@ -133,6 +139,7 @@ export function KpiCards({ logs, settings, currentWeight, currentSeason, goalRea
           daysLeft === null ? `${deadlineLabel}未設定`
           : daysLeft < 0 ? `${contestDate} 終了`
           : daysLeft === 0 ? `本日が${deadlineLabel}`
+          : monthsLeft !== null && weeksLeft !== null ? `${monthsLeft} 月 / ${weeksLeft} 週 / ${contestDate}`
           : weeksLeft !== null ? `${weeksLeft} 週 / ${contestDate}`
           : contestDate
         }

--- a/src/lib/utils/__tests__/date.test.ts
+++ b/src/lib/utils/__tests__/date.test.ts
@@ -11,6 +11,7 @@
 import {
   daysBetween,
   calcDaysLeft,
+  calcMonthsLeft,
   toJstDateStr,
   parseLocalDateStr,
   addDaysStr,
@@ -361,6 +362,93 @@ describe("addDaysStr — 日数加算", () => {
   test("不正な base → null", () => {
     expect(addDaysStr("abc", 1)).toBeNull();
     expect(addDaysStr("", 5)).toBeNull();
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// calcMonthsLeft — 実月差ベース（小数）
+// ════════════════════════════════════════════════════════════════════════════
+
+describe("calcMonthsLeft — 正常系", () => {
+  test("同日: 0", () => {
+    expect(calcMonthsLeft("2026-04-17", "2026-04-17")).toBe(0);
+  });
+
+  test("1ヶ月ちょうど（同日付）: 1", () => {
+    expect(calcMonthsLeft("2026-04-17", "2026-05-17")).toBe(1);
+  });
+
+  test("3ヶ月ちょうど: 3", () => {
+    expect(calcMonthsLeft("2026-04-17", "2026-07-17")).toBe(3);
+  });
+
+  test("4/17 → 8/9 は 7/17 を踏んで 23/31 ヶ月分: 3 + 23/31", () => {
+    const result = calcMonthsLeft("2026-04-17", "2026-08-09")!;
+    expect(result).toBeCloseTo(3 + 23 / 31, 5);
+    expect(result.toFixed(1)).toBe("3.7");
+  });
+
+  test("端数が当該月区間の日数に対する割合: 4/17 → 5/3 は 16/30 = 0.533", () => {
+    // 4/17 → 5/17 が区間 30 日、経過 16 日（4/17 → 5/3）→ 0 + 16/30
+    const result = calcMonthsLeft("2026-04-17", "2026-05-03")!;
+    expect(result).toBeCloseTo(16 / 30, 5);
+  });
+
+  test("月末クランプ: 1/31 → 2/28（平年）は 1.0", () => {
+    // 2/31 は存在しないため 2 月末に丸める → ちょうど 1 ヶ月扱い
+    expect(calcMonthsLeft("2025-01-31", "2025-02-28")).toBe(1);
+  });
+
+  test("月末クランプ: 1/31 → 3/1 は 1 + 1/31", () => {
+    // whole=2 だと anchor=3/31 > 3/1。戻して whole=1, anchor=2/28(平年)
+    // next=3/31、seg=31、used=(3/1 - 2/28)=1 → 1 + 1/31
+    const result = calcMonthsLeft("2025-01-31", "2025-03-01")!;
+    expect(result).toBeCloseTo(1 + 1 / 31, 5);
+  });
+
+  test("年跨ぎ: 12/15 → 翌年 3/15 は 3", () => {
+    expect(calcMonthsLeft("2025-12-15", "2026-03-15")).toBe(3);
+  });
+
+  test("年跨ぎ端数: 2025-12-15 → 2026-01-01 は 0 + 17/31", () => {
+    // whole=1 だと anchor=1/15 > 1/1。戻して whole=0, anchor=12/15
+    // next=1/15、seg=31、used=17 → 17/31
+    const result = calcMonthsLeft("2025-12-15", "2026-01-01")!;
+    expect(result).toBeCloseTo(17 / 31, 5);
+  });
+
+  test("逆方向（過去）は負の値", () => {
+    const result = calcMonthsLeft("2026-08-09", "2026-04-17")!;
+    expect(result).toBeCloseTo(-(3 + 23 / 31), 5);
+  });
+
+  test("翌日: 0 + 1/30 程度", () => {
+    // 4/17 → 4/18 → whole=0, anchor=4/17, next=5/17, seg=30, used=1
+    const result = calcMonthsLeft("2026-04-17", "2026-04-18")!;
+    expect(result).toBeCloseTo(1 / 30, 5);
+  });
+
+  test("小数1桁に丸めた表示例: 3.7 月", () => {
+    const result = calcMonthsLeft("2026-04-17", "2026-08-09")!;
+    expect(result.toFixed(1)).toBe("3.7");
+  });
+});
+
+describe("calcMonthsLeft — 例外・null ケース", () => {
+  test("today 不正 → null", () => {
+    expect(calcMonthsLeft("abc", "2026-08-09")).toBeNull();
+  });
+
+  test("target 不正 → null", () => {
+    expect(calcMonthsLeft("2026-04-17", "xyz")).toBeNull();
+  });
+
+  test("存在しない日付 → null", () => {
+    expect(calcMonthsLeft("2026-02-30", "2026-08-09")).toBeNull();
+  });
+
+  test("空文字 → null", () => {
+    expect(calcMonthsLeft("", "")).toBeNull();
   });
 });
 

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -133,6 +133,62 @@ export function calcDaysLeft(today: string, target: string): number | null {
 }
 
 /**
+ * 2つの YYYY-MM-DD 文字列間のカレンダー月数差を小数で返す。
+ *
+ * 「実月差ベース」の定義:
+ *   - 整数部は「同じ日付」で数えた完全な月数
+ *     （例: 4/17 → 7/17 で 3 ヶ月。月末日がはみ出す場合は月末に丸める）
+ *   - 端数は次のアンカー（1ヶ月先）までの区間日数に対する「経過日数 / 区間日数」
+ *     （例: 4/17 → 8/9 = 7/17 を踏んで残り 23 日、7/17〜8/17 は 31 日なので
+ *        3 + 23/31 ≈ 3.74）
+ *
+ * 30日換算や4週換算は使わず、常にカレンダー上の実月差ベースで算出する。
+ * KpiCards の残り日数 KPI 補助表示用。
+ *
+ * @param today  基準日 (YYYY-MM-DD)
+ * @param target 目標日 (YYYY-MM-DD)
+ * @returns 月数の小数 (整数部 + 端数)。同日は 0、過去は負。どちらか不正なら null。
+ */
+export function calcMonthsLeft(today: string, target: string): number | null {
+  const from = parseLocalDateStr(today);
+  const to = parseLocalDateStr(target);
+  if (from === null || to === null) return null;
+  if (from.getTime() === to.getTime()) return 0;
+
+  const sign = to.getTime() < from.getTime() ? -1 : 1;
+  const a = sign > 0 ? from : to;
+  const b = sign > 0 ? to : from;
+
+  // 初期推定: 年×12 + 月 の差分
+  let whole = (b.getFullYear() - a.getFullYear()) * 12 + (b.getMonth() - a.getMonth());
+  let anchor = addMonthsClamped(a, whole);
+  // anchor が b を超える場合（例: 4/17→7/14 で whole=3 だと anchor=7/17 > 7/14）は 1 ヶ月戻す
+  if (anchor.getTime() > b.getTime()) {
+    whole -= 1;
+    anchor = addMonthsClamped(a, whole);
+  }
+
+  const nextAnchor = addMonthsClamped(a, whole + 1);
+  const segDays = Math.round((nextAnchor.getTime() - anchor.getTime()) / 86_400_000);
+  const usedDays = Math.round((b.getTime() - anchor.getTime()) / 86_400_000);
+  const fraction = segDays <= 0 ? 0 : usedDays / segDays;
+
+  return sign * (whole + fraction);
+}
+
+/**
+ * 内部ヘルパー: 指定月数を加算した Date を返す。
+ * 加算先の月に日が存在しない場合（1/31 + 1ヶ月 など）は加算先の月末に丸める。
+ */
+function addMonthsClamped(d: Date, months: number): Date {
+  const targetMonthIdx = d.getFullYear() * 12 + d.getMonth() + months;
+  const newYear = Math.floor(targetMonthIdx / 12);
+  const newMonth = ((targetMonthIdx % 12) + 12) % 12;
+  const lastDay = new Date(newYear, newMonth + 1, 0).getDate();
+  return new Date(newYear, newMonth, Math.min(d.getDate(), lastDay));
+}
+
+/**
  * ある日付に指定日数を加算した日付を YYYY-MM-DD で返す（JST 基準）。
  *
  * @param base - 基準日 (YYYY-MM-DD)


### PR DESCRIPTION
## 概要

ダッシュボードの残り日数 KPI 補助行に「月」表示を追加し、日 / 週 / 月の 3 軸で残り期間を直感的に把握できるようにする。

表示例:
- Before: `16.3 週 / 2026-08-09`
- After: `3.7 月 / 16.3 週 / 2026-08-09`

## 変更内容

- **`src/lib/utils/date.ts`** — `calcMonthsLeft(today, target)` を追加
  - 「実月差ベース」の純粋関数。不正入力は `null`、同日は `0`、過去は負の値
  - 内部ヘルパー `addMonthsClamped` で月末クランプ（1/31 + 1ヶ月 → 2/28）を処理
- **`src/lib/utils/__tests__/date.test.ts`** — ユニットテスト 15 件追加
  - 完全月 / 端数 / 月末クランプ / 年跨ぎ / 逆方向（負） / 不正入力 / null ケース
- **`src/components/dashboard/KpiCards.tsx`** — 補助行の組み立てに `monthsLeft` を前置
  - `daysLeft > 0` のときのみ月/週を表示。既存の fallback（未設定 / 終了済 / 本日）は温存

## 実月差ベースの計算方法

30 日換算や 4 週換算は使わず、カレンダー上の実月差で算出:

1. `年×12 + 月` の差から初期 `whole` を算出
2. `a` から `whole` ヶ月後の「同日付アンカー」を `addMonthsClamped` で計算
3. アンカーが `b` を超える場合は `whole -= 1` で 1 ヶ月戻す（端数を正の領域に保つ）
4. 端数 = `(b - anchor) / (nextAnchor - anchor)` — **当該月区間の日数に対する割合**
5. 小数 1 桁に `toFixed(1)` で丸めて表示

**計算例**（今日 = 2026-04-17, 目標 = 2026-08-09, 114 日）:
- 7/17 まで 3 ヶ月 → 残り 23 日
- 区間 7/17 〜 8/17 は 31 日
- 月数 = 3 + 23/31 ≈ 3.742 → `3.7 月`
- 週数（既存）: 114 / 7 ≈ 16.3 → `16.3 週`

## 判断理由

- Issue が「カレンダー上の実月差ベースで小数 1 桁」と明記しているため、日数 / 30 などの近似は避けた
- 端数の定義（区間日数に対する割合）をコードに明示し、将来の読み手が計算意図を追えるようにした
- 既存 `calcDaysLeft` と同じ `date.ts` に置き、責務の近接性を保った
- `calcMonthsLeft` 内部で `addMonthsClamped` を private にし、外部 API を最小化した
- UI 側は sub 文字列の先頭に 1 節追加するだけで、レイアウト・スタイルには手を入れていない

## 影響範囲

- ダッシュボード `KpiCards` の残り日数 KPI 補助行のみ
- `calcDaysLeft` / `calcWeeksLeft` 相当のロジックや GoalNavigator / calcReadiness の計算には影響なし
- 既存の fallback（`—` / `大会日未設定` / `終了` / `本日が大会日`）は温存

## 補足

- モバイル: 既存の `text-xs` で sub 行を描画しており、文字列が数文字伸びる程度。レイアウト崩れは発生しない想定
- 既存 1504 件の Jest テストは全通過、`npx tsc --noEmit` / `npm run lint` もクリーン

## 残課題（別 Issue 候補）

- GoalNavigator 側の「残り週数」表示にも月軸を横展開するかは、本 Issue のスコープ外とした
  - KpiCards / GoalNavigator の役割分担（残り日数は KpiCards に集約、GoalNavigator は判断導線）に従うため、必要と判断した時点で別 Issue を切る想定

Closes #591

🤖 Generated with [Claude Code](https://claude.com/claude-code)