### PR TITLE
[codex] Fix E2E smoke expectations for current UI

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -29,22 +29,24 @@ for (const { path, navLabel } of MAIN_PAGES) {
   test(`${navLabel} ページが表示できる (${path})`, async ({ page }) => {
     await page.goto(path);
 
-    // NavBar が常に表示されること (layout.tsx で全ページ共通)
-    await expect(page.locator("nav")).toBeVisible();
+    // layout.tsx には desktop NavBar と mobile bottom nav の 2 つの nav がある。
+    // Desktop Chrome project では先頭の desktop NavBar が表示されることを確認する。
+    await expect(page.locator("nav").first()).toBeVisible();
 
     // Next.js の Application error ページが出ていないこと
     await expect(page.getByText("Application error")).not.toBeVisible();
   });
 }
 
-test("設定ページ: 「基本設定」セクションが表示できる", async ({ page }) => {
+test("設定ページ: 設定セクションが表示できる", async ({ page }) => {
   await page.goto("/settings");
 
   // h1 "設定" が表示される
   await expect(page.getByRole("heading", { name: "設定", exact: true })).toBeVisible();
 
-  // 「基本設定」セクション見出しが表示される
-  await expect(page.getByText("基本設定")).toBeVisible();
+  // 現在の SettingsForm セクション見出しが表示される
+  await expect(page.getByRole("heading", { name: "シーズン・コンテスト", exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "目標・身体情報", exact: true })).toBeVisible();
 });
 
 test("NavBar リンクからダッシュボード → 設定ページへ遷移できる", async ({ page }) => {


### PR DESCRIPTION
## Summary
- Update smoke test navigation assertion to handle both desktop and mobile `nav` elements in the layout.
- Replace the stale Settings assertion for `基本設定` with current SettingsForm section headings.
- Keep the smoke test scope read-only and focused on page load / basic UI availability.

## Root Cause
The smoke test was still written for an older DOM and Settings copy. The app now renders both a desktop NavBar and a mobile bottom nav, causing Playwright strict mode failures for `page.locator("nav")`. The Settings page no longer has a `基本設定` section, so that assertion timed out.

## Validation
- `npm run e2e:smoke`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test -- --runInBand`
- `npm run build`

Closes #609