### PR TITLE
[codex] Add Google Health daily metrics table

### DIFF
--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -140,6 +140,65 @@ export type Database = {
         }
         Relationships: []
       }
+      google_health_daily_metrics: {
+        Row: {
+          created_at: string
+          deep_sleep_minutes: number | null
+          google_health_steps_source: string | null
+          hrv_ms: number | null
+          id: string
+          metric_date: string
+          rhr_bpm: number | null
+          sleep_bed_at: string | null
+          sleep_minutes: number | null
+          sleep_wake_at: string | null
+          step_count: number | null
+          synced_at: string | null
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          deep_sleep_minutes?: number | null
+          google_health_steps_source?: string | null
+          hrv_ms?: number | null
+          id?: string
+          metric_date: string
+          rhr_bpm?: number | null
+          sleep_bed_at?: string | null
+          sleep_minutes?: number | null
+          sleep_wake_at?: string | null
+          step_count?: number | null
+          synced_at?: string | null
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          deep_sleep_minutes?: number | null
+          google_health_steps_source?: string | null
+          hrv_ms?: number | null
+          id?: string
+          metric_date?: string
+          rhr_bpm?: number | null
+          sleep_bed_at?: string | null
+          sleep_minutes?: number | null
+          sleep_wake_at?: string | null
+          step_count?: number | null
+          synced_at?: string | null
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "fk_google_health_daily_metrics_daily_logs"
+            columns: ["user_id", "metric_date"]
+            isOneToOne: true
+            referencedRelation: "daily_logs"
+            referencedColumns: ["user_id", "log_date"]
+          },
+        ]
+      }
       food_master: {
         Row: {
           calories: number | null
@@ -611,6 +670,7 @@ export type MacroDailyLog = Pick<DailyLog, "log_date" | "weight" | "calories" | 
  */
 export type TdeeDailyLog = Pick<DailyLog, "log_date" | "weight" | "calories">;
 
+export type GoogleHealthDailyMetricRow = Database["public"]["Tables"]["google_health_daily_metrics"]["Row"];
 export type SleepSession = Database["public"]["Tables"]["sleep_sessions"]["Row"];
 
 export type FoodMaster  = Database["public"]["Tables"]["food_master"]["Row"];

--- a/supabase/migrations/20260605000000_create_google_health_daily_metrics.sql
+++ b/supabase/migrations/20260605000000_create_google_health_daily_metrics.sql
@@ -1,0 +1,142 @@
+-- Google Health 日次メトリクス保存テーブルを作成する (#690)
+--
+-- 目的:
+--   Google Health 由来の歩数・睡眠・HRV・安静時心拍数を daily_logs から分離し、
+--   daily_logs を親、google_health_daily_metrics を子テーブルとして保存する。
+--
+-- 設計:
+--   - 1行 = 1ユーザー・1日分の Google Health 日次メトリクス
+--   - metric_date は daily_logs.log_date と同じ日付軸
+--   - daily_logs が存在する日のみ保存できるよう、(user_id, metric_date) で FK を張る
+--   - step_source / sleep_source は持たない。歩数・睡眠系データは Google Health 管理に寄せる
+--
+-- 旧 daily_logs.step_count / daily_logs.sleep_hours / sleep_sessions の削除は、
+-- 保存・表示切り替え後の後続 Issue で扱う。
+
+-- ── daily_logs 側の FK 参照前提 ───────────────────────────────────────────────
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+      FROM pg_constraint
+     WHERE conname = 'uq_daily_logs_user_id_log_date'
+       AND conrelid = 'daily_logs'::regclass
+  ) THEN
+    ALTER TABLE daily_logs
+      ADD CONSTRAINT uq_daily_logs_user_id_log_date UNIQUE (user_id, log_date);
+  END IF;
+END $$;
+
+COMMENT ON CONSTRAINT uq_daily_logs_user_id_log_date ON daily_logs IS
+  'google_health_daily_metrics から (user_id, metric_date) で daily_logs を参照するための一意制約。';
+
+-- ── テーブル作成 ───────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS google_health_daily_metrics (
+  id                         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id                    UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  metric_date                DATE        NOT NULL,
+  step_count                 INTEGER,
+  sleep_minutes              INTEGER,
+  deep_sleep_minutes         INTEGER,
+  sleep_bed_at               TIMESTAMPTZ,
+  sleep_wake_at              TIMESTAMPTZ,
+  hrv_ms                     NUMERIC,
+  rhr_bpm                    NUMERIC,
+  google_health_steps_source TEXT,
+  synced_at                  TIMESTAMPTZ,
+  created_at                 TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at                 TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT uq_google_health_daily_metrics_user_date
+    UNIQUE (user_id, metric_date),
+  CONSTRAINT fk_google_health_daily_metrics_daily_logs
+    FOREIGN KEY (user_id, metric_date)
+    REFERENCES daily_logs(user_id, log_date)
+    ON DELETE CASCADE,
+  CONSTRAINT chk_google_health_daily_metrics_step_count
+    CHECK (step_count IS NULL OR step_count >= 0),
+  CONSTRAINT chk_google_health_daily_metrics_sleep_minutes
+    CHECK (sleep_minutes IS NULL OR sleep_minutes >= 0),
+  CONSTRAINT chk_google_health_daily_metrics_deep_sleep_minutes
+    CHECK (deep_sleep_minutes IS NULL OR deep_sleep_minutes >= 0),
+  CONSTRAINT chk_google_health_daily_metrics_deep_sleep_lte_sleep
+    CHECK (
+      deep_sleep_minutes IS NULL
+      OR sleep_minutes IS NULL
+      OR deep_sleep_minutes <= sleep_minutes
+    ),
+  CONSTRAINT chk_google_health_daily_metrics_sleep_interval
+    CHECK (
+      sleep_bed_at IS NULL
+      OR sleep_wake_at IS NULL
+      OR sleep_bed_at < sleep_wake_at
+    ),
+  CONSTRAINT chk_google_health_daily_metrics_hrv_ms
+    CHECK (hrv_ms IS NULL OR hrv_ms >= 0),
+  CONSTRAINT chk_google_health_daily_metrics_rhr_bpm
+    CHECK (rhr_bpm IS NULL OR rhr_bpm >= 0),
+  CONSTRAINT chk_google_health_daily_metrics_steps_source
+    CHECK (
+      google_health_steps_source IS NULL
+      OR google_health_steps_source IN ('reconcile', 'dailyRollUp', 'listFallback')
+    )
+);
+
+COMMENT ON TABLE google_health_daily_metrics IS
+  'Google Health 由来の日次メトリクス。daily_logs を親とし、1ユーザー・1日につき1行で保存する。';
+COMMENT ON COLUMN google_health_daily_metrics.id IS 'UUID PK。';
+COMMENT ON COLUMN google_health_daily_metrics.user_id IS 'Owner Supabase auth.users.id。';
+COMMENT ON COLUMN google_health_daily_metrics.metric_date IS '日次キー。daily_logs.log_date に対応する。';
+COMMENT ON COLUMN google_health_daily_metrics.step_count IS 'Google Health 由来の歩数。';
+COMMENT ON COLUMN google_health_daily_metrics.sleep_minutes IS 'Google Health 由来の睡眠時間（分）。';
+COMMENT ON COLUMN google_health_daily_metrics.deep_sleep_minutes IS 'Google Health 由来の深睡眠時間（分）。';
+COMMENT ON COLUMN google_health_daily_metrics.sleep_bed_at IS 'Google Health の睡眠開始日時。';
+COMMENT ON COLUMN google_health_daily_metrics.sleep_wake_at IS 'Google Health の睡眠終了日時。metric_date は起床日基準。';
+COMMENT ON COLUMN google_health_daily_metrics.hrv_ms IS 'Google Health 由来の HRV（ms）。';
+COMMENT ON COLUMN google_health_daily_metrics.rhr_bpm IS 'Google Health 由来の安静時心拍数（bpm）。';
+COMMENT ON COLUMN google_health_daily_metrics.google_health_steps_source IS
+  'Google Health 歩数取得で採用した API source: reconcile / dailyRollUp / listFallback。';
+COMMENT ON COLUMN google_health_daily_metrics.synced_at IS 'Google Health との最終同期日時。';
+COMMENT ON COLUMN google_health_daily_metrics.created_at IS '作成日時。';
+COMMENT ON COLUMN google_health_daily_metrics.updated_at IS '最終更新日時。';
+
+-- ── updated_at 自動更新トリガー ────────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION set_updated_at_google_health_daily_metrics()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at := NOW();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_set_updated_at_google_health_daily_metrics
+  ON google_health_daily_metrics;
+
+CREATE TRIGGER trg_set_updated_at_google_health_daily_metrics
+BEFORE UPDATE ON google_health_daily_metrics
+FOR EACH ROW EXECUTE FUNCTION set_updated_at_google_health_daily_metrics();
+
+-- ── RLS ──────────────────────────────────────────────────────────────────────
+
+ALTER TABLE google_health_daily_metrics ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "authenticated owner can select google_health_daily_metrics"
+  ON google_health_daily_metrics;
+DROP POLICY IF EXISTS "authenticated owner can insert google_health_daily_metrics"
+  ON google_health_daily_metrics;
+DROP POLICY IF EXISTS "authenticated owner can update google_health_daily_metrics"
+  ON google_health_daily_metrics;
+DROP POLICY IF EXISTS "authenticated owner can delete google_health_daily_metrics"
+  ON google_health_daily_metrics;
+
+CREATE POLICY "authenticated owner can select google_health_daily_metrics"
+  ON google_health_daily_metrics FOR SELECT TO authenticated USING (user_id = auth.uid());
+CREATE POLICY "authenticated owner can insert google_health_daily_metrics"
+  ON google_health_daily_metrics FOR INSERT TO authenticated WITH CHECK (user_id = auth.uid());
+CREATE POLICY "authenticated owner can update google_health_daily_metrics"
+  ON google_health_daily_metrics FOR UPDATE TO authenticated USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+CREATE POLICY "authenticated owner can delete google_health_daily_metrics"
+  ON google_health_daily_metrics FOR DELETE TO authenticated USING (user_id = auth.uid());


### PR DESCRIPTION
## 概要
#690 の DB 設計に沿って、Google Health 由来の日次メトリクス保存テーブルを追加しました。

## 変更内容
- `google_health_daily_metrics` テーブル作成 migration を追加
- `daily_logs(user_id, log_date)` を親にするための一意制約を追加
- `google_health_daily_metrics(user_id, metric_date)` から `daily_logs(user_id, log_date)` への外部キーを追加
- Google Health 日次メトリクス用の Supabase 型を `types.ts` に追加

## 判断理由
- `metric_date` は `daily_logs.log_date` と同じ日付軸として扱うため、`user_id` と組み合わせて FK 関連にしました。
- `step_source` / `sleep_source` は持たず、歩数・睡眠系データは Google Health 管理に寄せる方針に合わせました。
- 旧 `daily_logs.step_count` / `daily_logs.sleep_hours` / `sleep_sessions` の削除は、保存・表示切り替え後の後続 Issue で扱うため今回の migration では削除していません。

## 検証結果
- `npx supabase start`: ローカル DB に migration 適用成功
- `npx supabase migration list --local`: `20260605000000` の適用を確認
- `npx supabase gen types --local --schema public`: 生成結果を確認。既存型との差分が広いため全差し替えは行わず、Google Health 関連型のみ手動更新を維持
- `npx supabase db lint --local --schema public`: No schema errors found
- `npm run lint -- src/lib/supabase/types.ts`: 成功
- `git diff --check`: 成功

## 補足
- remote DB には migration を適用していません。実 DB 適用は別途明示確認後に行う想定です。

Closes #690