### PR TITLE
Next.js レスポンスに基本セキュリティヘッダーを追加する

### DIFF
--- a/next.config.test.ts
+++ b/next.config.test.ts
@@ -1,0 +1,25 @@
+import nextConfig, { securityHeaders } from "./next.config";
+
+describe("next.config security headers", () => {
+  it("applies security headers to all routes", async () => {
+    const headerRules = await nextConfig.headers?.();
+
+    expect(headerRules).toEqual([
+      {
+        source: "/:path*",
+        headers: securityHeaders,
+      },
+    ]);
+  });
+
+  it("includes the baseline browser security headers", () => {
+    const headers = new Map(securityHeaders.map((header) => [header.key, header.value]));
+
+    expect(headers.get("X-Frame-Options")).toBe("DENY");
+    expect(headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(headers.get("Referrer-Policy")).toBe("strict-origin-when-cross-origin");
+    expect(headers.get("Permissions-Policy")).toContain("camera=()");
+    expect(headers.get("Content-Security-Policy")).toContain("frame-ancestors 'none'");
+    expect(headers.get("Content-Security-Policy")).toContain("connect-src 'self' https://*.supabase.co wss://*.supabase.co");
+  });
+});

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,48 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {};
+export const securityHeaders = [
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  {
+    key: "Permissions-Policy",
+    value: [
+      "camera=()",
+      "microphone=()",
+      "geolocation=()",
+      "payment=()",
+      "usb=()",
+      "fullscreen=(self)",
+    ].join(", "),
+  },
+  {
+    key: "Content-Security-Policy",
+    value: [
+      "default-src 'self'",
+      "base-uri 'self'",
+      "form-action 'self'",
+      "frame-ancestors 'none'",
+      "object-src 'none'",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data: blob:",
+      "font-src 'self' data:",
+      "connect-src 'self' https://*.supabase.co wss://*.supabase.co",
+      "manifest-src 'self'",
+      "worker-src 'self' blob:",
+    ].join("; "),
+  },
+] as const;
+
+const nextConfig: NextConfig = {
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: [...securityHeaders],
+      },
+    ];
+  },
+};
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- `next.config.ts` の `headers()` で全 route に基本 security header を付与
- `X-Frame-Options` / `X-Content-Type-Options` / `Referrer-Policy` / `Permissions-Policy` を追加
- Next.js runtime と Supabase browser auth 通信を考慮した控えめな CSP を追加
- header 設定の軽量テストを追加

## Notes
- CSP は `frame-ancestors 'none'` と `X-Frame-Options: DENY` を併用し、埋め込みを明示的に拒否します
- `connect-src` はログイン時の Supabase browser client 通信のため `https://*.supabase.co` / `wss://*.supabase.co` を許可しています
- `upgrade-insecure-requests` はローカル開発への影響を避けるため未設定です

## Tests
- `npm test -- --runInBand next.config.test.ts`
- `npm run lint`
- `npm run build`
- `npm run start -- -p 3101` + `curl -I 'http://127.0.0.1:3101/api/client-data?resource=daily_logs'`

Closes #648