### PR TITLE
feat: reflect cumulative drift in monthly required loss (#601)

### DIFF
--- a/src/lib/utils/monthlyGoalVisualization.test.ts
+++ b/src/lib/utils/monthlyGoalVisualization.test.ts
@@ -656,3 +656,95 @@ describe("buildMonthlyGoalComparisonRows — cumulativeGapKg", () => {
     expect(rows[1]!.cumulativeGapKg).toBeCloseTo(-0.3, 2);  // 0.2 + (-0.5) = -0.3
   });
 });
+
+// ─── buildMonthlyGoalComparisonRows — nextRequiredDeltaKg (累積ズレ補正) ────
+
+describe("buildMonthlyGoalComparisonRows — nextRequiredDeltaKg 累積ズレ補正", () => {
+  it("遅れ (+0.9 kg) があると翌月必要が計画より多くなる", () => {
+    // today = 2026-08-01 → 2026-07 は確定過去月
+    // diff = 74.7 - 73.8 = +0.9 → cumulativeGapKg = +0.9
+    // 翌月計画 = -1.3 → 調整後 = -1.3 - 0.9 = -2.2
+    const plan = makePlan([
+      entry("2026-07", 73.8, -1.2),
+      entry("2026-08", 72.5, -1.3),
+    ]);
+    const logs = [log("2026-07-31", 74.7)];
+    const summaryRows = buildMonthlyGoalSummaryRows(plan, logs, "2026-08-01");
+    const rows = buildMonthlyGoalComparisonRows(summaryRows, "Cut");
+    expect(rows[0]!.nextRequiredDeltaKg).toBeCloseTo(-2.2, 2);
+  });
+
+  it("先行 (-0.5 kg) があると翌月必要が計画より少なくなる", () => {
+    // diff = 73.3 - 73.8 = -0.5 → cumulativeGapKg = -0.5
+    // 翌月計画 = -1.3 → 調整後 = -1.3 - (-0.5) = -0.8
+    const plan = makePlan([
+      entry("2026-07", 73.8, -1.2),
+      entry("2026-08", 72.5, -1.3),
+    ]);
+    const logs = [log("2026-07-31", 73.3)];
+    const summaryRows = buildMonthlyGoalSummaryRows(plan, logs, "2026-08-01");
+    const rows = buildMonthlyGoalComparisonRows(summaryRows, "Cut");
+    expect(rows[0]!.nextRequiredDeltaKg).toBeCloseTo(-0.8, 2);
+  });
+
+  it("2ヶ月分の累積ズレが 3 ヶ月目の翌月必要に反映される", () => {
+    // today = 2026-09-01
+    // 07: diff = +0.2, cumul = +0.2 → 翌月必要 = -1.3 - 0.2 = -1.5
+    // 08: diff = +0.5, cumul = +0.7 → 翌月必要 = -1.0 - 0.7 = -1.7
+    // 09 (当月): nextRequiredDeltaKg = null (最終月)
+    const plan = makePlan([
+      entry("2026-07", 73.8, -1.2),
+      entry("2026-08", 72.5, -1.3),
+      entry("2026-09", 71.5, -1.0),
+    ]);
+    const logs = [
+      log("2026-07-31", 74.0), // diff = +0.2
+      log("2026-08-31", 73.0), // diff = +0.5
+    ];
+    const summaryRows = buildMonthlyGoalSummaryRows(plan, logs, "2026-09-01");
+    const rows = buildMonthlyGoalComparisonRows(summaryRows, "Cut");
+    expect(rows[0]!.nextRequiredDeltaKg).toBeCloseTo(-1.5, 2); // -1.3 - 0.2
+    expect(rows[1]!.nextRequiredDeltaKg).toBeCloseTo(-1.7, 2); // -1.0 - 0.7
+    expect(rows[2]!.nextRequiredDeltaKg).toBeNull();            // 最終月
+  });
+
+  it("データなし過去月 (cumulativeGapKg=null) は翌月必要をそのまま返す", () => {
+    // today = 2026-08-01 → 2026-07 は過去月だがデータなし
+    const plan = makePlan([
+      entry("2026-07", 73.8, -1.2),
+      entry("2026-08", 72.5, -1.3),
+    ]);
+    const logs: { log_date: string; weight: number | null }[] = [];
+    const summaryRows = buildMonthlyGoalSummaryRows(plan, logs, "2026-08-01");
+    const rows = buildMonthlyGoalComparisonRows(summaryRows, "Cut");
+    // cumulativeGapKg = null → 調整なし、プラン値をそのまま返す
+    expect(rows[0]!.nextRequiredDeltaKg).toBeCloseTo(-1.3, 2);
+  });
+
+  it("当月 (partial) の nextRequiredDeltaKg はプラン値をそのまま返す", () => {
+    // today = 2026-07-15 → 2026-07 は当月 (partial)
+    const plan = makePlan([
+      entry("2026-07", 73.8, -1.2),
+      entry("2026-08", 72.5, -1.3),
+    ]);
+    const logs = [log("2026-07-10", 74.0)];
+    const summaryRows = buildMonthlyGoalSummaryRows(plan, logs, "2026-07-15");
+    const rows = buildMonthlyGoalComparisonRows(summaryRows, "Cut");
+    // 当月は cumulativeGapKg=null → 調整なし
+    expect(rows[0]!.nextRequiredDeltaKg).toBeCloseTo(-1.3, 2);
+  });
+
+  it("最終月の nextRequiredDeltaKg は null のまま (補正対象外)", () => {
+    const plan = makePlan([
+      entry("2026-07", 73.8, -1.2),
+      entry("2026-08", 72.5, -1.3),
+    ]);
+    const logs = [
+      log("2026-07-31", 74.0),
+      log("2026-08-31", 73.0),
+    ];
+    const summaryRows = buildMonthlyGoalSummaryRows(plan, logs, "2026-09-01");
+    const rows = buildMonthlyGoalComparisonRows(summaryRows, "Cut");
+    expect(rows[1]!.nextRequiredDeltaKg).toBeNull();
+  });
+});

--- a/src/lib/utils/monthlyGoalVisualization.ts
+++ b/src/lib/utils/monthlyGoalVisualization.ts
@@ -112,6 +112,14 @@ export interface MonthlyGoalComparisonRow extends MonthlyGoalSummaryRow {
    * - 当月 partial / 未来月: null
    */
   cumulativeGapKg: number | null;
+  /**
+   * 翌月の必要変化量 (累積ズレ補正済み)。
+   * - 確定過去月かつ cumulativeGapKg が non-null の場合:
+   *   planNextRequired - cumulativeGapKg (0.01 kg 丸め)
+   *   例: 計画 -2.5 kg、累積ズレ +0.9 kg → 調整後 -3.4 kg
+   * - それ以外 (当月 / 未来月 / データなし月): MonthlyGoalSummaryRow の値 (プラン値) を引き継ぐ
+   */
+  nextRequiredDeltaKg: number | null;
 }
 
 // ─── プライベートヘルパー ─────────────────────────────────────────────────────
@@ -316,6 +324,13 @@ export function buildMonthlyGoalComparisonRows(
     }
     // 当月 partial / 未来月: null のまま
 
-    return { ...row, progressState, cumulativeGapKg };
+    // 翌月必要変化量: 確定過去月のみ累積ズレで補正する
+    const planNextRequired = row.nextRequiredDeltaKg;
+    const nextRequiredDeltaKg =
+      cumulativeGapKg !== null && planNextRequired !== null
+        ? Math.round((planNextRequired - cumulativeGapKg) * 100) / 100
+        : planNextRequired;
+
+    return { ...row, nextRequiredDeltaKg, progressState, cumulativeGapKg };
   });
 }


### PR DESCRIPTION
## Summary

- `buildMonthlyGoalComparisonRows` now adjusts `nextRequiredDeltaKg` for confirmed past months by subtracting the accumulated plan gap (`cumulativeGapKg`)
- Formula: `adjustedNextRequired = planNextRequired - cumulativeGapKg`
- Current month, future months, and data-absent past months are unaffected (pass through the raw plan value)
- Settings data (`monthlyPlanOverrides`) is untouched — display-only derived value

### Behaviour

| Scenario | Plan next required | Cumulative gap | Adjusted (shown in UI) |
|---|---|---|---|
| Behind by 0.9 kg | −2.5 kg | +0.9 kg | −3.4 kg |
| Ahead by 0.5 kg | −2.5 kg | −0.5 kg | −2.0 kg |
| On track | −2.5 kg | 0.0 kg | −2.5 kg |
| No data for past month | −2.5 kg | null | −2.5 kg (unchanged) |

### Files changed

- `src/lib/utils/monthlyGoalVisualization.ts` — 17 lines: adjustment logic in `buildMonthlyGoalComparisonRows`, updated `MonthlyGoalComparisonRow` JSDoc
- `src/lib/utils/monthlyGoalVisualization.test.ts` — 6 new unit tests (74 total)

## Test plan

- [x] `npx jest --no-coverage monthlyGoalVisualization` — 74 tests pass
- [x] `npx jest --no-coverage` — 1539 tests pass
- [x] `npx tsc --noEmit` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)