### PR TITLE
[codex] Validate nullable booleans in CSV import

### DIFF
--- a/src/lib/utils/csvParser.test.ts
+++ b/src/lib/utils/csvParser.test.ts
@@ -327,6 +327,35 @@ describe("parseCSV", () => {
     expect(result.rows[1]!.had_bowel_movement).toBe(false);
   });
 
+  it("新カラム: had_bowel_movement は 1/0 を正しくパースする", () => {
+    const csv = [
+      "log_date,had_bowel_movement",
+      "2026-03-15,1",
+      "2026-03-16,0",
+    ].join("\n");
+
+    const result = parseCSV(csv);
+    expect(result.errors).toHaveLength(0);
+    expect(result.rows[0]!.had_bowel_movement).toBe(true);
+    expect(result.rows[1]!.had_bowel_movement).toBe(false);
+  });
+
+  it("新カラム: had_bowel_movement の不正値は false にせず行をスキップする", () => {
+    const csv = [
+      "log_date,had_bowel_movement",
+      "2026-03-15,maybe",
+      "2026-03-16,true",
+    ].join("\n");
+
+    const result = parseCSV(csv);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain("had_bowel_movement");
+    expect(result.errors[0]).toContain("maybe");
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]!.log_date).toBe("2026-03-16");
+    expect(result.rows[0]!.had_bowel_movement).toBe(true);
+  });
+
   it("新カラム: leg_flag は空文字で null になる", () => {
     const csv = [
       "log_date,leg_flag",
@@ -347,6 +376,35 @@ describe("parseCSV", () => {
     const result = parseCSV(csv);
     expect(result.rows[0]!.leg_flag).toBe(true);
     expect(result.rows[1]!.leg_flag).toBe(false);
+  });
+
+  it("新カラム: leg_flag は 1/0 を正しくパースする", () => {
+    const csv = [
+      "log_date,leg_flag",
+      "2026-03-12,1",
+      "2026-03-13,0",
+    ].join("\n");
+
+    const result = parseCSV(csv);
+    expect(result.errors).toHaveLength(0);
+    expect(result.rows[0]!.leg_flag).toBe(true);
+    expect(result.rows[1]!.leg_flag).toBe(false);
+  });
+
+  it("新カラム: leg_flag の不正値は false にせず行をスキップする", () => {
+    const csv = [
+      "log_date,leg_flag",
+      "2026-03-12,maybe",
+      "2026-03-13,false",
+    ].join("\n");
+
+    const result = parseCSV(csv);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain("leg_flag");
+    expect(result.errors[0]).toContain("maybe");
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]!.log_date).toBe("2026-03-13");
+    expect(result.rows[0]!.leg_flag).toBe(false);
   });
 
   it("新カラム: training_type / work_mode / sleep_hours を正しくパースする", () => {

--- a/src/lib/utils/csvParser.ts
+++ b/src/lib/utils/csvParser.ts
@@ -102,11 +102,17 @@ function parseBool(v: string): boolean {
   return s === "true" || s === "1";
 }
 
-/** "true"/"1" → true, "false"/"0" → false, "" → null */
-function parseBoolNullable(v: string): boolean | null {
+type NullableBoolParseResult =
+  | { ok: true; value: boolean | null }
+  | { ok: false; raw: string };
+
+/** "true"/"1" → true, "false"/"0" → false, "" → null, その他 → invalid */
+function parseBoolNullable(v: string): NullableBoolParseResult {
   const s = v.trim().toLowerCase();
-  if (s === "") return null;
-  return s === "true" || s === "1";
+  if (s === "") return { ok: true, value: null };
+  if (s === "true" || s === "1") return { ok: true, value: true };
+  if (s === "false" || s === "0") return { ok: true, value: false };
+  return { ok: false, raw: v };
 }
 
 /**
@@ -310,6 +316,18 @@ export function parseCSV(text: string): ParseResult {
       continue;
     }
 
+    const hadBowelMovement = parseBoolNullable(raw["had_bowel_movement"] ?? "");
+    if (!hadBowelMovement.ok) {
+      errors.push(`行 ${i + 1}: had_bowel_movement の値が不正（${hadBowelMovement.raw}）— true/false/1/0/空欄 のいずれかを指定してください — スキップ`);
+      continue;
+    }
+
+    const legFlag = parseBoolNullable(raw["leg_flag"] ?? "");
+    if (!legFlag.ok) {
+      errors.push(`行 ${i + 1}: leg_flag の値が不正（${legFlag.raw}）— true/false/1/0/空欄 のいずれかを指定してください — スキップ`);
+      continue;
+    }
+
     rows.push({
       log_date: normalized,
       weight: parseNum(raw["weight"] ?? ""),
@@ -327,10 +345,10 @@ export function parseCSV(text: string): ParseResult {
       sleep_hours: parseNum(raw["sleep_hours"] ?? ""),
       sleep_bed_time:  rawBedTime,
       sleep_wake_time: rawWakeTime,
-      had_bowel_movement: parseBoolNullable(raw["had_bowel_movement"] ?? ""),
+      had_bowel_movement: hadBowelMovement.value,
       training_type,
       work_mode,
-      leg_flag: parseBoolNullable(raw["leg_flag"] ?? ""),
+      leg_flag: legFlag.value,
     });
   }
 


### PR DESCRIPTION
## Summary
- Change CSV nullable boolean parsing so invalid values are rejected instead of silently becoming `false`.
- Apply validation to `had_bowel_movement` and `leg_flag` during row parsing.
- Add coverage for `true/false/1/0/blank` and invalid-value skip behavior.

## Root Cause
`parseBoolNullable` only special-cased blank and `true`/`1`. Any other nonblank value, including invalid strings like `maybe`, evaluated to `false`, which could silently save incorrect condition data.

## Validation
- `npm test -- --runInBand src/lib/utils/csvParser.test.ts src/app/actions/__tests__/importDailyLogs.test.ts`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test -- --runInBand`
- `npm run build`

Closes #608