### PR TITLE
E2E Smoke Tests の Playwright browser install を安定化する

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,19 +27,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
-
-      - name: Install Playwright browser dependencies
-        run: npx playwright install-deps chromium-headless-shell
-
-      - name: Install Playwright browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --only-shell chromium
+      - name: Verify system Chrome
+        run: google-chrome --version
 
       - name: Build
         env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,8 +27,19 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Playwright browser dependencies
+        run: npx playwright install-deps chromium-headless-shell
+
       - name: Install Playwright browsers
-        run: npx playwright install chromium --with-deps
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --only-shell chromium
 
       - name: Build
         env:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,7 +26,10 @@ export default defineConfig({
   projects: [
     {
       name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
+      use: {
+        ...devices["Desktop Chrome"],
+        channel: process.env.CI ? "chrome" : undefined,
+      },
     },
   ],
   webServer: {


### PR DESCRIPTION
## 概要
- E2E Smoke Tests で Playwright browser download/install を行わない構成にしました。
- CI では GitHub-hosted runner に入っている system Chrome を使うようにしました。
- E2E test case や secrets 条件は変更していません。

## 判断理由
- 提示ログでは `npx playwright install chromium --with-deps` が Chrome download 100% 後に進まない状態でした。
- 初回修正で `--only-shell` と cache 化を試しましたが、PR #678 の CI でも `Install Playwright browsers` が in_progress のままになりました。
- そのため browser download/install 自体を workflow から外し、Playwright config で CI 時のみ `channel: "chrome"` を指定して system Chrome を使う方針に切り替えました。
- `Verify system Chrome` step を追加し、runner 側で Chrome が使えることを smoke test 前に明示確認します。

## 変更内容
- `.github/workflows/e2e.yml`
  - Playwright browser install step を削除。
  - `google-chrome --version` による system Chrome 確認 step を追加。
- `playwright.config.ts`
  - CI 時のみ `channel: "chrome"` を指定。
  - ローカル実行は従来通り Playwright の default Chromium を使う。

## 検証結果
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/e2e.yml"); puts "ok"'`: 成功
- `CI=true npx playwright test e2e/smoke.spec.ts --list`: 成功。10 tests を確認
- `git diff --check`: 成功
- GitHub Actions / PR #678
  - `e2e-smoke`: pass（1m13s）
  - `lint-typecheck-build`: pass
  - `python-test`: pass
  - CodeQL / Vercel も pass

## 補足
- `gh auth status` は権限付き実行で再認証済みを確認しました。
- 旧コミットの E2E run では browser install step が stuck していましたが、最新コミットでは browser install step 自体を通らず smoke test まで完了しています。

Closes #677