### PR TITLE
MealLogger の日付補完取得とテーマ保存ガードを追加

### DIFF
--- a/src/app/api/client-data/route.test.ts
+++ b/src/app/api/client-data/route.test.ts
@@ -127,6 +127,30 @@ describe("GET /api/client-data", () => {
     expect(body.data).toEqual({ wake_date: "2024-01-01" });
   });
 
+  it("returns null when date-specified sleep session is not found", async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: "user-id", email: "owner@example.com" });
+    const limit = jest.fn().mockReturnValue(queryResult([]));
+    const eq = jest.fn().mockReturnValue({ limit });
+    const select = jest.fn().mockReturnValue({ eq });
+    const from = jest.fn().mockReturnValue({ select });
+    mockCreateClient.mockResolvedValue({ from });
+
+    const response = await GET(makeRequest({ resource: "sleep_sessions", date: "2024-01-01" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data).toBeNull();
+  });
+
+  it("rejects invalid date for date-specified sleep session", async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: "user-id", email: "owner@example.com" });
+    mockCreateClient.mockResolvedValue({ from: jest.fn() });
+
+    const response = await GET(makeRequest({ resource: "sleep_sessions", date: "2024/01/01" }));
+
+    expect(response.status).toBe(400);
+  });
+
   it("validates date range for daily_log_dates", async () => {
     mockGetCurrentUser.mockResolvedValue({ id: "user-id", email: "owner@example.com" });
 

--- a/src/app/api/client-data/route.test.ts
+++ b/src/app/api/client-data/route.test.ts
@@ -65,6 +65,68 @@ describe("GET /api/client-data", () => {
     expect(body.data).toEqual([{ log_date: "2026-04-26" }]);
   });
 
+  it("fetches one daily log when date is specified", async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: "user-id", email: "owner@example.com" });
+    const limit = jest.fn().mockReturnValue(queryResult([{ log_date: "2024-01-01" }]));
+    const eq = jest.fn().mockReturnValue({ limit });
+    const select = jest.fn().mockReturnValue({ eq });
+    const from = jest.fn().mockReturnValue({ select });
+    mockCreateClient.mockResolvedValue({ from });
+
+    const response = await GET(makeRequest({ resource: "daily_logs", date: "2024-01-01" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(from).toHaveBeenCalledWith("daily_logs");
+    expect(select).toHaveBeenCalledWith("*");
+    expect(eq).toHaveBeenCalledWith("log_date", "2024-01-01");
+    expect(limit).toHaveBeenCalledWith(1);
+    expect(body.data).toEqual({ log_date: "2024-01-01" });
+  });
+
+  it("returns null when date-specified daily log is not found", async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: "user-id", email: "owner@example.com" });
+    const limit = jest.fn().mockReturnValue(queryResult([]));
+    const eq = jest.fn().mockReturnValue({ limit });
+    const select = jest.fn().mockReturnValue({ eq });
+    const from = jest.fn().mockReturnValue({ select });
+    mockCreateClient.mockResolvedValue({ from });
+
+    const response = await GET(makeRequest({ resource: "daily_logs", date: "2024-01-01" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data).toBeNull();
+  });
+
+  it("rejects invalid date for date-specified daily log", async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: "user-id", email: "owner@example.com" });
+    mockCreateClient.mockResolvedValue({ from: jest.fn() });
+
+    const response = await GET(makeRequest({ resource: "daily_logs", date: "2024/01/01" }));
+
+    expect(response.status).toBe(400);
+  });
+
+  it("fetches one sleep session when date is specified", async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: "user-id", email: "owner@example.com" });
+    const limit = jest.fn().mockReturnValue(queryResult([{ wake_date: "2024-01-01" }]));
+    const eq = jest.fn().mockReturnValue({ limit });
+    const select = jest.fn().mockReturnValue({ eq });
+    const from = jest.fn().mockReturnValue({ select });
+    mockCreateClient.mockResolvedValue({ from });
+
+    const response = await GET(makeRequest({ resource: "sleep_sessions", date: "2024-01-01" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(from).toHaveBeenCalledWith("sleep_sessions");
+    expect(select).toHaveBeenCalledWith("*");
+    expect(eq).toHaveBeenCalledWith("wake_date", "2024-01-01");
+    expect(limit).toHaveBeenCalledWith(1);
+    expect(body.data).toEqual({ wake_date: "2024-01-01" });
+  });
+
   it("validates date range for daily_log_dates", async () => {
     mockGetCurrentUser.mockResolvedValue({ id: "user-id", email: "owner@example.com" });
 

--- a/src/app/api/client-data/route.ts
+++ b/src/app/api/client-data/route.ts
@@ -31,6 +31,20 @@ export async function GET(request: NextRequest) {
   const supabase = await createClient();
 
   if (resource === "daily_logs") {
+    const date = request.nextUrl.searchParams.get("date") ?? "";
+    if (date) {
+      if (!isValidDateParam(date)) {
+        return NextResponse.json({ error: "Invalid date" }, { status: 400 });
+      }
+      const { data, error } = await supabase
+        .from("daily_logs")
+        .select("*")
+        .eq("log_date", date)
+        .limit(1);
+      if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+      return NextResponse.json({ data: data?.[0] ?? null });
+    }
+
     const { data, error } = await supabase
       .from("daily_logs")
       .select("*")
@@ -41,6 +55,20 @@ export async function GET(request: NextRequest) {
   }
 
   if (resource === "sleep_sessions") {
+    const date = request.nextUrl.searchParams.get("date") ?? "";
+    if (date) {
+      if (!isValidDateParam(date)) {
+        return NextResponse.json({ error: "Invalid date" }, { status: 400 });
+      }
+      const { data, error } = await supabase
+        .from("sleep_sessions")
+        .select("*")
+        .eq("wake_date", date)
+        .limit(1);
+      if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+      return NextResponse.json({ data: data?.[0] ?? null });
+    }
+
     const { data, error } = await supabase
       .from("sleep_sessions")
       .select("*")

--- a/src/components/meal/MealLogger.integration.test.tsx
+++ b/src/components/meal/MealLogger.integration.test.tsx
@@ -36,14 +36,20 @@ jest.mock("@/app/actions/saveSleepSession", () => ({
 
 let mockDailyLogs: DailyLog[] | undefined = [];
 let mockSleepSessions: SleepSession[] | undefined = [];
+let mockDailyLogByDate: DailyLog | null | undefined = null;
+let mockDailyLogByDateLoading = false;
+let mockSleepSessionByDate: SleepSession | null | undefined = null;
+let mockSleepSessionByDateLoading = false;
 
 // SWR フックをモック: テストごとに既存ログ有無を切り替える
 jest.mock("@/lib/hooks/useDailyLogs", () => ({
   useDailyLogs: () => ({ data: mockDailyLogs, mutate: jest.fn() }),
+  useDailyLogByDate: () => ({ data: mockDailyLogByDate, isLoading: mockDailyLogByDateLoading }),
 }));
 
 jest.mock("@/lib/hooks/useSleepSessions", () => ({
   useSleepSessions: () => ({ data: mockSleepSessions, mutate: jest.fn() }),
+  useSleepSessionByDate: () => ({ data: mockSleepSessionByDate, isLoading: mockSleepSessionByDateLoading }),
 }));
 
 // Cart と calcCartTotals のモック
@@ -95,6 +101,10 @@ beforeEach(() => {
   callOrder = [];
   mockDailyLogs = [];
   mockSleepSessions = [];
+  mockDailyLogByDate = null;
+  mockDailyLogByDateLoading = false;
+  mockSleepSessionByDate = null;
+  mockSleepSessionByDateLoading = false;
 
   mockSaveDailyLog.mockImplementation(async () => {
     callOrder.push("saveDailyLog");
@@ -242,6 +252,63 @@ describe("MealLogger handleSave — 保存順序 (#528 回帰)", () => {
     }];
 
     render(<MealLogger />);
+
+    const bedTimeInput = screen.getByLabelText(/就寝時刻/);
+    fireEvent.change(bedTimeInput, { target: { value: "22:30" } });
+
+    const wakeTimeInput = screen.getByLabelText(/起床時刻/);
+    fireEvent.change(wakeTimeInput, { target: { value: "06:30" } });
+
+    const saveButton = screen.getByRole("button", { name: /保存/ });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockSaveSleepSession).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockSaveDailyLog).not.toHaveBeenCalled();
+    expect(callOrder).toEqual(["saveSleepSession"]);
+  });
+
+  /**
+   * 直近 200 件キャッシュ外の日付:
+   * useDailyLogs の一覧に対象日付がなくても、日付指定 fetch で daily_logs 行が見つかれば
+   * 既存日付として扱い、睡眠のみ保存を許可する。
+   */
+  it("直近キャッシュ外の既存日付: 日付指定 daily log があれば睡眠のみ保存できる", async () => {
+    mockDailyLogs = [];
+    mockDailyLogByDate = {
+      id: "old-daily-log-2026-04-10",
+      log_date: "2026-04-10",
+      weight: 70,
+      calories: null,
+      protein: null,
+      fat: null,
+      carbs: null,
+      note: null,
+      is_cheat_day: false,
+      is_refeed_day: false,
+      is_eating_out: false,
+      is_travel_day: false,
+      is_tanning_day: false,
+      is_posing_day: false,
+      sleep_hours: null,
+      had_bowel_movement: null,
+      training_type: null,
+      work_mode: null,
+      leg_flag: null,
+      last_meal_end_time: null,
+      step_count: null,
+      created_at: null,
+      updated_at: "2026-04-10T00:00:00.000Z",
+      user_id: null,
+    };
+
+    render(<MealLogger />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("spinbutton", { name: /体重/ })).toHaveValue(70);
+    });
 
     const bedTimeInput = screen.getByLabelText(/就寝時刻/);
     fireEvent.change(bedTimeInput, { target: { value: "22:30" } });

--- a/src/components/meal/MealLogger.test.ts
+++ b/src/components/meal/MealLogger.test.ts
@@ -253,18 +253,26 @@ describe("buildNoteSaveValue", () => {
 
 describe("hasDailyLogForDate", () => {
   it("hydratedLog が対象日付なら true", () => {
-    expect(hasDailyLogForDate(undefined, { log_date: "2026-04-10" }, "2026-04-10")).toBe(true);
+    expect(hasDailyLogForDate(undefined, { log_date: "2026-04-10" }, undefined, false, "2026-04-10")).toBe(true);
   });
 
   it("logs が未ロードで hydratedLog もなければ null", () => {
-    expect(hasDailyLogForDate(undefined, null, "2026-04-10")).toBeNull();
+    expect(hasDailyLogForDate(undefined, null, undefined, false, "2026-04-10")).toBeNull();
   });
 
   it("logs に対象日付があれば true", () => {
-    expect(hasDailyLogForDate([{ log_date: "2026-04-10" }], null, "2026-04-10")).toBe(true);
+    expect(hasDailyLogForDate([{ log_date: "2026-04-10" }], null, undefined, false, "2026-04-10")).toBe(true);
+  });
+
+  it("日付指定 fetch の結果に対象日付があれば true", () => {
+    expect(hasDailyLogForDate([], null, { log_date: "2026-04-10" }, false, "2026-04-10")).toBe(true);
+  });
+
+  it("日付指定 fetch 中なら null", () => {
+    expect(hasDailyLogForDate([], null, undefined, true, "2026-04-10")).toBeNull();
   });
 
   it("logs がロード済みで対象日付がなければ false", () => {
-    expect(hasDailyLogForDate([{ log_date: "2026-04-09" }], null, "2026-04-10")).toBe(false);
+    expect(hasDailyLogForDate([{ log_date: "2026-04-09" }], null, null, false, "2026-04-10")).toBe(false);
   });
 });

--- a/src/components/meal/MealLogger.tsx
+++ b/src/components/meal/MealLogger.tsx
@@ -25,8 +25,8 @@ import {
   type TrainingType,
   type WorkMode,
 } from "@/lib/utils/trainingType";
-import { useDailyLogs } from "@/lib/hooks/useDailyLogs";
-import { useSleepSessions } from "@/lib/hooks/useSleepSessions";
+import { useDailyLogByDate, useDailyLogs } from "@/lib/hooks/useDailyLogs";
+import { useSleepSessionByDate, useSleepSessions } from "@/lib/hooks/useSleepSessions";
 import { parseStrictNumber } from "@/lib/utils/parseNumber";
 import { buildSleepSessionDatetimes, calcSleepDurationHours, extractJstHHMM } from "@/lib/utils/sleepSession";
 
@@ -95,11 +95,20 @@ export function computeHasDailyLogChanges(input: HasContentInput): boolean {
 export function hasDailyLogForDate(
   logs: Pick<DailyLog, "log_date">[] | undefined,
   hydratedLog: Pick<DailyLog, "log_date"> | null,
+  fetchedLog: Pick<DailyLog, "log_date"> | null | undefined,
+  isFetchingByDate: boolean,
   date: string
 ): boolean | null {
   if (hydratedLog?.log_date === date) return true;
-  if (logs === undefined) return null;
-  return logs.some((log) => log.log_date === date);
+  if (logs?.some((log) => log.log_date === date)) return true;
+  if (fetchedLog?.log_date === date) return true;
+  if (logs === undefined || isFetchingByDate) return null;
+  if (fetchedLog === null) return false;
+  return false;
+}
+
+function formIsPristine(input: HasContentInput): boolean {
+  return !computeHasContent(input);
 }
 
 /**
@@ -189,18 +198,37 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
   // 食品を追加セクションの開閉状態（初期: 非表示）
   const [foodPickerOpen, setFoodPickerOpen] = useState(false);
 
+  const cachedDailyLog = useMemo(
+    () => logs?.find((l) => l.log_date === date) ?? null,
+    [logs, date]
+  );
+  const shouldFetchDailyLogByDate = date !== "" && logs !== undefined && cachedDailyLog === null;
+  const {
+    data: fetchedDailyLog,
+    isLoading: isDailyLogByDateLoading,
+  } = useDailyLogByDate(date, shouldFetchDailyLogByDate);
+
+  const cachedSleepSession = useMemo(
+    () => sleepSessions?.find((s) => s.wake_date === date) ?? null,
+    [sleepSessions, date]
+  );
+  const shouldFetchSleepSessionByDate = date !== "" && sleepSessions !== undefined && cachedSleepSession === null;
+  const {
+    data: fetchedSleepSession,
+    isLoading: isSleepSessionByDateLoading,
+  } = useSleepSessionByDate(date, shouldFetchSleepSessionByDate);
+
   /**
    * 日付変更時にフォームを hydrate または空リセットする。
    * hydrate = 既存値の「初期表示」であり、touched フラグは立てない。
    * つまり hydrate 後に Save しても、ユーザーが操作していないフィールドは
    * payload に含まれず、partial update の安全性を維持する。
    */
-  function hydrateForm(newDate: string) {
-    const existingLog = logs?.find((l) => l.log_date === newDate) ?? null;
+  function applyHydratedValues(
+    existingLog: DailyLog | null,
+    existingSleep: SleepSession | null
+  ) {
     setHydratedLog(existingLog);
-
-    // 睡眠セッション: sleep_sessions が source of truth
-    const existingSleep = sleepSessions?.find((s) => s.wake_date === newDate) ?? null;
     setHydratedSleepSession(existingSleep);
 
     // touched フラグをすべてリセット（hydrate は「未編集」として扱う）
@@ -258,6 +286,13 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
     }
   }
 
+  function hydrateForm(newDate: string) {
+    const existingLog = logs?.find((l) => l.log_date === newDate) ?? null;
+    // 睡眠セッション: sleep_sessions が source of truth
+    const existingSleep = sleepSessions?.find((s) => s.wake_date === newDate) ?? null;
+    applyHydratedValues(existingLog, existingSleep);
+  }
+
   function handleDateChange(newDate: string) {
     setDate(newDate);
     hydrateForm(newDate);
@@ -296,6 +331,37 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
     // date: 初回ロード時点の selectedDate で固定するため除外。
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [logs, sleepSessions]);
+
+  useEffect(() => {
+    if (!shouldFetchDailyLogByDate && !shouldFetchSleepSessionByDate) return;
+    if (isDailyLogByDateLoading || isSleepSessionByDateLoading) return;
+    if (shouldFetchDailyLogByDate && fetchedDailyLog === undefined) return;
+    if (shouldFetchSleepSessionByDate && fetchedSleepSession === undefined) return;
+    if (!formIsPristine({
+      weight, weightTouched, cartItems, cartEverHadItems,
+      note, noteTouched, touchedTags,
+      sleepSessionTouched,
+      hadBowelMovementTouched, trainingTypeTouched, workModeTouched,
+      lastMealEndTimeTouched,
+    })) return;
+
+    applyHydratedValues(
+      cachedDailyLog ?? fetchedDailyLog ?? null,
+      cachedSleepSession ?? fetchedSleepSession ?? null
+    );
+    // 日付指定 fetch が後から返ったときだけ、未操作フォームへ反映する。
+    // touched 系を deps に含めるとユーザー操作ごとに再評価されるため、スナップショットとして読む。
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    shouldFetchDailyLogByDate,
+    shouldFetchSleepSessionByDate,
+    isDailyLogByDateLoading,
+    isSleepSessionByDateLoading,
+    fetchedDailyLog,
+    fetchedSleepSession,
+    cachedDailyLog,
+    cachedSleepSession,
+  ]);
 
   function toggleTag(tag: DayTag) {
     setTags((prev) => ({ ...prev, [tag]: !(prev as Record<DayTag, boolean>)[tag] }));
@@ -406,7 +472,13 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
         lastMealEndTimeTouched,
       });
 
-      const existingDailyLog = hasDailyLogForDate(logs, hydratedLog, date);
+      const existingDailyLog = hasDailyLogForDate(
+        logs,
+        hydratedLog,
+        fetchedDailyLog,
+        isDailyLogByDateLoading,
+        date
+      );
       if (
         sleepSessionTouched &&
         !sleepSessionPendingDelete &&

--- a/src/components/meal/MealLogger.tsx
+++ b/src/components/meal/MealLogger.tsx
@@ -103,7 +103,6 @@ export function hasDailyLogForDate(
   if (logs?.some((log) => log.log_date === date)) return true;
   if (fetchedLog?.log_date === date) return true;
   if (logs === undefined || isFetchingByDate) return null;
-  if (fetchedLog === null) return false;
   return false;
 }
 
@@ -350,6 +349,7 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
       cachedSleepSession ?? fetchedSleepSession ?? null
     );
     // 日付指定 fetch が後から返ったときだけ、未操作フォームへ反映する。
+    // SWR 再検証で再実行されても、未操作フォームなら最新の補完値へ同期してよい。
     // touched 系を deps に含めるとユーザー操作ごとに再評価されるため、スナップショットとして読む。
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [

--- a/src/lib/hooks/useDailyLogs.ts
+++ b/src/lib/hooks/useDailyLogs.ts
@@ -10,6 +10,7 @@
  * - 保存後は `mutate()` でキャッシュを更新する（revalidatePath ではなく SWR 側で即時反映）
  * - 件数上限: 直近 200 件（降順）。MealLogger の hydration 用途では十分な範囲。
  *   年単位でデータが蓄積された場合のメモリ・転送量増加を防ぐ。
+ * - 直近 200 件外の日付を手入力した場合は、useDailyLogByDate() で対象日付のみ補完取得する。
  *
  * ## full read が許容される理由
  * Client Component がブラウザからフォームを操作するため、
@@ -27,9 +28,26 @@ async function fetchDailyLogs(): Promise<DailyLog[]> {
   return fetchClientData<DailyLog[]>("/api/client-data?resource=daily_logs");
 }
 
+async function fetchDailyLogByDate(date: string): Promise<DailyLog | null> {
+  return fetchClientData<DailyLog | null>(
+    `/api/client-data?resource=daily_logs&date=${encodeURIComponent(date)}`
+  );
+}
+
 export function useDailyLogs() {
   return useSWR<DailyLog[]>("daily_logs", fetchDailyLogs, {
     revalidateOnFocus: false,
     dedupingInterval: 60_000,
   });
+}
+
+export function useDailyLogByDate(date: string, enabled: boolean) {
+  return useSWR<DailyLog | null>(
+    enabled ? ["daily_log_by_date", date] : null,
+    () => fetchDailyLogByDate(date),
+    {
+      revalidateOnFocus: false,
+      dedupingInterval: 60_000,
+    }
+  );
 }

--- a/src/lib/hooks/useSleepSessions.ts
+++ b/src/lib/hooks/useSleepSessions.ts
@@ -5,6 +5,7 @@
  * useDailyLogs と同じパターンで実装。
  *
  * - 件数上限: 直近 200 件（MealLogger の hydration 用途では十分な範囲）
+ * - 直近 200 件外の日付を手入力した場合は、useSleepSessionByDate() で対象日付のみ補完取得する
  * - 保存後は mutate() でキャッシュを更新する
  */
 "use client";
@@ -17,9 +18,26 @@ async function fetchRecentSleepSessions(): Promise<SleepSession[]> {
   return fetchClientData<SleepSession[]>("/api/client-data?resource=sleep_sessions");
 }
 
+async function fetchSleepSessionByDate(date: string): Promise<SleepSession | null> {
+  return fetchClientData<SleepSession | null>(
+    `/api/client-data?resource=sleep_sessions&date=${encodeURIComponent(date)}`
+  );
+}
+
 export function useSleepSessions() {
   return useSWR<SleepSession[]>("sleep_sessions", fetchRecentSleepSessions, {
     revalidateOnFocus: false,
     dedupingInterval: 60_000,
   });
+}
+
+export function useSleepSessionByDate(date: string, enabled: boolean) {
+  return useSWR<SleepSession | null>(
+    enabled ? ["sleep_session_by_date", date] : null,
+    () => fetchSleepSessionByDate(date),
+    {
+      revalidateOnFocus: false,
+      dedupingInterval: 60_000,
+    }
+  );
 }

--- a/src/lib/hooks/useTheme.integration.test.tsx
+++ b/src/lib/hooks/useTheme.integration.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { isTheme, useTheme } from "./useTheme";
+
+function ThemeProbe() {
+  const { theme, setTheme } = useTheme();
+  return (
+    <div>
+      <span data-testid="theme-value">{theme}</span>
+      <button type="button" onClick={() => setTheme("dark")}>dark</button>
+    </div>
+  );
+}
+
+describe("isTheme", () => {
+  it("valid theme values return true", () => {
+    expect(isTheme("light")).toBe(true);
+    expect(isTheme("dark")).toBe(true);
+    expect(isTheme("system")).toBe(true);
+  });
+
+  it("invalid values return false", () => {
+    expect(isTheme("foo")).toBe(false);
+    expect(isTheme(null)).toBe(false);
+  });
+});
+
+describe("useTheme", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove("dark");
+    jest.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("falls back to system when stored value is invalid", () => {
+    localStorage.setItem("theme", "foo");
+
+    render(<ThemeProbe />);
+
+    expect(screen.getByTestId("theme-value")).toHaveTextContent("system");
+  });
+
+  it("does not crash when localStorage.getItem throws", () => {
+    jest.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("storage unavailable");
+    });
+
+    render(<ThemeProbe />);
+
+    expect(screen.getByTestId("theme-value")).toHaveTextContent("system");
+  });
+
+  it("updates state and DOM even when localStorage.setItem throws", () => {
+    jest.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("quota exceeded");
+    });
+
+    render(<ThemeProbe />);
+    fireEvent.click(screen.getByRole("button", { name: "dark" }));
+
+    expect(screen.getByTestId("theme-value")).toHaveTextContent("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+});

--- a/src/lib/hooks/useTheme.ts
+++ b/src/lib/hooks/useTheme.ts
@@ -21,6 +21,28 @@ export type Theme = "light" | "dark" | "system";
 
 export const THEME_STORAGE_KEY = "theme";
 
+export function isTheme(value: unknown): value is Theme {
+  return value === "light" || value === "dark" || value === "system";
+}
+
+function readStoredTheme(): Theme {
+  if (typeof window === "undefined") return "system";
+  try {
+    const stored = localStorage.getItem(THEME_STORAGE_KEY);
+    return isTheme(stored) ? stored : "system";
+  } catch {
+    return "system";
+  }
+}
+
+function writeStoredTheme(theme: Theme): void {
+  try {
+    localStorage.setItem(THEME_STORAGE_KEY, theme);
+  } catch {
+    // localStorage が使えない環境でも state と DOM 反映は継続する。
+  }
+}
+
 function applyTheme(theme: Theme): void {
   const isDark =
     theme === "dark" ||
@@ -32,10 +54,7 @@ function applyTheme(theme: Theme): void {
 }
 
 export function useTheme(): { theme: Theme; setTheme: (t: Theme) => void } {
-  const [theme, setThemeState] = useState<Theme>(() => {
-    if (typeof window === "undefined") return "system";
-    return (localStorage.getItem(THEME_STORAGE_KEY) as Theme) ?? "system";
-  });
+  const [theme, setThemeState] = useState<Theme>(() => readStoredTheme());
 
   // system モード時: prefers-color-scheme の変化を監視して html.dark を更新する
   useEffect(() => {
@@ -49,7 +68,7 @@ export function useTheme(): { theme: Theme; setTheme: (t: Theme) => void } {
   }, [theme]);
 
   function setTheme(t: Theme): void {
-    localStorage.setItem(THEME_STORAGE_KEY, t);
+    writeStoredTheme(t);
     setThemeState(t);
     applyTheme(t);
   }


### PR DESCRIPTION
## 概要
調査で見つかった 2 件を Issue 化し、最小差分で対応しました。

Closes #669
Closes #670

## 変更内容
- `/api/client-data` に `daily_logs` / `sleep_sessions` の `date` 指定取得を追加
- MealLogger で直近 200 件キャッシュにない対象日付を、単発 fetch で補完 hydrate するように変更
- 直近キャッシュ外の既存 daily log 日付でも、睡眠だけ保存を既存日付として許可できるように変更
- `useTheme` に theme 値の type guard と localStorage get/set の例外防御を追加
- MealLogger / client-data / useTheme の回帰テストを追加

## 判断理由
- MealLogger の通常キャッシュは直近 200 件に制限したまま、古い日付だけ単発取得することで転送量増加を避けています。
- sleep_sessions も同じ 200 件制限を持つため、古い日付で睡眠時刻の初期表示が欠けないよう同時に補完取得対象にしました。
- localStorage が使えない環境でも、テーマの React state と DOM 反映は継続するようにしています。

## 検証結果
- `npm test -- MealLogger`: 3 suites / 66 tests passed
- `npm test -- client-data`: 8 tests passed
- `npm test -- useTheme`: 5 tests passed
- `npx tsc --noEmit`: passed
- `npm run lint`: passed
- `npm test`: 71 suites / 1614 tests passed
- `venv/bin/python -m pytest ml-pipeline`: 238 passed
- `npm run build`: passed

## 補足
- DB スキーマは変更していません。
- FOUC 防止用 inline script の仕様変更は #670 のスコープ外として触っていません。