### PR TITLE
[codex] Fix review follow-up bugs and maintenance notes

### DIFF
--- a/docs/security-single-user-auth.md
+++ b/docs/security-single-user-auth.md
@@ -64,6 +64,24 @@ END $$;
 
 backfill 前は、RLS により既存行がアプリから見えない。これは意図した移行状態。
 
+backfill 後は、以下の確認用 SQL で owner scoped 対象テーブルに `user_id IS NULL` の既存行が残っていないことを確認する。
+この SQL は確認専用で、データは変更しない。
+
+```sql
+SELECT 'daily_logs' AS table_name, COUNT(*) AS null_user_id_count FROM daily_logs WHERE user_id IS NULL
+UNION ALL
+SELECT 'sleep_sessions', COUNT(*) FROM sleep_sessions WHERE user_id IS NULL
+UNION ALL
+SELECT 'settings', COUNT(*) FROM settings WHERE user_id IS NULL
+UNION ALL
+SELECT 'food_master', COUNT(*) FROM food_master WHERE user_id IS NULL
+UNION ALL
+SELECT 'menu_master', COUNT(*) FROM menu_master WHERE user_id IS NULL;
+```
+
+全行の `null_user_id_count` が `0` であれば、既存データの owner backfill は完了している。
+いずれかが `0` 以外の場合、そのテーブルの既存行は RLS によりアプリから見えない可能性がある。
+
 ## 動作確認
 
 - 未ログイン状態でアプリを開くとログイン画面だけが表示される。

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -23,6 +23,8 @@ const eslintConfig = defineConfig([
     "next-env.d.ts",
     "playwright-report/**",
     "test-results/**",
+    ".venv/**",
+    "venv/**",
   ]),
 ]);
 

--- a/ml-pipeline/analyze.py
+++ b/ml-pipeline/analyze.py
@@ -100,23 +100,33 @@ def apply_feature_engineering(
                      ここに分岐を追加すること。
     """
     df = df.copy()
-    df = df.dropna(subset=["weight", "calories", "protein", "fat", "carbs"])
-    df = df.sort_values("log_date").reset_index(drop=True)
+    df["_log_date_dt"] = pd.to_datetime(df["log_date"])
+    df = df.sort_values("_log_date_dt").reset_index(drop=True)
 
-    df["cal_lag1"]      = df["calories"]
-    df["rolling_cal_7"] = df["calories"].rolling(window=7, min_periods=1).mean()
-    df["p_lag1"]        = df["protein"]
-    df["f_lag1"]        = df["fat"]
-    df["c_lag1"]        = df["carbs"]
+    # target は「次の完全入力行」ではなく、カレンダー上の翌日体重との差分に固定する。
+    # 先に欠損行を drop すると欠損日を飛ばして数日後との差分になるため、
+    # raw weight の日付マップから log_date + 1 日の weight を参照する。
+    weight_by_date = df.set_index("_log_date_dt")["weight"]
+    next_dates = df["_log_date_dt"] + pd.Timedelta(days=1)
 
     # ── 目的変数 ─────────────────────────────────────────────────────────────
     if target_type == TargetType.NEXT_DAY_CHANGE:
         # 翌日体重変化量 = weight(t+1) - weight(t)
         # 「翌日体重の絶対値」ではなく「翌日の変化量（増加=正、減少=負）」を予測する。
         # current_weight は説明変数から除外済み（リーケージ回避）。
-        df["target"] = df["weight"].shift(-1) - df["weight"]
+        df["target"] = next_dates.map(weight_by_date) - df["weight"]
     else:
         raise ValueError(f"未実装の target_type: {target_type!r}")
+
+    df = df.dropna(subset=["weight", "calories", "protein", "fat", "carbs"])
+    df = df.drop(columns=["_log_date_dt"])
+    df = df.reset_index(drop=True)
+
+    df["cal_lag1"]      = df["calories"]
+    df["rolling_cal_7"] = df["calories"].rolling(window=7, min_periods=1).mean()
+    df["p_lag1"]        = df["protein"]
+    df["f_lag1"]        = df["fat"]
+    df["c_lag1"]        = df["carbs"]
 
     return df
 

--- a/ml-pipeline/predict.py
+++ b/ml-pipeline/predict.py
@@ -226,6 +226,8 @@ def fetch_daily_logs(client) -> pd.DataFrame:
         .execute()
     )
     df = pd.DataFrame(response.data)
+    if df.empty:
+        return pd.DataFrame(columns=["ds", "y", "is_cheat_day", "is_travel_day"])
     df = df.dropna(subset=["weight"])
     df["ds"] = pd.to_datetime(df["log_date"])
     df["y"] = df["weight"].astype(float)

--- a/ml-pipeline/test_analyze.py
+++ b/ml-pipeline/test_analyze.py
@@ -158,6 +158,20 @@ class TestMissingValueHandling:
 
         assert pd.isna(row_before_missing["target"])
 
+    def test_target_uses_next_calendar_day_when_next_day_features_missing(self):
+        """翌日に weight はあるが特徴量が欠損していても、翌々日ではなく翌日体重との差分を target にする。"""
+        df = _make_df(n=5)
+        df.loc[1, "calories"] = None
+
+        result = apply_feature_engineering(df)
+        row0 = result.loc[result["log_date"] == "2025-01-01"].iloc[0]
+        expected_target = (
+            df.loc[df["log_date"] == "2025-01-02", "weight"].values[0]
+            - df.loc[df["log_date"] == "2025-01-01", "weight"].values[0]
+        )
+
+        assert row0["target"] == pytest.approx(expected_target)
+
 
 # ── 最小行数チェックのテスト ─────────────────────────────────────────────────
 

--- a/ml-pipeline/test_analyze.py
+++ b/ml-pipeline/test_analyze.py
@@ -148,6 +148,16 @@ class TestMissingValueHandling:
         # 欠損のある行（インデックス9がt, 10がt+1だがNaNで除外されたため9の次は11）が除外されている
         assert len(valid) < n - 1
 
+    def test_target_does_not_skip_missing_next_day_to_following_complete_row(self):
+        """翌日が欠損している場合、次の完全入力行との差分を target にしない。"""
+        df = _make_df(n=20)
+        df.loc[10, "weight"] = None
+
+        result = apply_feature_engineering(df)
+        row_before_missing = result.loc[result["log_date"] == "2025-01-10"].iloc[0]
+
+        assert pd.isna(row_before_missing["target"])
+
 
 # ── 最小行数チェックのテスト ─────────────────────────────────────────────────
 

--- a/ml-pipeline/test_predict.py
+++ b/ml-pipeline/test_predict.py
@@ -166,6 +166,15 @@ class TestFetchDailyLogsTransform:
         assert isinstance(df, pd.DataFrame)
         assert len(df) == 0
 
+    def test_empty_response_returns_empty_dataframe_with_expected_columns(self):
+        """daily_logs が完全に空でも KeyError にならず空 DataFrame を返す。"""
+        from predict import fetch_daily_logs
+        client = self._make_mock_client([])
+        df = fetch_daily_logs(client)
+        assert isinstance(df, pd.DataFrame)
+        assert list(df.columns) == ["ds", "y", "is_cheat_day", "is_travel_day"]
+        assert len(df) == 0
+
 
 # ── build_clean_series のテスト ──────────────────────────────────────────────
 

--- a/src/components/meal/MealLogger.integration.test.tsx
+++ b/src/components/meal/MealLogger.integration.test.tsx
@@ -18,6 +18,7 @@
 
 import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import type { DailyLog, SleepSession } from "@/lib/supabase/types";
 
 // ── モック定義 ────────────────────────────────────────────────────────────────
 // jest.mock は jest の babel transform でファイル先頭にホイストされるため、
@@ -33,13 +34,16 @@ jest.mock("@/app/actions/saveSleepSession", () => ({
   deleteSleepSession: jest.fn(async () => ({ ok: true })),
 }));
 
-// SWR フックをモック: 空データ（新規日付 = 既存ログなし）
+let mockDailyLogs: DailyLog[] = [];
+let mockSleepSessions: SleepSession[] = [];
+
+// SWR フックをモック: テストごとに既存ログ有無を切り替える
 jest.mock("@/lib/hooks/useDailyLogs", () => ({
-  useDailyLogs: () => ({ data: [], mutate: jest.fn() }),
+  useDailyLogs: () => ({ data: mockDailyLogs, mutate: jest.fn() }),
 }));
 
 jest.mock("@/lib/hooks/useSleepSessions", () => ({
-  useSleepSessions: () => ({ data: [], mutate: jest.fn() }),
+  useSleepSessions: () => ({ data: mockSleepSessions, mutate: jest.fn() }),
 }));
 
 // Cart と calcCartTotals のモック
@@ -89,6 +93,8 @@ let callOrder: string[] = [];
 
 beforeEach(() => {
   callOrder = [];
+  mockDailyLogs = [];
+  mockSleepSessions = [];
 
   mockSaveDailyLog.mockImplementation(async () => {
     callOrder.push("saveDailyLog");
@@ -146,11 +152,11 @@ describe("MealLogger handleSave — 保存順序 (#528 回帰)", () => {
   });
 
   /**
-   * 睡眠のみ変更（体重などの daily_logs 変更なし）:
-   * saveDailyLog は呼ばれず、saveSleepSession のみ呼ばれることを検証する。
-   * 既存日の場合、sleep_sessions 保存 → DB トリガーで既存行の sleep_hours が更新される。
+   * 新規日付で睡眠のみ変更（体重などの daily_logs 変更なし）:
+   * daily_logs 行がない状態で sleep_sessions だけを作ると sleep_hours 同期が 0 行更新になる。
+   * そのため saveDailyLog / saveSleepSession ともに呼ばず、体重入力を促す。
    */
-  it("睡眠のみ変更のとき saveDailyLog は呼ばれず saveSleepSession のみ呼ばれる", async () => {
+  it("新規日付: 睡眠のみ変更のとき saveDailyLog / saveSleepSession ともに呼ばれない", async () => {
     render(<MealLogger />);
 
     // 就寝時刻のみ入力（daily_logs 変更なし）
@@ -164,10 +170,63 @@ describe("MealLogger handleSave — 保存順序 (#528 回帰)", () => {
     fireEvent.click(saveButton);
 
     await waitFor(() => {
+      const toast = screen.queryByTestId("toast-message");
+      expect(toast).not.toBeNull();
+      expect(toast?.textContent).toContain("体重も入力してください");
+    });
+
+    expect(mockSaveDailyLog).not.toHaveBeenCalled();
+    expect(mockSaveSleepSession).not.toHaveBeenCalled();
+    expect(callOrder).toEqual([]);
+  });
+
+  /**
+   * 既存日付で睡眠のみ変更:
+   * 既に daily_logs 行があるため、saveDailyLog は呼ばず saveSleepSession のみ呼ぶ。
+   */
+  it("既存日付: 睡眠のみ変更のとき saveDailyLog は呼ばれず saveSleepSession のみ呼ばれる", async () => {
+    mockDailyLogs = [{
+      id: "daily-log-2026-04-10",
+      log_date: "2026-04-10",
+      weight: 70,
+      calories: null,
+      protein: null,
+      fat: null,
+      carbs: null,
+      note: null,
+      is_cheat_day: false,
+      is_refeed_day: false,
+      is_eating_out: false,
+      is_travel_day: false,
+      is_tanning_day: false,
+      is_posing_day: false,
+      sleep_hours: null,
+      had_bowel_movement: null,
+      training_type: null,
+      work_mode: null,
+      leg_flag: null,
+      last_meal_end_time: null,
+      step_count: null,
+      created_at: null,
+      updated_at: "2026-04-10T00:00:00.000Z",
+      user_id: null,
+    }];
+
+    render(<MealLogger />);
+
+    const bedTimeInput = screen.getByLabelText(/就寝時刻/);
+    fireEvent.change(bedTimeInput, { target: { value: "22:30" } });
+
+    const wakeTimeInput = screen.getByLabelText(/起床時刻/);
+    fireEvent.change(wakeTimeInput, { target: { value: "06:30" } });
+
+    const saveButton = screen.getByRole("button", { name: /保存/ });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
       expect(mockSaveSleepSession).toHaveBeenCalledTimes(1);
     });
 
-    // daily_logs 変更なし → saveDailyLog は呼ばれない
     expect(mockSaveDailyLog).not.toHaveBeenCalled();
     expect(callOrder).toEqual(["saveSleepSession"]);
   });

--- a/src/components/meal/MealLogger.tsx
+++ b/src/components/meal/MealLogger.tsx
@@ -396,6 +396,20 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
         lastMealEndTimeTouched,
       });
 
+      if (
+        sleepSessionTouched &&
+        !sleepSessionPendingDelete &&
+        !hasDailyLogChanges &&
+        hydratedLog === null &&
+        sleepBedTime &&
+        sleepWakeTime
+      ) {
+        setErrorMessage("新しい日付で睡眠記録を保存するには、体重も入力してください。");
+        setStatus("error");
+        setTimeout(() => { setStatus("idle"); setErrorMessage(""); }, 5000);
+        return;
+      }
+
       if (hasDailyLogChanges) {
         const totals = calcCartTotals(cartItems);
 

--- a/src/components/ui/InsightCard.tsx
+++ b/src/components/ui/InsightCard.tsx
@@ -86,8 +86,8 @@ export function InsightCardList({
   }
   return (
     <div className="space-y-2">
-      {items.map((item, i) => (
-        <InsightCard key={i} item={item} />
+      {items.map((item) => (
+        <InsightCard key={`${item.status}:${item.title}:${item.detail ?? ""}`} item={item} />
       ))}
     </div>
   );

--- a/src/lib/analytics/status.ts
+++ b/src/lib/analytics/status.ts
@@ -19,7 +19,7 @@ export type AnalyticsStatus = "fresh" | "stale" | "unavailable" | "error";
 
 export interface AnalyticsAvailability {
   status: AnalyticsStatus;
-  /** ML バッチ最終実行日 (YYYY-MM-DD)。unavailable / error の場合は null */
+  /** ML バッチ最終実行日 (YYYY-MM-DD、表示用)。unavailable / error の場合は null */
   lastUpdatedDate: string | null;
   /** stale の場合、最新依存データ日からの経過日数 */
   staleDays: number | null;
@@ -41,7 +41,7 @@ export function errorAvailability(): AnalyticsAvailability {
  * analytics_cache エントリの新鮮さを判定する汎用関数。
  *
  * @param cacheUpdatedAt             analytics_cache.updated_at (ISO 8601)。null = バッチ未実行
- * @param latestDependencyUpdatedAt  依存データの最新日 (YYYY-MM-DD)。
+ * @param latestDependencyUpdatedAt  依存データの最新更新日時 (ISO 8601)。
  *                                   null      = 依存データが存在しない（ログ0件の初期状態）→ fresh
  *                                   undefined = 依存データの取得自体が失敗 → unavailable
  *
@@ -49,7 +49,7 @@ export function errorAvailability(): AnalyticsAvailability {
  *   - cacheUpdatedAt が null → unavailable
  *   - latestDependencyUpdatedAt が undefined（取得失敗）→ unavailable
  *   - latestDependencyUpdatedAt が null（依存データなし）→ fresh
- *   - cacheUpdatedAt の日付部分 < latestDependencyUpdatedAt → stale
+ *   - cacheUpdatedAt < latestDependencyUpdatedAt → stale
  *   - それ以外 → fresh
  */
 export function getAnalyticsAvailability(
@@ -90,7 +90,7 @@ export function getAnalyticsAvailability(
 
 /**
  * enriched_logs キャッシュの新鮮さを判定する。
- * 依存: rawLogs の MAX(updated_at) の日付部分 (YYYY-MM-DD)
+ * 依存: rawLogs の MAX(updated_at) (ISO 8601)
  *
  * latestRawLogDate ではなく MAX(updated_at) を使うことで、
  * 過去日の行を編集した場合でも stale を正しく検知できる。
@@ -104,7 +104,7 @@ export function getEnrichedLogsAvailability(
 
 /**
  * xgboost_importance キャッシュの新鮮さを判定する。
- * 依存: rawLogs の MAX(updated_at) の日付部分 (YYYY-MM-DD)
+ * 依存: rawLogs の MAX(updated_at) (ISO 8601)
  *
  * latestRawLogDate ではなく MAX(updated_at) を使うことで、
  * 過去日の行を編集した場合でも stale を正しく検知できる。

--- a/src/lib/utils/calcMonthlyGoalProgress.ts
+++ b/src/lib/utils/calcMonthlyGoalProgress.ts
@@ -150,13 +150,14 @@ function calcMonthlyProgressState(
  * 今月目標に対する進捗を計算する。
  *
  * - #101 の buildMonthlyGoalPlan を使って月次プランを構築し、今月エントリーを取得する
- * - comparisonWeight には GoalNavigator の refWeight (7日平均優先) と同じ値を渡すこと
+ * - comparisonWeight には呼び出し側で選んだ比較体重を渡す
+ *   （Dashboard では最新体重優先で、単日ノイズ込みの実測進捗を見る）
  * - 計画が構築できない場合は hasData: false の fallback を返す (クラッシュしない)
  *
  * @param input.contestDate        - 大会・目標期限 (settings.contestDate)
  * @param input.targetWeight       - 最終目標体重 (settings.targetWeight)
  * @param input.monthlyPlanOverrides - 月次 override リスト (settings.monthlyPlanOverrides)
- * @param input.comparisonWeight   - 比較値 (weight_7d_avg ?? current_weight)
+ * @param input.comparisonWeight   - 今月目標との比較値
  * @param input.today              - 今日の JST 日付 (toJstDateStr() の値)
  * @param input.phase              - "Cut" | "Bulk"
  */


### PR DESCRIPTION
## 概要
レビュー調査で見つかった 5 件の follow-up issue をまとめて修正します。

## 変更内容
- 新規日付で睡眠のみ保存した場合に `sleep_sessions` だけが作られないよう、体重入力を促すガードを追加
- XGBoost 因子分析の target を「次の完全入力行」ではなく `log_date + 1日` の体重差分で算出
- `daily_logs` が空の場合でも予測バッチが空 DataFrame を返して graceful skip できるよう修正
- RLS owner backfill の未実行確認 SQL を docs に追記
- 古い JSDoc / コメントを現行実装に合わせ、`InsightCardList` の index key を複合 key に変更
- ローカル Python 仮想環境が ESLint 対象にならないよう ignore を追加

## 判断理由
既存仕様を維持しつつ、指摘箇所だけを最小差分で修正しています。`daily_logs` 新規作成には体重が必要という仕様は変えず、睡眠だけの孤立保存を防ぐ形にしました。

## 検証結果
- `npm run lint`
- `npx tsc --noEmit`
- `npm test`（70 suites / 1597 tests passed）
- `venv/bin/python -m pytest ml-pipeline`（237 passed）
- `npm run build`

Closes #659
Closes #660
Closes #661
Closes #662
Closes #663