### PR TITLE
[codex] Improve MealLogger sheet focus management

### DIFF
--- a/src/components/dashboard/MobileMealLoggerSheet.integration.test.tsx
+++ b/src/components/dashboard/MobileMealLoggerSheet.integration.test.tsx
@@ -1,0 +1,94 @@
+// @jest-environment jest-environment-jsdom
+
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+jest.mock("lucide-react", () => ({
+  ChevronRight: () => <span data-testid="icon-chevron-right" />,
+  PenLine: () => <span data-testid="icon-pen-line" />,
+  X: () => <span data-testid="icon-x" />,
+}));
+
+jest.mock("@/components/meal/MealLogger", () => ({
+  MealLogger: ({ onSaveSuccess }: { onSaveSuccess: () => void }) => (
+    <div>
+      <button type="button">食事入力</button>
+      <button type="button" onClick={onSaveSuccess}>
+        保存する
+      </button>
+    </div>
+  ),
+}));
+
+import { MobileMealLoggerSheet } from "./MobileMealLoggerSheet";
+
+describe("MobileMealLoggerSheet", () => {
+  afterEach(() => {
+    document.body.style.overflow = "";
+    jest.clearAllMocks();
+  });
+
+  it("開いた直後に閉じるボタンへフォーカスし、body スクロールを抑制する", () => {
+    render(<MobileMealLoggerSheet />);
+
+    fireEvent.click(screen.getByRole("button", { name: "食事・体重を記録する" }));
+
+    expect(screen.getByRole("dialog", { name: "食事・体重ログ入力" })).toBeInTheDocument();
+    expect(screen.getByLabelText("食事ログを閉じる")).toHaveFocus();
+    expect(document.body.style.overflow).toBe("hidden");
+  });
+
+  it("Shift+Tab と Tab でダイアログ内のフォーカスを循環する", () => {
+    render(<MobileMealLoggerSheet />);
+
+    fireEvent.click(screen.getByRole("button", { name: "食事・体重を記録する" }));
+
+    const closeButton = screen.getByLabelText("食事ログを閉じる");
+    const saveButton = screen.getByRole("button", { name: "保存する" });
+
+    expect(closeButton).toHaveFocus();
+
+    fireEvent.keyDown(document, { key: "Tab", shiftKey: true });
+    expect(saveButton).toHaveFocus();
+
+    fireEvent.keyDown(document, { key: "Tab" });
+    expect(closeButton).toHaveFocus();
+  });
+
+  it("Escape で閉じると起動ボタンへフォーカスを戻す", () => {
+    render(<MobileMealLoggerSheet />);
+
+    const trigger = screen.getByRole("button", { name: "食事・体重を記録する" });
+    fireEvent.click(trigger);
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(screen.queryByRole("dialog", { name: "食事・体重ログ入力" })).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+    expect(document.body.style.overflow).toBe("");
+  });
+
+  it("backdrop クリックで閉じると起動ボタンへフォーカスを戻す", () => {
+    render(<MobileMealLoggerSheet />);
+
+    const trigger = screen.getByRole("button", { name: "食事・体重を記録する" });
+    fireEvent.click(trigger);
+
+    const backdrop = document.querySelector("[aria-hidden='true']") as HTMLElement;
+    fireEvent.click(backdrop);
+
+    expect(screen.queryByRole("dialog", { name: "食事・体重ログ入力" })).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+  });
+
+  it("保存成功で閉じると起動ボタンへフォーカスを戻す", () => {
+    render(<MobileMealLoggerSheet />);
+
+    const trigger = screen.getByRole("button", { name: "食事・体重を記録する" });
+    fireEvent.click(trigger);
+    fireEvent.click(screen.getByRole("button", { name: "保存する" }));
+
+    expect(screen.queryByRole("dialog", { name: "食事・体重ログ入力" })).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+  });
+});

--- a/src/components/dashboard/MobileMealLoggerSheet.tsx
+++ b/src/components/dashboard/MobileMealLoggerSheet.tsx
@@ -15,22 +15,75 @@
  * - z-50 で MobileBottomNav (z-30) より上に重なる
  */
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { PenLine, X, ChevronRight } from "lucide-react";
 import { MealLogger } from "@/components/meal/MealLogger";
 
 export function MobileMealLoggerSheet() {
   const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
 
-  // Escape キーで閉じる
+  const closeSheet = useCallback(() => {
+    setOpen(false);
+    triggerRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    closeButtonRef.current?.focus();
+  }, [open]);
+
+  // Escape キーで閉じる / Tab フォーカスをダイアログ内に閉じ込める
   useEffect(() => {
     if (!open) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setOpen(false);
+      if (e.key === "Escape") {
+        closeSheet();
+        return;
+      }
+
+      if (e.key !== "Tab") return;
+
+      const panel = panelRef.current;
+      if (!panel) return;
+
+      const focusable = Array.from(
+        panel.querySelectorAll<HTMLElement>(
+          [
+            "a[href]",
+            "button:not([disabled])",
+            "textarea:not([disabled])",
+            "input:not([disabled])",
+            "select:not([disabled])",
+            "[tabindex]:not([tabindex='-1'])",
+          ].join(",")
+        )
+      ).filter((element) => element.tabIndex !== -1);
+
+      if (focusable.length === 0) return;
+
+      const first = focusable[0]!;
+      const last = focusable[focusable.length - 1]!;
+
+      if (!panel.contains(document.activeElement)) {
+        e.preventDefault();
+        first.focus();
+        return;
+      }
+
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
     };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [open]);
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, closeSheet]);
 
   // sheet / modal open 中は body スクロールを抑制
   useEffect(() => {
@@ -44,6 +97,7 @@ export function MobileMealLoggerSheet() {
     <div>
       {/* ── Trigger ── */}
       <button
+        ref={triggerRef}
         type="button"
         onClick={() => setOpen(true)}
         className="flex w-full items-center gap-2.5 rounded-xl border border-slate-100 bg-white px-3.5 py-2.5 shadow-sm transition-all hover:bg-slate-50 hover:shadow-md dark:border-slate-700 dark:bg-slate-900 dark:shadow-none dark:hover:bg-slate-800/60 lg:max-w-xs"
@@ -62,7 +116,7 @@ export function MobileMealLoggerSheet() {
         <div
           className="fixed inset-0 z-50 bg-black/40"
           aria-hidden="true"
-          onClick={() => setOpen(false)}
+          onClick={closeSheet}
         />
       )}
 
@@ -72,6 +126,7 @@ export function MobileMealLoggerSheet() {
       */}
       {open && (
         <div
+          ref={panelRef}
           role="dialog"
           aria-modal="true"
           aria-label="食事・体重ログ入力"
@@ -96,8 +151,9 @@ export function MobileMealLoggerSheet() {
               <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">食事ログ</span>
             </div>
             <button
+              ref={closeButtonRef}
               type="button"
-              onClick={() => setOpen(false)}
+              onClick={closeSheet}
               aria-label="食事ログを閉じる"
               className="flex h-8 w-8 items-center justify-center rounded-lg text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600 dark:text-slate-500 dark:hover:bg-slate-800 dark:hover:text-slate-300"
             >
@@ -114,7 +170,7 @@ export function MobileMealLoggerSheet() {
             style={{ maxHeight: "calc(min(88svh, 85vh) - 56px)" }}
           >
             <div className="px-5 py-4 overflow-hidden">
-              <MealLogger sidebar showHeader={false} onSaveSuccess={() => setOpen(false)} />
+              <MealLogger sidebar showHeader={false} onSaveSuccess={closeSheet} />
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Focus the MealLogger sheet close button when the modal opens.
- Trap Tab / Shift+Tab navigation inside the modal while it is open.
- Restore focus to the trigger when the sheet closes via Escape, backdrop, close button, or save success.
- Add jsdom integration coverage for the modal focus lifecycle.

## Root Cause
The sheet previously opened without assigning focus and only handled Escape as a global close shortcut. Keyboard users could tab out behind the modal, and closing the modal did not restore focus to the original trigger.

## Validation
- `npm test -- MobileMealLoggerSheet.integration.test.tsx`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test`
- `npm run build`

Closes #610