### PR TITLE
[codex] Fix MealLogger note clearing

### DIFF
--- a/src/app/actions/__tests__/saveDailyLog.test.ts
+++ b/src/app/actions/__tests__/saveDailyLog.test.ts
@@ -262,7 +262,7 @@ describe("buildUpdatePayload — 部分更新シナリオ", () => {
   });
 
   // ※ buildUpdatePayload 自体は空文字を通す。呼び出し側 (MealLogger) が
-  //   note !== "" ? note : undefined で変換する責務を持つ。
+  //   未操作なら undefined、空文字による明示クリアなら null へ変換する責務を持つ。
   test("空文字を渡した場合はそのまま含まれる（呼び出し側での変換が必要）", () => {
     const payload = buildUpdatePayload({ note: "" });
     expect(payload.note).toBe("");

--- a/src/components/meal/MealLogger.test.ts
+++ b/src/components/meal/MealLogger.test.ts
@@ -1,4 +1,8 @@
-import { computeHasContent, computeHasDailyLogChanges } from "./MealLogger";
+import {
+  buildNoteSaveValue,
+  computeHasContent,
+  computeHasDailyLogChanges,
+} from "./MealLogger";
 
 const base = {
   weight: "" as string | null,
@@ -224,5 +228,24 @@ describe("computeHasDailyLogChanges", () => {
       note: "メモ",
       noteTouched: true,
     })).toBe(true);
+  });
+});
+
+describe("buildNoteSaveValue", () => {
+  it("未操作の場合は undefined を返して既存値を保持する", () => {
+    expect(buildNoteSaveValue("既存メモ", false)).toBeUndefined();
+    expect(buildNoteSaveValue("", false)).toBeUndefined();
+  });
+
+  it("入力値がある場合はその文字列を返す", () => {
+    expect(buildNoteSaveValue("調子良い", true)).toBe("調子良い");
+  });
+
+  it("空文字にして保存する場合は null を返して既存メモを削除する", () => {
+    expect(buildNoteSaveValue("", true)).toBeNull();
+  });
+
+  it("削除予定状態の場合は null を返す", () => {
+    expect(buildNoteSaveValue(null, true)).toBeNull();
   });
 });

--- a/src/components/meal/MealLogger.tsx
+++ b/src/components/meal/MealLogger.tsx
@@ -92,6 +92,22 @@ export function computeHasDailyLogChanges(input: HasContentInput): boolean {
   );
 }
 
+/**
+ * MealLogger の note 入力状態を saveDailyLog の 3 状態へ変換する。
+ *
+ * undefined — 未操作なので既存値を保持
+ * null      — ユーザーが空にした、または削除予定にしたので明示クリア
+ * string    — 入力値で上書き
+ */
+export function buildNoteSaveValue(
+  note: string | null,
+  noteTouched: boolean
+): string | null | undefined {
+  if (!noteTouched) return undefined;
+  if (note === null || note === "") return null;
+  return note;
+}
+
 interface MealLoggerProps {
   sidebar?: boolean; // サイドバーモード: 常時展開・縦レイアウト
   /** サイドバーモード時のみ有効。false にすると内部ヘッダー行を非表示にする */
@@ -401,9 +417,7 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
           protein:  cartItems.length > 0 ? totals.protein  : (cartEverHadItems ? null : undefined),
           fat:      cartItems.length > 0 ? totals.fat      : (cartEverHadItems ? null : undefined),
           carbs:    cartItems.length > 0 ? totals.carbs    : (cartEverHadItems ? null : undefined),
-          note:     noteTouched
-            ? (note === null     ? null   : (note     !== "" ? note                 : undefined))
-            : undefined,
+          note:     buildNoteSaveValue(note, noteTouched),
           ...tagPayload,
           // ルール: touched=true → hadBowelMovement の値をそのまま送信
           //           null  = 明示クリア（未記録に戻す）


### PR DESCRIPTION
## Summary
- Fix MealLogger note serialization so a touched empty note clears the existing DB value with `null` instead of preserving it with `undefined`.
- Add focused tests for the note save-state mapping.
- Update the existing saveDailyLog test comment to match the MealLogger responsibility.

## Root Cause
MealLogger treated `noteTouched === true` with `note === ""` as `undefined`, which means "do not update" in the partial update contract. As a result, deleting all text from the note input did not clear the existing note unless the explicit delete button was used.

## Validation
- `npm test -- --runInBand src/components/meal/MealLogger.test.ts src/components/meal/MealLogger.integration.test.tsx src/app/actions/__tests__/saveDailyLog.test.ts`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test -- --runInBand`
- `npm run build`

Closes #607