### PR TITLE
許可メールを server-side allowlist に寄せる

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,7 +34,7 @@ jobs:
         env:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
-          NEXT_PUBLIC_ALLOWED_AUTH_EMAIL: ${{ secrets.E2E_AUTH_EMAIL }}
+          ALLOWED_AUTH_EMAIL: ${{ secrets.E2E_AUTH_EMAIL }}
         run: npm run build
 
       - name: Run smoke tests
@@ -42,7 +42,7 @@ jobs:
           CI: true
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
-          NEXT_PUBLIC_ALLOWED_AUTH_EMAIL: ${{ secrets.E2E_AUTH_EMAIL }}
+          ALLOWED_AUTH_EMAIL: ${{ secrets.E2E_AUTH_EMAIL }}
           E2E_REQUIRE_AUTH: ${{ (secrets.E2E_AUTH_EMAIL != '' && secrets.E2E_AUTH_PASSWORD != '') && 'true' || 'false' }}
           E2E_AUTH_EMAIL: ${{ secrets.E2E_AUTH_EMAIL }}
           E2E_AUTH_PASSWORD: ${{ secrets.E2E_AUTH_PASSWORD }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,7 +182,7 @@ body-comp-tracker-v2/
 
 ### 前提: Supabase Auth + RLS による single-user hardening
 - このアプリは個人利用前提だが、外部到達可能なデプロイに備えて Supabase Auth と RLS を導入済み
-- アプリ画面はログイン必須。許可メールは `NEXT_PUBLIC_ALLOWED_AUTH_EMAIL` で制限する
+- アプリ画面はログイン必須。許可メールは server-only `ALLOWED_AUTH_EMAIL` で制限する
 - 主要なユーザー入力データは `user_id = auth.uid()` の owner scoped RLS で保護する
 - anon key は公開可能な Supabase client key として使うが、anon role 単体ではユーザー入力データも派生データも読めない
 - ML / analytics バッチだけが `SUPABASE_SERVICE_ROLE_KEY` を GitHub Secrets 経由で使い、RLS を bypass する

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ ForecastChart（`src/components/charts/ForecastChart.tsx`）は 3 タブ（7日 
 |---|---|
 | `NEXT_PUBLIC_SUPABASE_URL` | E2E 対象 Supabase project |
 | `NEXT_PUBLIC_SUPABASE_ANON_KEY` | E2E 対象 Supabase anon key |
-| `E2E_AUTH_EMAIL` | Supabase Auth の読み取り専用 smoke 用ユーザー。workflow 内で `NEXT_PUBLIC_ALLOWED_AUTH_EMAIL` にも使う |
+| `E2E_AUTH_EMAIL` | Supabase Auth の読み取り専用 smoke 用ユーザー。workflow 内で server-only `ALLOWED_AUTH_EMAIL` にも使う |
 | `E2E_AUTH_PASSWORD` | 上記ユーザーのパスワード |
 
 E2E smoke は書き込み操作を行わない。`E2E_AUTH_EMAIL` は、Supabase Auth に存在し、RLS 適用後の主要画面を読み取れるユーザーにする。
@@ -310,12 +310,12 @@ Client Components のデータ取得も `/api/client-data` 経由で server-side
 
 - Supabase Auth で自分用ユーザーを作成している
 - 公開 signup を無効化するか、invite / 手動作成のみにしている
-- 本番 / preview では `NEXT_PUBLIC_ALLOWED_AUTH_EMAIL` に許可メールを設定している
+- 本番 / preview では server-only `ALLOWED_AUTH_EMAIL` に許可メールを設定している
 - 既存データの `user_id` backfill を完了している
 - `SUPABASE_SERVICE_ROLE_KEY` はサーバー専用（GitHub Secrets / `.env.local`）に限定し、クライアントバンドルに含めない
 
-本番 / preview で `NEXT_PUBLIC_ALLOWED_AUTH_EMAIL` が未設定の場合、Auth gate は fail-closed になり、Supabase Auth ユーザーが存在してもログインを許可しない。
-ローカル開発では未設定でもログイン UI の allowlist 判定を通すが、デプロイ環境では必ず設定する。
+本番 / preview で `ALLOWED_AUTH_EMAIL` が未設定の場合、Auth gate は fail-closed になり、Supabase Auth ユーザーが存在してもログインを許可しない。
+ローカル開発では未設定でも server-side allowlist 判定を通すが、デプロイ環境では必ず設定する。
 
 ### /api/export エンドポイントについて
 
@@ -415,7 +415,7 @@ Vercel などにデプロイする場合は、個人利用でも Supabase Auth +
 主要なユーザー入力テーブルは `user_id = auth.uid()` で owner scoped にし、派生データ系テーブルも authenticated read に限定する。
 そのため anon key だけでは、ユーザー入力データもバッチ生成・分析データも読めない。
 
-初回移行時は Supabase Auth の自分用ユーザーを作成し、`NEXT_PUBLIC_ALLOWED_AUTH_EMAIL` を設定した上で、
+初回移行時は Supabase Auth の自分用ユーザーを作成し、server-only `ALLOWED_AUTH_EMAIL` を設定した上で、
 既存行の `user_id` を owner user id で backfill する。手順は [docs/security-single-user-auth.md](docs/security-single-user-auth.md) を参照。
 
 ### 5. テスト実行（unit tests + UI integration tests）

--- a/docs/security-single-user-auth.md
+++ b/docs/security-single-user-auth.md
@@ -27,12 +27,12 @@
 3. アプリの環境変数に許可メールを設定する。
 
 ```bash
-NEXT_PUBLIC_ALLOWED_AUTH_EMAIL=you@example.com
+ALLOWED_AUTH_EMAIL=you@example.com
 ```
 
-この値はクライアント側のログイン UI と server layout の両方で使う。秘密情報ではない。
+この値は `/api/auth/session` の server-side 検証だけで使う。所有者メールを browser bundle に含めないため、`NEXT_PUBLIC_` では定義しない。
 本番 / preview ではこの値が未設定の場合、Auth gate は fail-closed になり、ログイン済み Supabase Auth ユーザーも許可しない。
-ローカル開発では未設定でも allowlist 判定を通すが、デプロイ環境では必ず設定する。
+ローカル開発では未設定でも server-side allowlist 判定を通すが、デプロイ環境では必ず設定する。
 
 ## Auth cookie
 

--- a/src/app/api/auth/session/route.test.ts
+++ b/src/app/api/auth/session/route.test.ts
@@ -24,10 +24,10 @@ function setCookie(response: Response): string {
 }
 
 describe("POST /api/auth/session", () => {
-  const originalAllowedEmail = process.env.NEXT_PUBLIC_ALLOWED_AUTH_EMAIL;
+  const originalAllowedEmail = process.env.ALLOWED_AUTH_EMAIL;
 
   beforeEach(() => {
-    process.env.NEXT_PUBLIC_ALLOWED_AUTH_EMAIL = "owner@example.com";
+    process.env.ALLOWED_AUTH_EMAIL = "owner@example.com";
     mockGetUser.mockReset();
     mockCreateClient.mockReturnValue({
       auth: {
@@ -40,9 +40,9 @@ describe("POST /api/auth/session", () => {
 
   afterEach(() => {
     if (originalAllowedEmail === undefined) {
-      delete process.env.NEXT_PUBLIC_ALLOWED_AUTH_EMAIL;
+      delete process.env.ALLOWED_AUTH_EMAIL;
     } else {
-      process.env.NEXT_PUBLIC_ALLOWED_AUTH_EMAIL = originalAllowedEmail;
+      process.env.ALLOWED_AUTH_EMAIL = originalAllowedEmail;
     }
   });
 
@@ -96,7 +96,7 @@ describe("POST /api/auth/session", () => {
 
 describe("PATCH /api/auth/session", () => {
   beforeEach(() => {
-    process.env.NEXT_PUBLIC_ALLOWED_AUTH_EMAIL = "owner@example.com";
+    process.env.ALLOWED_AUTH_EMAIL = "owner@example.com";
     mockCreateClient.mockReturnValue({
       auth: {
         getUser: mockGetUser,

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -3,11 +3,6 @@
 import { FormEvent, useState } from "react";
 import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
-import {
-  isAllowedUserEmail,
-  isAuthAllowlistConfigured,
-  isProductionAuthAllowlistRequired,
-} from "@/lib/auth/session";
 import { syncAuthCookie } from "@/lib/auth/browserSession";
 
 export function LoginForm() {
@@ -23,18 +18,6 @@ export function LoginForm() {
     setError(null);
 
     const normalizedEmail = email.trim().toLowerCase();
-    if (isProductionAuthAllowlistRequired() && !isAuthAllowlistConfigured()) {
-      setError("ログイン許可メールが設定されていません。管理者に確認してください。");
-      setSubmitting(false);
-      return;
-    }
-
-    if (!isAllowedUserEmail(normalizedEmail)) {
-      setError("このメールアドレスは許可されていません。");
-      setSubmitting(false);
-      return;
-    }
-
     const supabase = createClient();
     const { data, error: signInError } = await supabase.auth.signInWithPassword({
       email: normalizedEmail,
@@ -49,7 +32,7 @@ export function LoginForm() {
 
     const synced = await syncAuthCookie(data.session);
     if (!synced) {
-      setError("ログインセッションの保存に失敗しました。もう一度ログインしてください。");
+      setError("ログインが許可されていないか、セッションの保存に失敗しました。");
       setSubmitting(false);
       return;
     }

--- a/src/lib/auth/session.test.ts
+++ b/src/lib/auth/session.test.ts
@@ -7,12 +7,10 @@ import {
 
 const originalEnv = {
   NODE_ENV: process.env.NODE_ENV,
-  NEXT_PUBLIC_ALLOWED_AUTH_EMAIL: process.env.NEXT_PUBLIC_ALLOWED_AUTH_EMAIL,
   ALLOWED_AUTH_EMAIL: process.env.ALLOWED_AUTH_EMAIL,
 };
 
 function resetEnv(overrides: Record<string, string | undefined> = {}) {
-  delete process.env.NEXT_PUBLIC_ALLOWED_AUTH_EMAIL;
   delete process.env.ALLOWED_AUTH_EMAIL;
 
   Object.defineProperty(process.env, "NODE_ENV", {
@@ -38,20 +36,11 @@ describe("auth session allowlist", () => {
     resetEnv(originalEnv);
   });
 
-  it("normalizes the configured public allowlist email", () => {
-    resetEnv({ NEXT_PUBLIC_ALLOWED_AUTH_EMAIL: " Owner@Example.COM " });
+  it("normalizes the configured server-side allowlist email", () => {
+    resetEnv({ ALLOWED_AUTH_EMAIL: " Owner@Example.COM " });
 
     expect(getAllowedAuthEmail()).toBe("owner@example.com");
     expect(isAuthAllowlistConfigured()).toBe(true);
-  });
-
-  it("prefers NEXT_PUBLIC_ALLOWED_AUTH_EMAIL over ALLOWED_AUTH_EMAIL", () => {
-    resetEnv({
-      NEXT_PUBLIC_ALLOWED_AUTH_EMAIL: "public@example.com",
-      ALLOWED_AUTH_EMAIL: "server@example.com",
-    });
-
-    expect(getAllowedAuthEmail()).toBe("public@example.com");
   });
 
   it("allows any email in non-production when the allowlist is not configured", () => {
@@ -73,7 +62,7 @@ describe("auth session allowlist", () => {
   it("only allows the configured email in production", () => {
     resetEnv({
       NODE_ENV: "production",
-      NEXT_PUBLIC_ALLOWED_AUTH_EMAIL: "owner@example.com",
+      ALLOWED_AUTH_EMAIL: "owner@example.com",
     });
 
     expect(isAllowedUserEmail(" OWNER@example.com ")).toBe(true);

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -4,7 +4,7 @@ export const AUTH_ACCESS_TOKEN_COOKIE = "bc_auth_access_token";
 export const AUTH_REFRESH_TOKEN_COOKIE = "bc_auth_refresh_token";
 
 export function getAllowedAuthEmail(): string | null {
-  const value = process.env.NEXT_PUBLIC_ALLOWED_AUTH_EMAIL ?? process.env.ALLOWED_AUTH_EMAIL ?? "";
+  const value = process.env.ALLOWED_AUTH_EMAIL ?? "";
   const email = value.trim().toLowerCase();
   return email.length > 0 ? email : null;
 }


### PR DESCRIPTION
## 概要
- LoginForm から許可メールの client-side 判定を削除
- Auth allowlist を server-only `ALLOWED_AUTH_EMAIL` に一本化
- E2E workflow と README / security docs の環境変数説明を更新

## 背景
Issue #637 の通り、`NEXT_PUBLIC_ALLOWED_AUTH_EMAIL` を Client Component から参照すると許可メールアドレスが client bundle に含まれる可能性がありました。実際の認可境界は `/api/auth/session` 側の access token 検証なので、LoginForm では Supabase login と cookie sync だけを行い、許可判定は server-side に寄せています。

## 確認
- `npm test -- --runInBand src/lib/auth/session.test.ts src/app/api/auth/session/route.test.ts`
- `npm run lint`
- `npm test -- --runInBand`
- `npm run build`
- `.next/static` に `NEXT_PUBLIC_ALLOWED_AUTH_EMAIL` / `ALLOWED_AUTH_EMAIL` / 許可メール関連文字列が含まれないことを `rg` で確認

Closes #637