### PR TITLE
Auth refresh の expires_at fallback を修正する

### DIFF
--- a/src/app/api/auth/session/route.test.ts
+++ b/src/app/api/auth/session/route.test.ts
@@ -132,6 +132,59 @@ describe("PATCH /api/auth/session", () => {
     expect(setCookie(response)).toContain("HttpOnly");
   });
 
+  it("uses expires_in as the access token cookie fallback when expires_at is missing", async () => {
+    const nowSpy = jest.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+    mockRefreshSession.mockResolvedValue({
+      data: {
+        user: { id: "user-id", email: "owner@example.com" },
+        session: {
+          access_token: "new-access-token",
+          refresh_token: "new-refresh-token",
+          expires_in: 1800,
+        },
+      },
+      error: null,
+    });
+    const request = new NextRequest("http://localhost/api/auth/session", {
+      method: "PATCH",
+      headers: { cookie: `${AUTH_REFRESH_TOKEN_COOKIE}=old-refresh-token` },
+    });
+
+    const response = await PATCH(request);
+
+    expect(response.status).toBe(200);
+    expect(setCookie(response)).toContain(`${AUTH_ACCESS_TOKEN_COOKIE}=new-access-token`);
+    expect(setCookie(response)).toContain("Max-Age=1800");
+
+    nowSpy.mockRestore();
+  });
+
+  it("uses a safe default access token cookie fallback when expires_at and expires_in are missing", async () => {
+    const nowSpy = jest.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+    mockRefreshSession.mockResolvedValue({
+      data: {
+        user: { id: "user-id", email: "owner@example.com" },
+        session: {
+          access_token: "new-access-token",
+          refresh_token: "new-refresh-token",
+        },
+      },
+      error: null,
+    });
+    const request = new NextRequest("http://localhost/api/auth/session", {
+      method: "PATCH",
+      headers: { cookie: `${AUTH_REFRESH_TOKEN_COOKIE}=old-refresh-token` },
+    });
+
+    const response = await PATCH(request);
+
+    expect(response.status).toBe(200);
+    expect(setCookie(response)).toContain(`${AUTH_ACCESS_TOKEN_COOKIE}=new-access-token`);
+    expect(setCookie(response)).toContain("Max-Age=3600");
+
+    nowSpy.mockRestore();
+  });
+
   it("does not clear cookies when refresh fails", async () => {
     mockRefreshSession.mockResolvedValue({
       data: { user: null, session: null },

--- a/src/app/api/auth/session/route.ts
+++ b/src/app/api/auth/session/route.ts
@@ -13,6 +13,8 @@ interface SessionCookiePayload {
   refreshToken?: unknown;
 }
 
+const DEFAULT_ACCESS_TOKEN_TTL_SECONDS = 60 * 60;
+
 function clearAuthCookie(response: NextResponse): NextResponse {
   const cookieOptions = {
     httpOnly: true,
@@ -124,7 +126,8 @@ export async function PATCH(request: NextRequest) {
   return setAuthCookie(
     NextResponse.json({ ok: true }),
     data.session.access_token,
-    data.session.expires_at ?? Math.floor(Date.now() / 1000),
+    data.session.expires_at
+      ?? Math.floor(Date.now() / 1000) + (data.session.expires_in ?? DEFAULT_ACCESS_TOKEN_TTL_SECONDS),
     data.session.refresh_token,
   );
 }


### PR DESCRIPTION
## 概要
- refresh 成功時に `session.expires_at` が無い場合、`expires_in` を使って access token cookie の期限を計算
- `expires_at` / `expires_in` がどちらも無い場合は 3600 秒の安全な fallback を使用
- fallback ケースの regression test を追加

## 背景
Issue #641 の通り、従来は `expires_at` が undefined の場合に現在時刻を fallback にしていたため、`setAuthCookie()` の `Max-Age` が 0 になり、access token cookie が即時失効する可能性がありました。

## 確認
- `npm test -- --runInBand src/app/api/auth/session/route.test.ts`
- `npm run lint`
- `npm test -- --runInBand`
- `npm run build`

Closes #641