### PR TITLE
ws Uninitialized memory disclosure advisory に対応する

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11485,9 +11485,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
## 概要
- `ws` の transitive dependency を `8.19.0` から `8.21.0` に更新しました。
- 変更は `package-lock.json` の lockfile 解決先のみです。
- `ws` は直接依存に追加していません。

## 判断理由
- GitHub Advisory Database の GHSA-58qx-3vcg-4xpx / CVE-2026-45736 では、影響範囲が `ws >= 8.0.0 < 8.20.1`、patched version が `8.20.1` です。
- 現状は `ws@8.19.0` で影響範囲内でした。
- 既存の依存範囲 `^8.18.x` のまま `8.21.0` に解決できるため、上位 dependency の更新や直接依存追加は不要と判断しました。

## 変更内容
- `package-lock.json`
  - `node_modules/ws` を `8.21.0` に更新。

## 検証結果
- `npm audit --omit=dev --audit-level=moderate`: 成功、`found 0 vulnerabilities`
- `npm run build`: 成功
- `npm test -- --runInBand`: 成功、71 suites / 1604 tests passed
- `git diff --check`: 成功
- `npm explain ws`: `ws@8.21.0` を確認

## 補足
- `npm test` 実行時に既存の Node warning `--localstorage-file was provided without a valid path` が出ましたが、テストは全件成功しています。

Closes #679