### PR TITLE
Auth refresh 後に layout の認証状態を再同期する

### DIFF
--- a/src/components/auth/AuthSessionSync.integration.test.tsx
+++ b/src/components/auth/AuthSessionSync.integration.test.tsx
@@ -1,0 +1,66 @@
+import { render, waitFor } from "@testing-library/react";
+import { AuthSessionSync } from "./AuthSessionSync";
+import { refreshAuthCookie } from "@/lib/auth/browserSession";
+
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock("@/lib/auth/browserSession", () => ({
+  refreshAuthCookie: jest.fn(),
+}));
+
+import { useRouter } from "next/navigation";
+
+const mockUseRouter = useRouter as jest.Mock;
+const mockRefreshAuthCookie = refreshAuthCookie as jest.MockedFunction<typeof refreshAuthCookie>;
+
+describe("AuthSessionSync", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockUseRouter.mockReturnValue({ refresh: jest.fn() });
+    mockRefreshAuthCookie.mockReset();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it("refreshes the layout after a successful cookie refresh", async () => {
+    const refresh = jest.fn();
+    mockUseRouter.mockReturnValue({ refresh });
+    mockRefreshAuthCookie.mockResolvedValue(true);
+
+    render(<AuthSessionSync />);
+
+    await waitFor(() => expect(refresh).toHaveBeenCalledTimes(1));
+  });
+
+  it("refreshes the layout after a failed cookie refresh so auth state is re-evaluated", async () => {
+    const refresh = jest.fn();
+    mockUseRouter.mockReturnValue({ refresh });
+    mockRefreshAuthCookie.mockResolvedValue(false);
+
+    render(<AuthSessionSync />);
+
+    await waitFor(() => expect(refresh).toHaveBeenCalledTimes(1));
+  });
+
+  it("does not refresh after unmount", async () => {
+    const refresh = jest.fn();
+    mockUseRouter.mockReturnValue({ refresh });
+    let resolveRefresh: (value: boolean) => void = () => {};
+    mockRefreshAuthCookie.mockReturnValue(new Promise<boolean>((resolve) => {
+      resolveRefresh = resolve;
+    }));
+
+    const { unmount } = render(<AuthSessionSync />);
+    unmount();
+    resolveRefresh(false);
+
+    await Promise.resolve();
+
+    expect(refresh).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/auth/AuthSessionSync.tsx
+++ b/src/components/auth/AuthSessionSync.tsx
@@ -10,12 +10,15 @@ export function AuthSessionSync() {
   useEffect(() => {
     let cancelled = false;
 
-    void refreshAuthCookie().then((synced) => {
-      if (synced && !cancelled) router.refresh();
-    });
+    const refreshAndResync = async () => {
+      await refreshAuthCookie();
+      if (!cancelled) router.refresh();
+    };
+
+    void refreshAndResync();
 
     const intervalId = window.setInterval(() => {
-      void refreshAuthCookie();
+      void refreshAndResync();
     }, 10 * 60 * 1000);
 
     return () => {


### PR DESCRIPTION
## 概要
- `AuthSessionSync` で refresh の成否に関係なく `router.refresh()` を実行
- 初回実行・10分ごとの定期 refresh の両方で server-side `getCurrentUser()` を再評価
- refresh 失敗時にも cookie は削除しない既存方針を維持
- 成功時 / 失敗時 / unmount 後の挙動を integration test で追加

## 背景
Issue #638 の通り、refresh token が期限切れ・無効化された場合に `AuthSessionSync` が失敗を無視すると、UI がログイン済み状態のまま残る可能性がありました。`PATCH /api/auth/session` 失敗時に cookie を clear しない multi-tab race 対策は維持しつつ、layout を再評価して認証状態を反映します。

## 確認
- `npm test -- --runInBand src/components/auth/AuthSessionSync.integration.test.tsx src/app/api/auth/session/route.test.ts`
- `npm run lint`
- `npm test -- --runInBand`
- `npm run build`

Closes #638