### PR TITLE
feat: show work mode in mobile calendar day detail

### DIFF
--- a/src/components/dashboard/MonthlyCalendar.tsx
+++ b/src/components/dashboard/MonthlyCalendar.tsx
@@ -363,8 +363,9 @@ function MobileDayDetailPanel({
 
   const trainingTag = data?.conditionTags.find((t) => t.key === "training");
   const bowelTag    = data?.conditionTags.find((t) => t.key === "bowel");
+  const workTag     = data?.conditionTags.find((t) => t.key === "work");
   const hasConditionData = !!(
-    (data?.dayTags.length ?? 0) > 0 || trainingTag || bowelTag
+    (data?.dayTags.length ?? 0) > 0 || trainingTag || bowelTag || workTag
   );
 
   return (
@@ -446,6 +447,16 @@ function MobileDayDetailPanel({
                   <span className="shrink-0 text-[11px] text-slate-400 dark:text-slate-500">排便</span>
                   <span className={`rounded-full px-2 py-0.5 text-[11px] font-semibold leading-none ${bowelTag.colorClass}`}>
                     {bowelTag.label}
+                  </span>
+                </div>
+              )}
+
+              {/* 勤務 */}
+              {workTag && (
+                <div className="flex items-center gap-1.5">
+                  <span className="shrink-0 text-[11px] text-slate-400 dark:text-slate-500">勤務</span>
+                  <span className={`rounded-full px-2 py-0.5 text-[11px] font-semibold leading-none ${workTag.colorClass}`}>
+                    {workTag.label}
                   </span>
                 </div>
               )}


### PR DESCRIPTION
## 概要

モバイルカレンダーの日別詳細パネルに勤務形態を追加。
トレーニング・排便と同じ badge 行として「勤務」ラベルで表示する。

## 変更内容

**`src/components/dashboard/MonthlyCalendar.tsx`** のみ (+12 行 / -1 行)

- `MobileDayDetailPanel` に `workTag` の抽出を追加
- `hasConditionData` の条件に `workTag` を追加（勤務のみ記録の日もセクションが表示される）
- 「勤務」ラベル + カラーバッジの表示行を排便の直後に追加

## 表示対象

`CalendarDayData.conditionTags` の `key === "work"` タグ。
このタグは `buildConditionTags`（`calendarUtils.ts`）が既に生成済みで、
`buildCalendarDayMap` 経由で全日のデータに含まれている。
追加の props 変更・mapping 変更・query 変更は不要。

## 勤務形態の表示ルール

| `work_mode` | 表示ラベル | バッジカラー |
|---|---|---|
| `off` | 休日 | 黄 (amber) |
| `office` | 出社 | グレー (slate) |
| `remote` | 在宅 | シアン (cyan) |

ラベル・色は `WORK_MODE_LABELS` / `WORK_MODE_COLOR`（`calendarUtils.ts`）の既存定義を再利用。

## 未入力時の扱い

`work_mode` が null または未記録の場合は `workTag` が `undefined` になり行を描画しない。
トレーニング・排便の既存ルールと同一。

## モバイル確認内容

- `sm:hidden` の `MobileDayDetailPanel` 内のみ変更
- 既存の就寝・起床・睡眠・断食・特殊日・トレーニング・排便の表示は無変更
- `hasConditionData` 条件更新により、勤務のみ記録の日もセクションが正常表示される
- モバイル幅での追加行は badge 1行のみ（縦に伸びすぎない）

## デスクトップ影響確認

- デスクトップ用カレンダーセル（`CalendarDayCell`）は変更なし
- デスクトップ用 `conditionTags` 表示（sm:flex 部分）は変更なし
- `buildConditionTags` / `buildCalendarDayMap` / `calendarUtils.ts` は変更なし

## テスト / 確認内容

- `npx jest --no-coverage` — 1539 tests passed (変化なし)
- `npx tsc --noEmit` — エラーなし

Closes #603