### PR TITLE
Ignore local agent instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ Thumbs.db
 *.swp
 *.swo
 
+# Local agent instructions
+AGENTS.md
+
 # TypeScript
 *.tsbuildinfo
 next-env.d.ts


### PR DESCRIPTION
## Summary
- Add `AGENTS.md` to `.gitignore` so local agent instructions stay outside repository tracking

## Verification
- Not run; gitignore-only change

## Notes
- This keeps the previous direct local commit out of `main` and moves it into the normal PR flow.