### PR TITLE
torch.load patch で pickle_module と mmap を転送する

### DIFF
--- a/ml-pipeline/predict.py
+++ b/ml-pipeline/predict.py
@@ -133,6 +133,38 @@ def build_clean_series(
     return df.loc[mask, ["ds", "y"]].copy()
 
 
+def patch_torch_load_for_neuralprophet(torch_module) -> bool:
+    """torch 2.6+ の weights_only default 変更を NeuralProphet 用に補正する。
+
+    Returns:
+        patch を適用した場合 true。torch 2.5 以下では false。
+    """
+    if tuple(int(x) for x in torch_module.__version__.split(".")[:2]) < (2, 6):
+        return False
+
+    original_torch_load = torch_module.load
+
+    def trusted_load(
+        f,
+        map_location=None,
+        pickle_module=None,
+        weights_only=None,
+        mmap=None,
+        **kw,
+    ):
+        return original_torch_load(
+            f,
+            map_location=map_location,
+            pickle_module=pickle_module,
+            weights_only=False,
+            mmap=mmap,
+            **kw,
+        )
+
+    torch_module.load = trusted_load
+    return True
+
+
 def run_model(df: pd.DataFrame) -> pd.DataFrame:
     """NeuralProphet で予測を実行して予測 DataFrame を返す。
 
@@ -164,13 +196,7 @@ def run_model(df: pd.DataFrame) -> pd.DataFrame:
     # LR-finder checkpoint restore when loading NeuralProphet objects.
     # This pipeline only ever loads checkpoints it wrote itself in the same run (trusted),
     # so overriding weights_only=False is safe here.
-    if tuple(int(x) for x in _torch.__version__.split(".")[:2]) >= (2, 6):
-        _orig_torch_load = _torch.load
-
-        def _trusted_load(f, map_location=None, pickle_module=None, weights_only=None, mmap=None, **kw):
-            return _orig_torch_load(f, map_location=map_location, weights_only=False, **kw)
-
-        _torch.load = _trusted_load
+    patch_torch_load_for_neuralprophet(_torch)
 
     model = NeuralProphet(
         n_lags=0,

--- a/ml-pipeline/test_predict.py
+++ b/ml-pipeline/test_predict.py
@@ -282,6 +282,69 @@ class TestBuildCleanSeries:
         assert _LONG_EVENT_RECOVERY_DAYS == 5
 
 
+# ── torch.load patch のテスト ────────────────────────────────────────────────
+
+class TestTorchLoadPatch:
+    def test_does_not_patch_torch_before_2_6(self):
+        """torch 2.5 以下では monkey patch しない。"""
+        from predict import patch_torch_load_for_neuralprophet
+
+        def load(*_, **__):
+            return "loaded"
+
+        class _Torch:
+            __version__ = "2.5.1"
+
+        torch_module = _Torch()
+        torch_module.load = load
+
+        patched = patch_torch_load_for_neuralprophet(torch_module)
+
+        assert patched is False
+        assert torch_module.load is load
+
+    def test_patch_forwards_pickle_module_and_mmap(self):
+        """torch 2.6+ patch は pickle_module / mmap を元の torch.load に転送する。"""
+        from predict import patch_torch_load_for_neuralprophet
+
+        calls = []
+
+        def load(*args, **kwargs):
+            calls.append((args, kwargs))
+            return "loaded"
+
+        class _Torch:
+            __version__ = "2.6.0"
+
+        torch_module = _Torch()
+        torch_module.load = load
+
+        patched = patch_torch_load_for_neuralprophet(torch_module)
+        result = torch_module.load(
+            "checkpoint.ckpt",
+            map_location="cpu",
+            pickle_module="pickle-module",
+            weights_only=True,
+            mmap=True,
+            extra_arg="extra",
+        )
+
+        assert patched is True
+        assert result == "loaded"
+        assert calls == [
+            (
+                ("checkpoint.ckpt",),
+                {
+                    "map_location": "cpu",
+                    "pickle_module": "pickle-module",
+                    "weights_only": False,
+                    "mmap": True,
+                    "extra_arg": "extra",
+                },
+            )
+        ]
+
+
 # ── record 組み立てロジックのテスト ─────────────────────────────────────────
 
 


### PR DESCRIPTION
## 概要
- NeuralProphet 用 `torch.load` patch を `patch_torch_load_for_neuralprophet()` に切り出し
- `pickle_module` / `mmap` を元の `torch.load` に転送
- `weights_only=False` override の既存方針は維持
- fake torch module で patch の引数転送をテスト

## 背景
Issue #644 の通り、既存 wrapper は `pickle_module` / `mmap` を受け取っていたものの元の `torch.load` に渡していませんでした。現状の NeuralProphet では顕在化していませんが、wrapper として引数透過性を保つため修正しています。

## 確認
- `python -m py_compile ml-pipeline/predict.py`
- `pytest ml-pipeline/test_predict.py -q`
- `pytest ml-pipeline/test_predict.py ml-pipeline/test_backtest.py -q`
- `npm run lint`
- `npm run build`

Closes #644