### PR TITLE
食品・メニュー更新後に /foods を再検証する

### DIFF
--- a/src/app/actions/__tests__/foods.test.ts
+++ b/src/app/actions/__tests__/foods.test.ts
@@ -19,7 +19,13 @@ const mockRevalidateAfterFoodMutation =
 function mockSupabaseAction(error: { message: string } | null = null) {
   const terminal = Promise.resolve({ error });
   let eqCount = 0;
-  const builder = {
+  type MockSupabaseBuilder = {
+    eq: jest.Mock<MockSupabaseBuilder | typeof terminal, []>;
+    insert: jest.Mock<typeof terminal, []>;
+    update: jest.Mock<MockSupabaseBuilder, []>;
+    delete: jest.Mock<MockSupabaseBuilder, []>;
+  };
+  const builder: MockSupabaseBuilder = {
     eq: jest.fn(() => {
       eqCount += 1;
       return eqCount >= 2 ? terminal : builder;

--- a/src/app/actions/__tests__/foods.test.ts
+++ b/src/app/actions/__tests__/foods.test.ts
@@ -1,13 +1,46 @@
+jest.mock("@/lib/cache/revalidate", () => ({
+  revalidateAfterFoodMutation: jest.fn(),
+}));
+
 jest.mock("@/lib/supabase/server", () => ({
   createClient: jest.fn(),
   requireCurrentUser: jest.fn(async () => ({ id: "test-user-id", email: "owner@example.com" })),
 }));
 
 import { deleteFood, deleteMenu, insertFood, insertMenu, updateMenu } from "@/app/actions/foods";
+import { revalidateAfterFoodMutation } from "@/lib/cache/revalidate";
 import { createClient, requireCurrentUser } from "@/lib/supabase/server";
 
 const mockCreateClient = createClient as jest.MockedFunction<typeof createClient>;
 const mockRequireCurrentUser = requireCurrentUser as jest.MockedFunction<typeof requireCurrentUser>;
+const mockRevalidateAfterFoodMutation =
+  revalidateAfterFoodMutation as jest.MockedFunction<typeof revalidateAfterFoodMutation>;
+
+function mockSupabaseAction(error: { message: string } | null = null) {
+  const terminal = Promise.resolve({ error });
+  let eqCount = 0;
+  const builder = {
+    eq: jest.fn(() => {
+      eqCount += 1;
+      return eqCount >= 2 ? terminal : builder;
+    }),
+    insert: jest.fn(() => terminal),
+    update: jest.fn(() => builder),
+    delete: jest.fn(() => builder),
+  };
+  mockCreateClient.mockResolvedValue({
+    from: jest.fn(() => builder),
+  } as never);
+  return builder;
+}
+
+const actions = [
+  ["insertFood", () => insertFood({ name: "鶏むね", calories: 100, protein: 20, fat: 1, carbs: 0 })],
+  ["deleteFood", () => deleteFood("鶏むね")],
+  ["insertMenu", () => insertMenu({ name: "朝食", recipe: [] })],
+  ["updateMenu", () => updateMenu("朝食", { name: "朝食2", recipe: [] })],
+  ["deleteMenu", () => deleteMenu("朝食")],
+] as const;
 
 describe("foods/menu actions — auth_required", () => {
   beforeEach(() => {
@@ -15,17 +48,35 @@ describe("foods/menu actions — auth_required", () => {
     mockRequireCurrentUser.mockRejectedValue(new Error("auth_required"));
   });
 
-  it.each([
-    ["insertFood", () => insertFood({ name: "鶏むね", calories: 100, protein: 20, fat: 1, carbs: 0 })],
-    ["deleteFood", () => deleteFood("鶏むね")],
-    ["insertMenu", () => insertMenu({ name: "朝食", recipe: [] })],
-    ["updateMenu", () => updateMenu("朝食", { name: "朝食2", recipe: [] })],
-    ["deleteMenu", () => deleteMenu("朝食")],
-  ])("%s はログインし直しメッセージとして返す", async (_name, action) => {
+  it.each(actions)("%s はログインし直しメッセージとして返す", async (_name, action) => {
     await expect(action()).resolves.toEqual({
       error: "ログインし直してください",
       reason: "auth_required",
     });
     expect(mockCreateClient).not.toHaveBeenCalled();
+    expect(mockRevalidateAfterFoodMutation).not.toHaveBeenCalled();
+  });
+});
+
+describe("foods/menu actions — revalidate", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRequireCurrentUser.mockResolvedValue({ id: "test-user-id", email: "owner@example.com" } as never);
+  });
+
+  it.each(actions)("%s は成功時に /foods を revalidate する", async (_name, action) => {
+    mockSupabaseAction(null);
+
+    await expect(action()).resolves.toEqual({ error: null });
+
+    expect(mockRevalidateAfterFoodMutation).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(actions)("%s は DB エラー時に revalidate しない", async (_name, action) => {
+    mockSupabaseAction({ message: "db error" });
+
+    await expect(action()).resolves.toEqual({ error: "db error" });
+
+    expect(mockRevalidateAfterFoodMutation).not.toHaveBeenCalled();
   });
 });

--- a/src/app/actions/foods.ts
+++ b/src/app/actions/foods.ts
@@ -2,6 +2,7 @@
 
 import { createClient, requireCurrentUser } from "@/lib/supabase/server";
 import { AUTH_REQUIRED_MESSAGE, isAuthRequiredError } from "@/lib/auth/actionErrors";
+import { revalidateAfterFoodMutation } from "@/lib/cache/revalidate";
 import type { Database, Json } from "@/lib/supabase/types";
 import type { RecipeItem } from "@/lib/supabase/types";
 
@@ -31,6 +32,7 @@ export async function insertFood(payload: FoodMasterInsert): Promise<FoodActionR
 
   const supabase = await createClient();
   const { error } = await supabase.from("food_master").insert({ ...payload, user_id: auth.userId });
+  if (!error) revalidateAfterFoodMutation();
   return { error: error?.message ?? null };
 }
 
@@ -41,6 +43,7 @@ export async function deleteFood(name: string): Promise<FoodActionResult> {
 
   const supabase = await createClient();
   const { error } = await supabase.from("food_master").delete().eq("user_id", auth.userId).eq("name", name);
+  if (!error) revalidateAfterFoodMutation();
   return { error: error?.message ?? null };
 }
 
@@ -58,6 +61,7 @@ export async function insertMenu(payload: {
     name: payload.name,
     recipe: payload.recipe as unknown as Json,
   });
+  if (!error) revalidateAfterFoodMutation();
   return { error: error?.message ?? null };
 }
 
@@ -75,6 +79,7 @@ export async function updateMenu(
     .update({ name: payload.name, recipe: payload.recipe as unknown as Json })
     .eq("user_id", auth.userId)
     .eq("name", originalName);
+  if (!error) revalidateAfterFoodMutation();
   return { error: error?.message ?? null };
 }
 
@@ -85,5 +90,6 @@ export async function deleteMenu(name: string): Promise<FoodActionResult> {
 
   const supabase = await createClient();
   const { error } = await supabase.from("menu_master").delete().eq("user_id", auth.userId).eq("name", name);
+  if (!error) revalidateAfterFoodMutation();
   return { error: error?.message ?? null };
 }

--- a/src/lib/cache/revalidate.ts
+++ b/src/lib/cache/revalidate.ts
@@ -31,6 +31,9 @@
  * forecast backtest 更新:
  *   /forecast-accuracy  fetchLatestRuns / fetchMetrics
  *
+ * food_master / menu_master 更新:
+ *   /foods       fetchFoods / fetchMenus
+ *
  * analytics_cache (enriched_logs) 更新:
  *   /tdee         fetchEnrichedLogs
  *   ※ GitHub Actions の ml-daily バッチは Supabase を直接更新するため、
@@ -70,6 +73,14 @@ export function revalidateAfterSettingsMutation(): void {
  */
 export function revalidateAfterForecastMutation(): void {
   revalidatePath("/forecast-accuracy");
+}
+
+/**
+ * food_master / menu_master への書き込み後に呼ぶ。
+ * 食品データベースページの Server Component 初期値を再検証する。
+ */
+export function revalidateAfterFoodMutation(): void {
+  revalidatePath("/foods");
 }
 
 /**


### PR DESCRIPTION
## 概要
- `revalidateAfterFoodMutation()` を追加し、`/foods` の Server Component 初期値を再検証
- food/menu の insert/update/delete 成功時だけ revalidate を実行
- auth_required / DB エラー時に revalidate しないことをテストで確認

## 背景
Issue #643 の通り、食品マスタ・セットメニューの Server Action 成功後に RSC/router cache へ明示的な再検証が伝わっていませんでした。画面内の local state / SWR mutate は維持しつつ、`/foods` ページの SSR 初期値も更新されるようにします。

## 確認
- `npm test -- --runInBand src/app/actions/__tests__/foods.test.ts`
- `npm run lint`
- `npm test -- --runInBand`
- `npm run build`

Closes #643