### PR TITLE
認証切れ時の server action エラー表示を統一する

### DIFF
--- a/src/app/actions/__tests__/foods.test.ts
+++ b/src/app/actions/__tests__/foods.test.ts
@@ -1,0 +1,31 @@
+jest.mock("@/lib/supabase/server", () => ({
+  createClient: jest.fn(),
+  requireCurrentUser: jest.fn(async () => ({ id: "test-user-id", email: "owner@example.com" })),
+}));
+
+import { deleteFood, deleteMenu, insertFood, insertMenu, updateMenu } from "@/app/actions/foods";
+import { createClient, requireCurrentUser } from "@/lib/supabase/server";
+
+const mockCreateClient = createClient as jest.MockedFunction<typeof createClient>;
+const mockRequireCurrentUser = requireCurrentUser as jest.MockedFunction<typeof requireCurrentUser>;
+
+describe("foods/menu actions — auth_required", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRequireCurrentUser.mockRejectedValue(new Error("auth_required"));
+  });
+
+  it.each([
+    ["insertFood", () => insertFood({ name: "鶏むね", calories: 100, protein: 20, fat: 1, carbs: 0 })],
+    ["deleteFood", () => deleteFood("鶏むね")],
+    ["insertMenu", () => insertMenu({ name: "朝食", recipe: [] })],
+    ["updateMenu", () => updateMenu("朝食", { name: "朝食2", recipe: [] })],
+    ["deleteMenu", () => deleteMenu("朝食")],
+  ])("%s はログインし直しメッセージとして返す", async (_name, action) => {
+    await expect(action()).resolves.toEqual({
+      error: "ログインし直してください",
+      reason: "auth_required",
+    });
+    expect(mockCreateClient).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/actions/__tests__/importDailyLogs.test.ts
+++ b/src/app/actions/__tests__/importDailyLogs.test.ts
@@ -163,6 +163,19 @@ describe("importDailyLogs — saveSleepSession 失敗", () => {
 
     expect(result).toEqual({ ok: true, count: 2, skipped: 0, sleepSkipped: 1 });
   });
+
+  it("saveSleepSession の認証切れはインポート全体のエラーとして返す", async () => {
+    mockSaveSleepSession.mockResolvedValueOnce({
+      ok: false,
+      message: "ログインし直してください",
+      reason: "auth_required",
+    });
+
+    const row = makeRow({ sleep_bed_time: "23:30", sleep_wake_time: "07:00" });
+    const result = await importDailyLogs([row]);
+
+    expect(result).toEqual({ ok: false, message: "ログインし直してください" });
+  });
 });
 
 describe("importDailyLogs — saveDailyLog 失敗", () => {
@@ -176,6 +189,20 @@ describe("importDailyLogs — saveDailyLog 失敗", () => {
     const result = await importDailyLogs([row]);
 
     expect(result).toEqual({ ok: true, count: 0, skipped: 1, sleepSkipped: 0 });
+    expect(mockSaveSleepSession).not.toHaveBeenCalled();
+  });
+
+  it("saveDailyLog の認証切れは skipped にせずインポート全体のエラーとして返す", async () => {
+    mockSaveDailyLog.mockResolvedValueOnce({
+      ok: false,
+      message: "ログインし直してください",
+      reason: "auth_required",
+    });
+
+    const row = makeRow({ sleep_bed_time: "23:30", sleep_wake_time: "07:00" });
+    const result = await importDailyLogs([row]);
+
+    expect(result).toEqual({ ok: false, message: "ログインし直してください" });
     expect(mockSaveSleepSession).not.toHaveBeenCalled();
   });
 });

--- a/src/app/actions/__tests__/saveDailyLog.test.ts
+++ b/src/app/actions/__tests__/saveDailyLog.test.ts
@@ -20,10 +20,11 @@ jest.mock("@/lib/supabase/server", () => ({
 
 import { buildUpdatePayload } from "../buildUpdatePayload";
 import { saveDailyLog } from "../saveDailyLog";
-import { createClient } from "@/lib/supabase/server";
+import { createClient, requireCurrentUser } from "@/lib/supabase/server";
 import { revalidatePath } from "next/cache";
 
 const mockCreateClient = createClient as jest.MockedFunction<typeof createClient>;
+const mockRequireCurrentUser = requireCurrentUser as jest.MockedFunction<typeof requireCurrentUser>;
 
 // ── Supabase クライアントモックヘルパー ─────────────────────────────────────
 
@@ -303,6 +304,20 @@ describe("buildUpdatePayload — null による明示的クリア", () => {
 // ════════════════════════════════════════════════════════════════════════════
 
 describe("saveDailyLog — atomic upsert (RPC 呼び出し検証)", () => {
+  test("認証切れはログインし直しメッセージとして返す", async () => {
+    mockCreateClient.mockClear();
+    mockRequireCurrentUser.mockRejectedValueOnce(new Error("auth_required"));
+
+    const result = await saveDailyLog({ log_date: "2026-03-13", weight: 70.5 });
+
+    expect(result).toEqual({
+      ok: false,
+      message: "ログインし直してください",
+      reason: "auth_required",
+    });
+    expect(mockCreateClient).not.toHaveBeenCalled();
+  });
+
   test("weight のみ → RPC が save_daily_log_partial で呼ばれ p_fields に weight が含まれる", async () => {
     const capture = makeRpcMock();
     const result = await saveDailyLog({ log_date: "2026-03-13", weight: 70.5 });

--- a/src/app/actions/__tests__/saveSleepSession.test.ts
+++ b/src/app/actions/__tests__/saveSleepSession.test.ts
@@ -1,0 +1,47 @@
+jest.mock("@/lib/cache/revalidate", () => ({ revalidateAfterDailyLogMutation: jest.fn() }));
+jest.mock("@/lib/supabase/server", () => ({
+  createClient: jest.fn(),
+  requireCurrentUser: jest.fn(async () => ({ id: "test-user-id", email: "owner@example.com" })),
+}));
+
+import { deleteSleepSession, saveSleepSession } from "@/app/actions/saveSleepSession";
+import { createClient, requireCurrentUser } from "@/lib/supabase/server";
+
+const mockCreateClient = createClient as jest.MockedFunction<typeof createClient>;
+const mockRequireCurrentUser = requireCurrentUser as jest.MockedFunction<typeof requireCurrentUser>;
+
+describe("saveSleepSession/deleteSleepSession — auth_required", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("saveSleepSession はログインし直しメッセージとして返す", async () => {
+    mockRequireCurrentUser.mockRejectedValueOnce(new Error("auth_required"));
+
+    const result = await saveSleepSession({
+      wake_date: "2026-04-01",
+      bed_time: "23:30",
+      wake_time: "07:00",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      message: "ログインし直してください",
+      reason: "auth_required",
+    });
+    expect(mockCreateClient).not.toHaveBeenCalled();
+  });
+
+  test("deleteSleepSession はログインし直しメッセージとして返す", async () => {
+    mockRequireCurrentUser.mockRejectedValueOnce(new Error("auth_required"));
+
+    const result = await deleteSleepSession("2026-04-01");
+
+    expect(result).toEqual({
+      ok: false,
+      message: "ログインし直してください",
+      reason: "auth_required",
+    });
+    expect(mockCreateClient).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/actions/foods.ts
+++ b/src/app/actions/foods.ts
@@ -1,26 +1,46 @@
 "use server";
 
 import { createClient, requireCurrentUser } from "@/lib/supabase/server";
+import { AUTH_REQUIRED_MESSAGE, isAuthRequiredError } from "@/lib/auth/actionErrors";
 import type { Database, Json } from "@/lib/supabase/types";
 import type { RecipeItem } from "@/lib/supabase/types";
 
 type FoodMasterInsert = Database["public"]["Tables"]["food_master"]["Insert"];
 
-export type FoodActionResult = { error: string | null };
+export type FoodActionResult = { error: string | null; reason?: "auth_required" };
+
+async function getCurrentUserIdForFoodAction(): Promise<
+  | { ok: true; userId: string }
+  | { ok: false; error: string; reason: "auth_required" }
+> {
+  try {
+    const user = await requireCurrentUser();
+    return { ok: true, userId: user.id };
+  } catch (error) {
+    if (isAuthRequiredError(error)) {
+      return { ok: false, error: AUTH_REQUIRED_MESSAGE, reason: "auth_required" };
+    }
+    throw error;
+  }
+}
 
 /** food_master への insert */
 export async function insertFood(payload: FoodMasterInsert): Promise<FoodActionResult> {
-  const user = await requireCurrentUser();
+  const auth = await getCurrentUserIdForFoodAction();
+  if (!auth.ok) return { error: auth.error, reason: auth.reason };
+
   const supabase = await createClient();
-  const { error } = await supabase.from("food_master").insert({ ...payload, user_id: user.id });
+  const { error } = await supabase.from("food_master").insert({ ...payload, user_id: auth.userId });
   return { error: error?.message ?? null };
 }
 
 /** food_master からの delete（name が PK） */
 export async function deleteFood(name: string): Promise<FoodActionResult> {
-  const user = await requireCurrentUser();
+  const auth = await getCurrentUserIdForFoodAction();
+  if (!auth.ok) return { error: auth.error, reason: auth.reason };
+
   const supabase = await createClient();
-  const { error } = await supabase.from("food_master").delete().eq("user_id", user.id).eq("name", name);
+  const { error } = await supabase.from("food_master").delete().eq("user_id", auth.userId).eq("name", name);
   return { error: error?.message ?? null };
 }
 
@@ -29,10 +49,12 @@ export async function insertMenu(payload: {
   name: string;
   recipe: RecipeItem[];
 }): Promise<FoodActionResult> {
-  const user = await requireCurrentUser();
+  const auth = await getCurrentUserIdForFoodAction();
+  if (!auth.ok) return { error: auth.error, reason: auth.reason };
+
   const supabase = await createClient();
   const { error } = await supabase.from("menu_master").insert({
-    user_id: user.id,
+    user_id: auth.userId,
     name: payload.name,
     recipe: payload.recipe as unknown as Json,
   });
@@ -44,20 +66,24 @@ export async function updateMenu(
   originalName: string,
   payload: { name: string; recipe: RecipeItem[] }
 ): Promise<FoodActionResult> {
-  const user = await requireCurrentUser();
+  const auth = await getCurrentUserIdForFoodAction();
+  if (!auth.ok) return { error: auth.error, reason: auth.reason };
+
   const supabase = await createClient();
   const { error } = await supabase
     .from("menu_master")
     .update({ name: payload.name, recipe: payload.recipe as unknown as Json })
-    .eq("user_id", user.id)
+    .eq("user_id", auth.userId)
     .eq("name", originalName);
   return { error: error?.message ?? null };
 }
 
 /** menu_master からの delete（name が PK） */
 export async function deleteMenu(name: string): Promise<FoodActionResult> {
-  const user = await requireCurrentUser();
+  const auth = await getCurrentUserIdForFoodAction();
+  if (!auth.ok) return { error: auth.error, reason: auth.reason };
+
   const supabase = await createClient();
-  const { error } = await supabase.from("menu_master").delete().eq("user_id", user.id).eq("name", name);
+  const { error } = await supabase.from("menu_master").delete().eq("user_id", auth.userId).eq("name", name);
   return { error: error?.message ?? null };
 }

--- a/src/app/actions/importDailyLogs.ts
+++ b/src/app/actions/importDailyLogs.ts
@@ -89,10 +89,16 @@ export async function importDailyLogs(
           { skipRevalidate: true }
         );
         if (!sleepResult.ok) {
+          if (sleepResult.reason === "auth_required") {
+            return { ok: false, message: sleepResult.message };
+          }
           sleepSkipped++;
         }
       }
     } else {
+      if (result.reason === "auth_required") {
+        return { ok: false, message: result.message };
+      }
       skipped++;
     }
   }

--- a/src/app/actions/saveDailyLog.ts
+++ b/src/app/actions/saveDailyLog.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { createClient, requireCurrentUser } from "@/lib/supabase/server";
+import { authRequiredMessage } from "@/lib/auth/actionErrors";
 import { revalidateAfterDailyLogMutation } from "@/lib/cache/revalidate";
 import { isValidTrainingType, isValidWorkMode } from "@/lib/utils/trainingType";
 import { buildUpdatePayload } from "./buildUpdatePayload";
@@ -52,7 +53,7 @@ export type DailyLogPayload = Omit<SaveDailyLogInput, "log_date"> & {
 
 export type SaveDailyLogResult =
   | { ok: true }
-  | { ok: false; message: string };
+  | { ok: false; message: string; reason?: "auth_required" };
 
 /**
  * saveDailyLog のオプション。
@@ -135,7 +136,14 @@ export async function saveDailyLog(
     }
   }
 
-  await requireCurrentUser();
+  try {
+    await requireCurrentUser();
+  } catch (error) {
+    const message = authRequiredMessage(error);
+    if (message) return { ok: false, message, reason: "auth_required" };
+    throw error;
+  }
+
   const supabase = await createClient();
 
   const payload = buildUpdatePayload(input);

--- a/src/app/actions/saveSleepSession.ts
+++ b/src/app/actions/saveSleepSession.ts
@@ -24,6 +24,7 @@
  */
 
 import { createClient, requireCurrentUser } from "@/lib/supabase/server";
+import { authRequiredMessage } from "@/lib/auth/actionErrors";
 import { revalidateAfterDailyLogMutation } from "@/lib/cache/revalidate";
 import { parseLocalDateStr } from "@/lib/utils/date";
 import { buildSleepSessionDatetimes } from "@/lib/utils/sleepSession";
@@ -41,7 +42,7 @@ export type SaveSleepSessionInput = {
 
 export type SaveSleepSessionResult =
   | { ok: true }
-  | { ok: false; message: string };
+  | { ok: false; message: string; reason?: "auth_required" };
 
 export type SaveSleepSessionOptions = {
   /**
@@ -136,6 +137,9 @@ export async function saveSleepSession(
 
     return { ok: true };
   } catch (e) {
+    const message = authRequiredMessage(e);
+    if (message) return { ok: false, message, reason: "auth_required" };
+
     // Supabase の fetch 失敗など、想定外の例外が発生した場合のフォールバック。
     // throw をそのまま外部に伝播させると MealLogger の generic catch に落ちて
     // 「予期しないエラーが発生しました」が表示されるため、ここで { ok: false } に正規化する (#544)。
@@ -155,12 +159,21 @@ export async function deleteSleepSession(
     return { ok: false, message: "wake_date の形式が正しくありません (YYYY-MM-DD)" };
   }
 
-  const user = await requireCurrentUser();
+  let userId: string;
+  try {
+    const user = await requireCurrentUser();
+    userId = user.id;
+  } catch (error) {
+    const message = authRequiredMessage(error);
+    if (message) return { ok: false, message, reason: "auth_required" };
+    throw error;
+  }
+
   const supabase = await createClient();
   const { error } = await supabase
     .from("sleep_sessions")
     .delete()
-    .eq("user_id", user.id)
+    .eq("user_id", userId)
     .eq("wake_date", wakeDate);
 
   if (error) {

--- a/src/app/settings/actions.auth.test.ts
+++ b/src/app/settings/actions.auth.test.ts
@@ -1,0 +1,31 @@
+jest.mock("@/lib/cache/revalidate", () => ({ revalidateAfterSettingsMutation: jest.fn() }));
+jest.mock("@/lib/supabase/server", () => ({
+  createClient: jest.fn(),
+  requireCurrentUser: jest.fn(async () => ({ id: "test-user-id", email: "owner@example.com" })),
+}));
+
+import { saveSettings } from "@/app/settings/actions";
+import { EMPTY_SETTINGS_INPUT } from "@/lib/schemas/settingsSchema";
+import { createClient, requireCurrentUser } from "@/lib/supabase/server";
+
+const mockCreateClient = createClient as jest.MockedFunction<typeof createClient>;
+const mockRequireCurrentUser = requireCurrentUser as jest.MockedFunction<typeof requireCurrentUser>;
+
+describe("saveSettings — auth_required", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("認証切れは field error に混ぜずログインし直しメッセージとして返す", async () => {
+    mockRequireCurrentUser.mockRejectedValueOnce(new Error("auth_required"));
+
+    const result = await saveSettings(EMPTY_SETTINGS_INPUT);
+
+    expect(result).toEqual({
+      ok: false,
+      error: "ログインし直してください",
+      reason: "auth_required",
+    });
+    expect(mockCreateClient).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/settings/actions.ts
+++ b/src/app/settings/actions.ts
@@ -8,6 +8,7 @@
  */
 
 import { createClient, requireCurrentUser } from "@/lib/supabase/server";
+import { authRequiredMessage } from "@/lib/auth/actionErrors";
 import { revalidateAfterSettingsMutation } from "@/lib/cache/revalidate";
 import { parseSettings } from "@/lib/schemas/settingsSchema";
 import type { SettingsInput } from "@/lib/schemas/settingsSchema";
@@ -17,7 +18,7 @@ import { normalizeMonthlyPlanOverridesBeforeSave } from "@/lib/utils/normalizeMo
 /** saveSettings の戻り値 */
 export type SaveSettingsResult =
   | { ok: true }
-  | { ok: false; error: string };
+  | { ok: false; error: string; reason?: "auth_required" };
 
 /**
  * 設定値を検証して Supabase の settings テーブルに upsert する。
@@ -38,9 +39,18 @@ export async function saveSettings(
   }
 
   // 2. DB 保存
-  const user = await requireCurrentUser();
+  let userId: string;
+  try {
+    const user = await requireCurrentUser();
+    userId = user.id;
+  } catch (error) {
+    const message = authRequiredMessage(error);
+    if (message) return { ok: false, error: message, reason: "auth_required" };
+    throw error;
+  }
+
   const supabase = await createClient();
-  const records = parsed.records.map((record) => ({ ...record, user_id: user.id }));
+  const records = parsed.records.map((record) => ({ ...record, user_id: userId }));
   const { error } = await supabase
     .from("settings")
     .upsert(records as never);

--- a/src/components/foods/FoodTable.integration.test.tsx
+++ b/src/components/foods/FoodTable.integration.test.tsx
@@ -232,6 +232,21 @@ describe("FoodTable — 削除", () => {
     // 食品はリストに残る
     expect(screen.getAllByText("削除対象").length).toBeGreaterThanOrEqual(1);
   });
+
+  it("削除失敗時は追加フォームを開いていなくても一覧上部にエラーを表示する", async () => {
+    mockDeleteFood.mockResolvedValueOnce({ error: "ログインし直してください", reason: "auth_required" });
+    render(<FoodTable initialFoods={[makeFoodMaster({ name: "削除対象" })]} />);
+
+    fireEvent.click(screen.getAllByLabelText("削除対象を削除")[0]!);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "削除" }));
+    });
+
+    expect(screen.queryByText("新規食品を追加 (100g あたり)")).not.toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent("ログインし直してください");
+    expect(screen.getAllByText("削除対象").length).toBeGreaterThanOrEqual(1);
+  });
 });
 
 // ─── シナリオ 7: ソートヘッダー (button / aria-sort) ─────────────────────

--- a/src/components/foods/FoodTable.tsx
+++ b/src/components/foods/FoodTable.tsx
@@ -154,10 +154,13 @@ export function FoodTable({ initialFoods }: FoodTableProps) {
   function handleDelete(name: string) {
     startTransition(async () => {
       const { error: err } = await deleteFood(name);
-      if (!err) {
-        setFoods((prev) => prev.filter((f) => f.name !== name));
-        void mutate("food_master"); // FoodPicker (useFoodList) の SWR キャッシュを無効化
+      if (err) {
+        setError(err);
+        return;
       }
+      setError(null);
+      setFoods((prev) => prev.filter((f) => f.name !== name));
+      void mutate("food_master"); // FoodPicker (useFoodList) の SWR キャッシュを無効化
     });
   }
 

--- a/src/components/foods/FoodTable.tsx
+++ b/src/components/foods/FoodTable.tsx
@@ -49,6 +49,7 @@ export function FoodTable({ initialFoods }: FoodTableProps) {
   const [showForm, setShowForm] = useState(false);
   const [form, setForm] = useState<NewFood>(EMPTY_FOOD);
   const [error, setError] = useState<string | null>(null);
+  const [listError, setListError] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const [saveSuccess, setSaveSuccess] = useState(false);
   /** true のとき新規カテゴリ名をテキスト入力、false のとき既存から選択 */
@@ -98,6 +99,7 @@ export function FoodTable({ initialFoods }: FoodTableProps) {
   }
 
   async function handleAdd() {
+    setListError(null);
     if (!form.name.trim()) return setError("食品名は必須です");
 
     // calories / protein / fat / carbs は必須。空文字や NaN はエラー
@@ -155,10 +157,10 @@ export function FoodTable({ initialFoods }: FoodTableProps) {
     startTransition(async () => {
       const { error: err } = await deleteFood(name);
       if (err) {
-        setError(err);
+        setListError(err);
         return;
       }
-      setError(null);
+      setListError(null);
       setFoods((prev) => prev.filter((f) => f.name !== name));
       void mutate("food_master"); // FoodPicker (useFoodList) の SWR キャッシュを無効化
     });
@@ -210,7 +212,7 @@ export function FoodTable({ initialFoods }: FoodTableProps) {
         </div>
         <button
           onClick={() => {
-            if (showForm) { closeForm(); } else { setShowForm(true); setError(null); }
+            if (showForm) { closeForm(); } else { setShowForm(true); setError(null); setListError(null); }
           }}
           className="flex items-center gap-1.5 rounded-xl bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 dark:bg-blue-800 dark:hover:bg-blue-700"
         >
@@ -236,6 +238,12 @@ export function FoodTable({ initialFoods }: FoodTableProps) {
             </button>
           ))}
         </div>
+      )}
+
+      {listError && (
+        <p role="alert" className="order-4 rounded-lg border border-rose-100 bg-rose-50 px-3 py-2 text-xs text-rose-600 dark:border-rose-800/50 dark:bg-rose-900/20 dark:text-rose-300">
+          {listError}
+        </p>
       )}
 
       {/* ── 追加フォーム ── */}

--- a/src/components/foods/MenuTable.integration.test.tsx
+++ b/src/components/foods/MenuTable.integration.test.tsx
@@ -280,4 +280,19 @@ describe("MenuTable — 削除", () => {
     // セットはリストに残る
     expect(screen.getAllByText("鶏飯セット").length).toBeGreaterThanOrEqual(1);
   });
+
+  it("削除失敗時は編集フォームを開いていなくても一覧上部にエラーを表示する", async () => {
+    mockDeleteMenu.mockResolvedValueOnce({ error: "ログインし直してください", reason: "auth_required" });
+    render(<MenuTable initialMenus={INITIAL_MENUS} foods={FOODS} />);
+
+    fireEvent.click(screen.getAllByLabelText("鶏飯セットを削除")[0]!);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "削除" }));
+    });
+
+    expect(screen.queryByPlaceholderText("セット名（例: 鶏飯セット）")).not.toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent("ログインし直してください");
+    expect(screen.getAllByText("鶏飯セット").length).toBeGreaterThanOrEqual(1);
+  });
 });

--- a/src/components/foods/MenuTable.tsx
+++ b/src/components/foods/MenuTable.tsx
@@ -127,10 +127,13 @@ export function MenuTable({ initialMenus, foods }: MenuTableProps) {
   function handleDelete(name: string) {
     startTransition(async () => {
       const { error } = await deleteMenu(name);
-      if (!error) {
-        setMenus((prev) => prev.filter((m) => m.name !== name));
-        void mutate("menu_master"); // MenuPicker (useMenuList) の SWR キャッシュを無効化
+      if (error) {
+        setSaveError(error);
+        return;
       }
+      setSaveError(null);
+      setMenus((prev) => prev.filter((m) => m.name !== name));
+      void mutate("menu_master"); // MenuPicker (useMenuList) の SWR キャッシュを無効化
     });
   }
 

--- a/src/components/foods/MenuTable.tsx
+++ b/src/components/foods/MenuTable.tsx
@@ -34,6 +34,7 @@ export function MenuTable({ initialMenus, foods }: MenuTableProps) {
   const [addAmount, setAddAmount] = useState("100");
   const [addCategory, setAddCategory] = useState("すべて");
   const [saveError, setSaveError] = useState<string | null>(null);
+  const [listError, setListError] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const [saveSuccess, setSaveSuccess] = useState(false);
   const [isPending, startTransition] = useTransition();
@@ -57,12 +58,14 @@ export function MenuTable({ initialMenus, foods }: MenuTableProps) {
   function startNew() {
     setEditing({ originalName: null, name: "", items: [] });
     setSaveError(null);
+    setListError(null);
     setSaveSuccess(false);
   }
 
   function startEdit(menu: MenuEntry) {
     setEditing({ originalName: menu.name, name: menu.name, items: [...menu.recipe] });
     setSaveError(null);
+    setListError(null);
     setSaveSuccess(false);
   }
 
@@ -92,6 +95,7 @@ export function MenuTable({ initialMenus, foods }: MenuTableProps) {
 
   async function handleSave() {
     if (!editing) return;
+    setListError(null);
     if (!editing.name.trim()) return setSaveError("セット名は必須です");
     if (editing.items.length === 0) return setSaveError("1品以上追加してください");
 
@@ -128,10 +132,10 @@ export function MenuTable({ initialMenus, foods }: MenuTableProps) {
     startTransition(async () => {
       const { error } = await deleteMenu(name);
       if (error) {
-        setSaveError(error);
+        setListError(error);
         return;
       }
-      setSaveError(null);
+      setListError(null);
       setMenus((prev) => prev.filter((m) => m.name !== name));
       void mutate("menu_master"); // MenuPicker (useMenuList) の SWR キャッシュを無効化
     });
@@ -166,6 +170,12 @@ export function MenuTable({ initialMenus, foods }: MenuTableProps) {
           新規セット
         </button>
       </div>
+
+      {listError && (
+        <p role="alert" className="rounded-lg border border-rose-100 bg-rose-50 px-3 py-2 text-xs text-rose-600 dark:border-rose-800/50 dark:bg-rose-900/20 dark:text-rose-300">
+          {listError}
+        </p>
+      )}
 
       {/* 編集フォーム */}
       {editing && (

--- a/src/components/settings/SettingsForm.tsx
+++ b/src/components/settings/SettingsForm.tsx
@@ -178,6 +178,7 @@ export function SettingsForm({ initialSettings, currentWeight = null }: Settings
 
   const [values, setValues] = useState<Record<string, string>>(initMap);
   const [status, setStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
+  const [statusMessage, setStatusMessage] = useState<string>("");
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
 
   // アコーディオン開閉状態: デフォルトは "season" セクションのみ開く
@@ -260,6 +261,7 @@ export function SettingsForm({ initialSettings, currentWeight = null }: Settings
    */
   async function handleSave() {
     setStatus("saving");
+    setStatusMessage("");
     setFieldErrors({});
 
     const result = await saveSettings({
@@ -285,6 +287,17 @@ export function SettingsForm({ initialSettings, currentWeight = null }: Settings
     });
 
     if (!result.ok) {
+      if (result.reason === "auth_required") {
+        setFieldErrors({});
+        setStatusMessage(result.error);
+        setStatus("error");
+        setTimeout(() => {
+          setStatus("idle");
+          setStatusMessage("");
+        }, 3000);
+        return;
+      }
+
       // server action からのエラーを fieldErrors に展開する
       // フォーマット: "field: message, field: message"
       const newErrors: Record<string, string> = {};
@@ -302,8 +315,12 @@ export function SettingsForm({ initialSettings, currentWeight = null }: Settings
       if (Object.keys(newErrors).length > 0) {
         setFieldErrors(newErrors);
       }
+      setStatusMessage("保存に失敗しました");
       setStatus("error");
-      setTimeout(() => setStatus("idle"), 3000);
+      setTimeout(() => {
+        setStatus("idle");
+        setStatusMessage("");
+      }, 3000);
     } else {
       setStatus("saved");
       setTimeout(() => setStatus("idle"), 2000);
@@ -486,7 +503,7 @@ export function SettingsForm({ initialSettings, currentWeight = null }: Settings
         <div className="flex items-center gap-1.5 text-xs font-medium sm:mr-3">
           {status === "error" && (
             <span className="flex items-center gap-1.5 text-rose-500">
-              <AlertCircle size={13} /> 保存に失敗しました
+              <AlertCircle size={13} /> {statusMessage || "保存に失敗しました"}
             </span>
           )}
           {status === "saved" && (

--- a/src/lib/auth/actionErrors.ts
+++ b/src/lib/auth/actionErrors.ts
@@ -1,0 +1,9 @@
+export const AUTH_REQUIRED_MESSAGE = "ログインし直してください";
+
+export function isAuthRequiredError(error: unknown): boolean {
+  return error instanceof Error && error.message === "auth_required";
+}
+
+export function authRequiredMessage(error: unknown): string | null {
+  return isAuthRequiredError(error) ? AUTH_REQUIRED_MESSAGE : null;
+}


### PR DESCRIPTION
## Summary
- Normalize `auth_required` from settings, daily log, sleep session, food, and menu server actions into `ログインし直してください` results instead of unhandled exceptions.
- Keep auth errors out of field validation paths and show them in the relevant status/error area in Settings, Food, and Menu UI.
- Stop CSV import from counting auth expiry as skipped rows and return a top-level login retry message instead.

## Issue
Closes #623

## Validation
- `npm test -- --runInBand`
- `npm run lint`
- `npm run build`