### PR TITLE
Auth/RLS 導入後の古い anon 前提ドキュメントを更新する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,32 +180,36 @@ body-comp-tracker-v2/
 
 ## Supabase クライアント / 権限設計
 
-### 前提: 認証なし・個人運用
-- このアプリは Supabase Auth（ユーザー認証）を **導入していない**
-- **anon key のみ**を使用する（service_role key はフロントエンド・Server Components・Server Actions いずれにも渡さない）
-- 権限制御の唯一の層は **RLS ポリシー**（`supabase/migrations/` で定義）
-- 非公開 URL + anon key の組み合わせが現在の運用上の保護手段
+### 前提: Supabase Auth + RLS による single-user hardening
+- このアプリは個人利用前提だが、外部到達可能なデプロイに備えて Supabase Auth と RLS を導入済み
+- アプリ画面はログイン必須。許可メールは `NEXT_PUBLIC_ALLOWED_AUTH_EMAIL` で制限する
+- 主要なユーザー入力データは `user_id = auth.uid()` の owner scoped RLS で保護する
+- anon key は公開可能な Supabase client key として使うが、anon role 単体ではユーザー入力データも派生データも読めない
+- ML / analytics バッチだけが `SUPABASE_SERVICE_ROLE_KEY` を GitHub Secrets 経由で使い、RLS を bypass する
 
 ### クライアント生成の使い分け
 
 | ファイル | 使用箇所 | 備考 |
 |---|---|---|
-| `src/lib/supabase/client.ts` | Browser client / SWR hooks / Client Components | anon key ベース、RLS 適用 |
-| `src/lib/supabase/server.ts` | Server Components / Server Actions / Route Handlers | anon key ベース、RLS 適用 |
+| `src/lib/supabase/client.ts` | LoginForm など browser-side Supabase Auth 操作 | anon key。`persistSession: false` で browser storage に session を永続化しない |
+| `src/lib/supabase/server.ts` | Server Components / Server Actions / Route Handlers | anon key + httpOnly cookie の access token。authenticated role として RLS 適用 |
+| `/api/client-data` | Client Components の読み取り API | server-side Supabase client 経由で owner scoped read |
 
 - Server Components で使うからといって service_role key を使わない
-- anon key で実現できない操作が必要になった場合は、RLS ポリシーを拡張するか、設計を見直す
-- `@supabase/ssr` はインストールしていない（シンプルさ優先）
+- browser code から DB を直接 read する導線は増やさず、Client Components は `/api/client-data` を経由する
+- access / refresh token は `/api/auth/session` が httpOnly cookie として管理する
 
 ### RLS ポリシーの方針
 - 全テーブルに `ENABLE ROW LEVEL SECURITY` を適用する
-- anon ロールに対して必要最低限の操作（`SELECT` / `INSERT` / `UPDATE` / `DELETE`）を許可する
+- anon ロールにはアプリデータの SELECT / INSERT / UPDATE / DELETE を許可しない
+- `daily_logs` / `sleep_sessions` / `settings` / `food_master` / `menu_master` は authenticated user の `user_id = auth.uid()` 行だけを許可する
+- `predictions` / `analytics_cache` / `career_logs` / `forecast_backtest_*` は authenticated SELECT のみ。書き込みは service_role の ML / analytics バッチが担当する
 - ポリシーはすべて `supabase/migrations/` で管理し、手動 Console 操作で追加しない
 
 ### 将来のマルチユーザー化について
-- Auth 導入時は `auth.uid()` を使う RLS ポリシーへの差し替えが必要
-- `daily_logs` 等に `user_id` カラムを追加し、RLS で `user_id = auth.uid()` を条件にする
-- フロントのクライアント生成コードは `@supabase/ssr` の `createBrowserClient` / `createServerClient` への移行が推奨される
+- Auth / owner scoped RLS は導入済みだが、現在は single-user 運用が前提
+- `daily_logs.log_date` や `settings.key` などのグローバル UNIQUE / PRIMARY KEY は multi-user 対応時に `user_id` 複合キーへ移行する
+- ユーザー招待・削除・権限管理 UI は未実装
 - 詳細は `README.md`「アクセス制御の前提」を参照
 
 ## 実装原則

--- a/docs/daily-logs-read-inventory.md
+++ b/docs/daily-logs-read-inventory.md
@@ -118,8 +118,8 @@ Dashboard は 18列中 16列を使用しており全列に近い。ただし:
 
 | 経路 | ファイル | 用途 | クライアント種別 |
 |---|---|---|---|
-| Client SWR hook | `src/lib/hooks/useDailyLogs.ts` | MealLogger フォーム hydration | Browser (anon key) |
-| CSV export route | `src/app/api/export/route.ts` | CSV ダウンロード（全列必要） | Server Route Handler (anon key) |
+| Client SWR hook | `src/lib/hooks/useDailyLogs.ts` | MealLogger フォーム hydration | Browser → `/api/client-data` → Server Route Handler（httpOnly Auth cookie + RLS） |
+| CSV export route | `src/app/api/export/route.ts` | CSV ダウンロード（全列必要） | Server Route Handler（httpOnly Auth cookie + RLS） |
 | ML batch enrich | `ml-pipeline/enrich.py` | TDEE 推定バッチ（全列必要） | Python supabase-py (service_role key) |
 | ML batch analyze | `ml-pipeline/analyze.py` | XGBoost 因子分析バッチ（全列必要） | Python supabase-py (service_role key) |
 | ML batch predict | `ml-pipeline/predict.py` | 体重予測バッチ（log_date, weight のみ） | Python supabase-py (service_role key) |
@@ -127,10 +127,12 @@ Dashboard は 18列中 16列を使用しており全列に近い。ただし:
 ### 各 full read が許容される理由
 
 **`useDailyLogs.ts`**: MealLogger は編集フォームのため、どの列が操作されるか事前に絞れない。
-Browser から直接取得する client-side SWR であり、Server Component SSR の projection 最適化とは別レイヤー。
+Client Component の SWR だが、DB へ直接アクセスせず `/api/client-data?resource=daily_logs` を経由する。
+Route Handler 側の server-side Supabase client が httpOnly cookie の access token を渡し、RLS で owner scoped に絞る。
+Server Component SSR の projection 最適化とは別レイヤー。
 
 **`api/export/route.ts`**: CSV エクスポートはユーザーがバックアップ目的で全データを取得するもの。
-表示最適化の対象外であり、全列取得が機能要件。
+表示最適化の対象外であり、全列取得が機能要件。未ログイン時は 401 を返し、ログイン済み session の RLS 権限で自分の行だけを返す。
 
 **`ml-pipeline/*.py`**: GitHub Actions cron で実行される Python バッチ。
 anon key ではなく service_role key を使用し、JS の query layer と完全に独立した経路。
@@ -300,7 +302,7 @@ Macro ページの stale 判定を廃止・簡略化する必要がある。
 ```
 【front 用 read（現行の fetchDailyLogs 系）】
   - 目的: UI 表示・フロント計算のためのデータ取得
-  - 認証: anon key + RLS
+  - 認証: Supabase Auth session + RLS（Server Components / Route Handlers は httpOnly cookie の access token を server client に渡す）
   - 量: 画面に必要な行数に限定すべき（最適化余地あり）
   - 現行の重さ: fetchDailyLogs() は全件・全列 = 個人利用規模では許容範囲
 
@@ -312,6 +314,7 @@ Macro ページの stale 判定を廃止・簡略化する必要がある。
 ```
 
 **責務境界の原則:**
+- フロント向けの DB read は authenticated session + RLS を前提にする。anon key だけでは `daily_logs` は読めない
 - フロントが全件 full read をするのは Dashboard のみ正当（月次計画・全期間グラフが必要）
 - Macro・TDEE は表示期間に合わせた軽量 read に移行できる設計余地がある
 - ML バッチの full read はフロントとは完全に分離されており変更不要

--- a/docs/sleep-sessions-model-spec.md
+++ b/docs/sleep-sessions-model-spec.md
@@ -311,7 +311,7 @@ sleep_sessions モデルでは:
 
 - 睡眠計測・睡眠トラッキング（このアプリは「推定値としての睡眠記録」のみ扱う）
 - リアルタイム同期・自動取得（外部デバイスとのライブ連携）
-- 複数ユーザー対応（Auth 設計は既存制約と同様）
+- 複数ユーザー対応（現行は single-user hardening。Supabase Auth + RLS は導入済みだが、チーム共有 UI や複合 UNIQUE への移行は対象外）
 - 睡眠スコアリング・評価機能
 
 ### 保留事項（#515〜#518 で決定する）
@@ -321,7 +321,7 @@ sleep_sessions モデルでは:
 | `weigh_in_time` と `wake_at` の UI 共有 | 2 フィールドを 1 入力欄にするかどうか UX 要確認 | #516 |
 | DB トリガー vs enrich.py での `sleep_hours` 更新 | バッチ設計依存 | #515 |
 | `daily_logs.bed_time` の廃止タイミング | ~~migration 互換性・移行期の長さ~~ | **#529 で廃止済み** |
-| `sleep_sessions` の RLS ポリシー | 既存パターンと同じ（anon 全許可）のはずだが確認が必要 | #515 |
+| `sleep_sessions` の RLS ポリシー | **#606 で確定済み**。anon は不可、authenticated は `user_id = auth.uid()` の owner scoped SELECT / INSERT / UPDATE / DELETE | #606 |
 | sleep_sessions の wake_date UNIQUE 制約の将来外し判断 | nap 対応のタイミングで決定 | 将来 Issue |
 
 ---
@@ -331,7 +331,7 @@ sleep_sessions モデルでは:
 ### #515: DB / 保存基盤
 
 - `sleep_sessions` テーブルを上記スキーマで作成する
-- RLS ポリシー: `anon` に SELECT / INSERT / UPDATE / DELETE を許可（既存パターン通り）
+- RLS ポリシー: anon には許可しない。authenticated session で `user_id = auth.uid()` の自分の行だけ SELECT / INSERT / UPDATE / DELETE を許可する
 - `save_sleep_session` RPC または supabase-js 直接 upsert を実装する
   - upsert key: `wake_date`（主睡眠 1件制約を維持）
 - `daily_logs.sleep_hours` を更新する手段を決定する（トリガー推奨）

--- a/src/lib/hooks/useDailyLogs.ts
+++ b/src/lib/hooks/useDailyLogs.ts
@@ -4,7 +4,7 @@
  * ## スコープと制約
  *
  * - このフックは **client component (MealLogger) 専用** であり、Server Components からは使わないこと
- * - `daily_logs` の **全列 full read** を行う（`select("*")`）
+ * - `daily_logs` の **全列 full read** を行う（server-side `/api/client-data` 経由）
  *   - 理由: MealLogger はフォーム hydration に既存ログの全フィールドが必要
  *   - front 側の Server Component ページは `src/lib/queries/dailyLogs.ts` の projection query を使うこと
  * - 保存後は `mutate()` でキャッシュを更新する（revalidatePath ではなく SWR 側で即時反映）
@@ -12,8 +12,10 @@
  *   年単位でデータが蓄積された場合のメモリ・転送量増加を防ぐ。
  *
  * ## full read が許容される理由
- * Client Component がブラウザから直接フォームを操作するため、
- * どの列が編集されるか事前に絞れない。Server Component SSR 側の read 最適化とは別物として扱う。
+ * Client Component がブラウザからフォームを操作するため、
+ * どの列が編集されるか事前に絞れない。DB への read は `/api/client-data` の
+ * server-side Supabase client に寄せ、httpOnly Auth cookie + RLS で owner scoped にする。
+ * Server Component SSR 側の read 最適化とは別物として扱う。
  */
 "use client";
 


### PR DESCRIPTION
## Summary
- Replace old `anon`-open RLS wording in the sleep sessions spec with the current authenticated owner-scoped policy.
- Update daily_logs read inventory to distinguish front-facing authenticated session + RLS reads from service_role ML batch reads.
- Align the project guidance doc with the current Supabase Auth, httpOnly cookie, `/api/client-data`, and RLS setup.

## Issue
Closes #625

## Validation
- `npm run build`
- `npm run lint`