### PR TITLE
API route の日付パラメータ検証を共通化する

### DIFF
--- a/src/app/api/client-data/route.ts
+++ b/src/app/api/client-data/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient, getCurrentUser } from "@/lib/supabase/server";
+import { isValidDateParam } from "@/lib/utils/date";
 
 const RESOURCES = [
   "daily_logs",
@@ -14,17 +15,6 @@ type ClientDataResource = (typeof RESOURCES)[number];
 
 function isResource(value: string): value is ClientDataResource {
   return (RESOURCES as readonly string[]).includes(value);
-}
-
-function isValidDateParam(value: string): boolean {
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
-  const [year, month, day] = value.split("-").map(Number) as [number, number, number];
-  const date = new Date(year, month - 1, day);
-  return (
-    date.getFullYear() === year &&
-    date.getMonth() + 1 === month &&
-    date.getDate() === day
-  );
 }
 
 export async function GET(request: NextRequest) {

--- a/src/app/api/export/route.test.ts
+++ b/src/app/api/export/route.test.ts
@@ -17,7 +17,8 @@ jest.mock("@/lib/supabase/server", () => ({
 }));
 
 import { NextRequest } from "next/server";
-import { GET, isValidDateParam } from "./route";
+import { isValidDateParam } from "@/lib/utils/date";
+import { GET } from "./route";
 import { createClient } from "@/lib/supabase/server";
 
 const mockCreateClient = createClient as jest.Mock;

--- a/src/app/api/export/route.ts
+++ b/src/app/api/export/route.ts
@@ -8,28 +8,12 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { createClient, getCurrentUser } from "@/lib/supabase/server";
+import { isValidDateParam } from "@/lib/utils/date";
 import { extractJstHHMM } from "@/lib/utils/sleepSession";
 
 // ── バリデーション ────────────────────────────────────────────────────────────
 
 const ALLOWED_TABLES = ["daily_logs", "food_master", "predictions"] as const;
-
-/**
- * 日付パラメータのフォーマット検証。
- *
- * - `YYYY-MM-DD` 形式かつ実在する日付のみ true を返す。
- * - 空文字は呼び出し側で除外してから渡すこと（空文字は false になる）。
- */
-export function isValidDateParam(s: string): boolean {
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(s)) return false;
-  const [y, m, d] = s.split("-").map(Number) as [number, number, number];
-  const date = new Date(y, m - 1, d);
-  return (
-    date.getFullYear() === y &&
-    date.getMonth() + 1 === m &&
-    date.getDate() === d
-  );
-}
 
 function toCSV(rows: Record<string, unknown>[], columns: string[]): string {
   const header = columns.join(",");

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -80,6 +80,16 @@ export function parseLocalDateStr(s: string): Date | null {
 }
 
 /**
+ * API query parameter の日付検証。
+ *
+ * `YYYY-MM-DD` 形式かつ実在する日付のみ true を返す。
+ * 空文字は false。任意パラメータとして扱う場合は呼び出し側でスキップする。
+ */
+export function isValidDateParam(s: string): boolean {
+  return parseLocalDateStr(s) !== null;
+}
+
+/**
  * 2つの YYYY-MM-DD 文字列間のカレンダー日数差を返す（低レベル基盤関数）。
  *
  * 戻り値: (to - from) の日数。


### PR DESCRIPTION
## Summary
- `isValidDateParam` を `src/lib/utils/date.ts` に移動し、既存の `parseLocalDateStr` を再利用
- `/api/export` と `/api/client-data` の重複実装を共通ユーティリティ import に置き換え
- export route の既存テストは共通ユーティリティを参照する形に更新

## Tests
- `npm test -- --runInBand src/app/api/export/route.test.ts src/app/api/client-data/route.test.ts src/lib/utils/date.test.ts`
- `npm run lint`
- `npm run build`

Closes #645