### PR TITLE
Add Google Health OAuth token storage foundation

### DIFF
--- a/src/lib/googleHealth/tokenCrypto.test.ts
+++ b/src/lib/googleHealth/tokenCrypto.test.ts
@@ -1,0 +1,63 @@
+import {
+  decryptGoogleHealthToken,
+  encryptGoogleHealthToken,
+  getGoogleHealthTokenEncryptionKey,
+  parseGoogleHealthTokenEncryptionKey,
+} from "./tokenCrypto";
+
+const key = Buffer.from("0123456789abcdef0123456789abcdef", "utf8");
+const otherKey = Buffer.from("abcdef0123456789abcdef0123456789", "utf8");
+const token = "ya29.google-health-access-token";
+
+describe("Google Health token crypto", () => {
+  it("AES-256-GCM で token を暗号化して復号できる", () => {
+    const encrypted = encryptGoogleHealthToken(token, { key });
+
+    expect(encrypted).toEqual({
+      v: 1,
+      alg: "A256GCM",
+      kid: "1",
+      iv: expect.any(String),
+      tag: expect.any(String),
+      data: expect.any(String),
+    });
+    expect(JSON.stringify(encrypted)).not.toContain(token);
+    expect(decryptGoogleHealthToken(encrypted, { key })).toBe(token);
+  });
+
+  it("同じ token でも暗号化 payload は毎回異なる", () => {
+    const encryptedA = encryptGoogleHealthToken(token, { key });
+    const encryptedB = encryptGoogleHealthToken(token, { key });
+
+    expect(encryptedA).not.toEqual(encryptedB);
+    expect(decryptGoogleHealthToken(encryptedA, { key })).toBe(token);
+    expect(decryptGoogleHealthToken(encryptedB, { key })).toBe(token);
+  });
+
+  it("異なる key では復号できず token を含まないエラーを返す", () => {
+    const encrypted = encryptGoogleHealthToken(token, { key });
+
+    expect(() => decryptGoogleHealthToken(encrypted, { key: otherKey }))
+      .toThrow("google_health_token_decryption_failed");
+  });
+
+  it("不正な payload は復号しない", () => {
+    expect(() => decryptGoogleHealthToken({ data: token }, { key }))
+      .toThrow("google_health_token_ciphertext_invalid");
+  });
+
+  it("base64url または hex の 32 bytes key を読み取る", () => {
+    expect(parseGoogleHealthTokenEncryptionKey(key.toString("base64url"))).toEqual(key);
+    expect(parseGoogleHealthTokenEncryptionKey(key.toString("hex"))).toEqual(key);
+  });
+
+  it("env の key がない場合は sanitized error を返す", () => {
+    expect(() => getGoogleHealthTokenEncryptionKey({}))
+      .toThrow("google_health_token_encryption_key_missing");
+  });
+
+  it("32 bytes ではない key は拒否する", () => {
+    expect(() => parseGoogleHealthTokenEncryptionKey(Buffer.from("short").toString("base64url")))
+      .toThrow("google_health_token_encryption_key_invalid");
+  });
+});

--- a/src/lib/googleHealth/tokenCrypto.ts
+++ b/src/lib/googleHealth/tokenCrypto.ts
@@ -1,0 +1,151 @@
+import {
+  createCipheriv,
+  createDecipheriv,
+  randomBytes,
+} from "crypto";
+
+export const GOOGLE_HEALTH_TOKEN_ENCRYPTION_KEY_ENV = "GOOGLE_HEALTH_TOKEN_ENCRYPTION_KEY";
+export const GOOGLE_HEALTH_TOKEN_ENCRYPTION_KEY_VERSION = 1;
+
+const ALGORITHM = "aes-256-gcm";
+const PAYLOAD_ALGORITHM = "A256GCM";
+const KEY_BYTES = 32;
+const IV_BYTES = 12;
+const AAD = Buffer.from("body-comp-tracker-v2:google-health-token:v1", "utf8");
+
+export type GoogleHealthEncryptedTokenPayload = {
+  v: 1;
+  alg: "A256GCM";
+  kid: string;
+  iv: string;
+  tag: string;
+  data: string;
+};
+
+type EncryptOptions = {
+  key?: Buffer;
+  keyVersion?: number;
+};
+
+type DecryptOptions = {
+  key?: Buffer;
+};
+
+type EnvLike = Record<string, string | undefined>;
+
+function toBase64Url(value: Buffer): string {
+  return value.toString("base64url");
+}
+
+function fromBase64Url(value: string): Buffer {
+  try {
+    return Buffer.from(value, "base64url");
+  } catch {
+    throw new Error("google_health_token_ciphertext_invalid");
+  }
+}
+
+function isEncryptedPayload(value: unknown): value is GoogleHealthEncryptedTokenPayload {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const payload = value as Partial<GoogleHealthEncryptedTokenPayload>;
+  return (
+    payload.v === 1 &&
+    payload.alg === PAYLOAD_ALGORITHM &&
+    typeof payload.kid === "string" &&
+    typeof payload.iv === "string" &&
+    typeof payload.tag === "string" &&
+    typeof payload.data === "string"
+  );
+}
+
+function decodeKey(value: string): Buffer {
+  const normalized = value.trim();
+  if (normalized.length === 0) {
+    throw new Error("google_health_token_encryption_key_missing");
+  }
+
+  if (/^[0-9a-f]{64}$/i.test(normalized)) {
+    return Buffer.from(normalized, "hex");
+  }
+
+  try {
+    return Buffer.from(normalized, "base64url");
+  } catch {
+    throw new Error("google_health_token_encryption_key_invalid");
+  }
+}
+
+export function parseGoogleHealthTokenEncryptionKey(value: string): Buffer {
+  const key = decodeKey(value);
+  if (key.byteLength !== KEY_BYTES) {
+    throw new Error("google_health_token_encryption_key_invalid");
+  }
+  return key;
+}
+
+export function getGoogleHealthTokenEncryptionKey(env: EnvLike = process.env): Buffer {
+  const value = env[GOOGLE_HEALTH_TOKEN_ENCRYPTION_KEY_ENV];
+  if (!value) {
+    throw new Error("google_health_token_encryption_key_missing");
+  }
+  return parseGoogleHealthTokenEncryptionKey(value);
+}
+
+export function encryptGoogleHealthToken(
+  token: string,
+  options: EncryptOptions = {},
+): GoogleHealthEncryptedTokenPayload {
+  if (token.length === 0) {
+    throw new Error("google_health_token_empty");
+  }
+
+  const key = options.key ?? getGoogleHealthTokenEncryptionKey();
+  const iv = randomBytes(IV_BYTES);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  cipher.setAAD(AAD);
+
+  const ciphertext = Buffer.concat([
+    cipher.update(token, "utf8"),
+    cipher.final(),
+  ]);
+  const authTag = cipher.getAuthTag();
+
+  return {
+    v: 1,
+    alg: PAYLOAD_ALGORITHM,
+    kid: String(options.keyVersion ?? GOOGLE_HEALTH_TOKEN_ENCRYPTION_KEY_VERSION),
+    iv: toBase64Url(iv),
+    tag: toBase64Url(authTag),
+    data: toBase64Url(ciphertext),
+  };
+}
+
+export function decryptGoogleHealthToken(
+  payload: unknown,
+  options: DecryptOptions = {},
+): string {
+  if (!isEncryptedPayload(payload)) {
+    throw new Error("google_health_token_ciphertext_invalid");
+  }
+
+  const key = options.key ?? getGoogleHealthTokenEncryptionKey();
+  const iv = fromBase64Url(payload.iv);
+  const authTag = fromBase64Url(payload.tag);
+  const ciphertext = fromBase64Url(payload.data);
+
+  if (iv.byteLength !== IV_BYTES || authTag.byteLength !== 16 || ciphertext.byteLength === 0) {
+    throw new Error("google_health_token_ciphertext_invalid");
+  }
+
+  try {
+    const decipher = createDecipheriv(ALGORITHM, key, iv);
+    decipher.setAAD(AAD);
+    decipher.setAuthTag(authTag);
+    return Buffer.concat([
+      decipher.update(ciphertext),
+      decipher.final(),
+    ]).toString("utf8");
+  } catch {
+    throw new Error("google_health_token_decryption_failed");
+  }
+}

--- a/src/lib/supabase/serviceRole.test.ts
+++ b/src/lib/supabase/serviceRole.test.ts
@@ -1,0 +1,48 @@
+jest.mock("@supabase/supabase-js", () => ({
+  createClient: jest.fn(() => ({ kind: "service-role-client" })),
+}));
+
+import { createClient as createSupabaseClient } from "@supabase/supabase-js";
+import { createServiceRoleClient } from "./serviceRole";
+
+const mockCreateSupabaseClient = createSupabaseClient as jest.Mock;
+
+describe("createServiceRoleClient", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    mockCreateSupabaseClient.mockClear();
+    process.env = {
+      ...originalEnv,
+      NEXT_PUBLIC_SUPABASE_URL: "https://example.supabase.co",
+      SUPABASE_SERVICE_ROLE_KEY: "service-role-key",
+    };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("service role key で persistSession 無効の Supabase client を作成する", () => {
+    const client = createServiceRoleClient();
+
+    expect(client).toEqual({ kind: "service-role-client" });
+    expect(mockCreateSupabaseClient).toHaveBeenCalledWith(
+      "https://example.supabase.co",
+      "service-role-key",
+      {
+        auth: {
+          autoRefreshToken: false,
+          persistSession: false,
+        },
+      },
+    );
+  });
+
+  it("必要な env がない場合は sanitized error を返す", () => {
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+    expect(() => createServiceRoleClient()).toThrow("supabase_service_role_env_missing");
+    expect(mockCreateSupabaseClient).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/supabase/serviceRole.ts
+++ b/src/lib/supabase/serviceRole.ts
@@ -1,0 +1,26 @@
+import { createClient as createSupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "./types";
+
+export function createServiceRoleClient() {
+  if (typeof window !== "undefined") {
+    throw new Error("supabase_service_role_server_only");
+  }
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error("supabase_service_role_env_missing");
+  }
+
+  return createSupabaseClient<Database>(
+    supabaseUrl,
+    serviceRoleKey,
+    {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false,
+      },
+    },
+  );
+}

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -12,6 +12,86 @@ export type Database = {
   __InternalSupabase: {
     PostgrestVersion: "14.1"
   }
+  private: {
+    Tables: {
+      google_health_connections: {
+        Row: {
+          access_token_expires_at: string | null
+          created_at: string
+          encrypted_access_token: Json | null
+          encrypted_refresh_token: Json | null
+          encryption_key_version: number
+          granted_scopes: string[]
+          id: string
+          last_checked_at: string | null
+          last_error_code: string | null
+          last_error_message: string | null
+          last_sync_at: string | null
+          status: Database["private"]["Enums"]["google_health_connection_status"]
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          access_token_expires_at?: string | null
+          created_at?: string
+          encrypted_access_token?: Json | null
+          encrypted_refresh_token?: Json | null
+          encryption_key_version?: number
+          granted_scopes?: string[]
+          id?: string
+          last_checked_at?: string | null
+          last_error_code?: string | null
+          last_error_message?: string | null
+          last_sync_at?: string | null
+          status?: Database["private"]["Enums"]["google_health_connection_status"]
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          access_token_expires_at?: string | null
+          created_at?: string
+          encrypted_access_token?: Json | null
+          encrypted_refresh_token?: Json | null
+          encryption_key_version?: number
+          granted_scopes?: string[]
+          id?: string
+          last_checked_at?: string | null
+          last_error_code?: string | null
+          last_error_message?: string | null
+          last_sync_at?: string | null
+          status?: Database["private"]["Enums"]["google_health_connection_status"]
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "google_health_connections_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: true
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      [_ in never]: never
+    }
+    Enums: {
+      google_health_connection_status:
+        | "not_connected"
+        | "connected"
+        | "scope_missing"
+        | "reauthorization_required"
+        | "error"
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
   public: {
     Tables: {
       analytics_cache: {
@@ -631,6 +711,17 @@ export type CompositeTypes<
     : never
 
 export const Constants = {
+  private: {
+    Enums: {
+      google_health_connection_status: [
+        "not_connected",
+        "connected",
+        "scope_missing",
+        "reauthorization_required",
+        "error",
+      ],
+    },
+  },
   public: {
     Enums: {},
   },
@@ -674,6 +765,8 @@ export type MacroDailyLog = Pick<DailyLog, "log_date" | "weight" | "calories" | 
 export type TdeeDailyLog = Pick<DailyLog, "log_date" | "weight" | "calories">;
 
 export type GoogleHealthDailyMetricRow = Database["public"]["Tables"]["google_health_daily_metrics"]["Row"];
+export type GoogleHealthConnectionRow = Database["private"]["Tables"]["google_health_connections"]["Row"];
+export type GoogleHealthConnectionStatus = Database["private"]["Enums"]["google_health_connection_status"];
 export type SleepSession = OptionalUserId<Database["public"]["Tables"]["sleep_sessions"]["Row"]>;
 
 export type FoodMaster  = OptionalUserId<Database["public"]["Tables"]["food_master"]["Row"]>;

--- a/supabase/migrations/20260605010000_create_google_health_connections.sql
+++ b/supabase/migrations/20260605010000_create_google_health_connections.sql
@@ -1,0 +1,139 @@
+-- Google Health OAuth token storage foundation (#694)
+--
+-- Purpose:
+--   Store Google Health OAuth connection metadata and encrypted tokens for each
+--   Supabase Auth user. Tokens must be usable only by server-side service_role
+--   code and must not be exposed through browser clients or authenticated RLS.
+--
+-- Design:
+--   - Store token ciphertext in a private schema, not public.
+--   - Do not grant anon / authenticated direct privileges on the token table.
+--   - service_role is expected to access this table from server-only code.
+--   - Token ciphertext payloads are JSONB objects produced by application code.
+
+CREATE SCHEMA IF NOT EXISTS private;
+
+REVOKE ALL ON SCHEMA private FROM PUBLIC;
+REVOKE ALL ON SCHEMA private FROM anon;
+REVOKE ALL ON SCHEMA private FROM authenticated;
+GRANT USAGE ON SCHEMA private TO service_role;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA private REVOKE ALL ON TABLES FROM PUBLIC;
+ALTER DEFAULT PRIVILEGES IN SCHEMA private REVOKE ALL ON FUNCTIONS FROM PUBLIC;
+ALTER DEFAULT PRIVILEGES IN SCHEMA private REVOKE ALL ON SEQUENCES FROM PUBLIC;
+
+DO $$
+BEGIN
+  CREATE TYPE private.google_health_connection_status AS ENUM (
+    'not_connected',
+    'connected',
+    'scope_missing',
+    'reauthorization_required',
+    'error'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+REVOKE ALL ON TYPE private.google_health_connection_status FROM PUBLIC;
+REVOKE ALL ON TYPE private.google_health_connection_status FROM anon;
+REVOKE ALL ON TYPE private.google_health_connection_status FROM authenticated;
+GRANT USAGE ON TYPE private.google_health_connection_status TO service_role;
+
+CREATE TABLE IF NOT EXISTS private.google_health_connections (
+  id                         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id                    UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  encrypted_access_token     JSONB,
+  encrypted_refresh_token    JSONB,
+  access_token_expires_at    TIMESTAMPTZ,
+  granted_scopes             TEXT[] NOT NULL DEFAULT '{}',
+  status                     private.google_health_connection_status NOT NULL DEFAULT 'not_connected',
+  last_checked_at            TIMESTAMPTZ,
+  last_sync_at               TIMESTAMPTZ,
+  last_error_code            TEXT,
+  last_error_message         TEXT,
+  encryption_key_version     SMALLINT NOT NULL DEFAULT 1,
+  created_at                 TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at                 TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT uq_google_health_connections_user_id UNIQUE (user_id),
+  CONSTRAINT chk_google_health_connections_key_version
+    CHECK (encryption_key_version > 0),
+  CONSTRAINT chk_google_health_connections_access_token_shape
+    CHECK (
+      encrypted_access_token IS NULL
+      OR jsonb_typeof(encrypted_access_token) = 'object'
+    ),
+  CONSTRAINT chk_google_health_connections_refresh_token_shape
+    CHECK (
+      encrypted_refresh_token IS NULL
+      OR jsonb_typeof(encrypted_refresh_token) = 'object'
+    ),
+  CONSTRAINT chk_google_health_connections_error_message_length
+    CHECK (last_error_message IS NULL OR length(last_error_message) <= 500)
+);
+
+COMMENT ON SCHEMA private IS
+  'Server-only schema for sensitive application data. Do not expose to anon/authenticated clients.';
+COMMENT ON TYPE private.google_health_connection_status IS
+  'Google Health OAuth connection status for settings/status UI.';
+COMMENT ON TABLE private.google_health_connections IS
+  'Server-only Google Health OAuth connection records. Token fields contain encrypted JSON payloads only.';
+COMMENT ON COLUMN private.google_health_connections.id IS 'UUID primary key.';
+COMMENT ON COLUMN private.google_health_connections.user_id IS 'Owner Supabase auth.users.id. One Google Health connection per user.';
+COMMENT ON COLUMN private.google_health_connections.encrypted_access_token IS
+  'Encrypted Google OAuth access token payload. Never store plaintext token values.';
+COMMENT ON COLUMN private.google_health_connections.encrypted_refresh_token IS
+  'Encrypted Google OAuth refresh token payload. Never store plaintext token values.';
+COMMENT ON COLUMN private.google_health_connections.access_token_expires_at IS
+  'Google OAuth access token expiry timestamp.';
+COMMENT ON COLUMN private.google_health_connections.granted_scopes IS
+  'Scopes granted by Google OAuth consent.';
+COMMENT ON COLUMN private.google_health_connections.status IS
+  'Sanitized connection status: not_connected / connected / scope_missing / reauthorization_required / error.';
+COMMENT ON COLUMN private.google_health_connections.last_checked_at IS
+  'Last time the connection status was checked.';
+COMMENT ON COLUMN private.google_health_connections.last_sync_at IS
+  'Last successful Google Health daily metrics sync time.';
+COMMENT ON COLUMN private.google_health_connections.last_error_code IS
+  'Sanitized operational error code. Must not contain token values.';
+COMMENT ON COLUMN private.google_health_connections.last_error_message IS
+  'Sanitized operational error message. Must not contain token values.';
+COMMENT ON COLUMN private.google_health_connections.encryption_key_version IS
+  'Application encryption key version used for the encrypted token payloads.';
+
+CREATE INDEX IF NOT EXISTS idx_google_health_connections_user_id
+  ON private.google_health_connections(user_id);
+CREATE INDEX IF NOT EXISTS idx_google_health_connections_status
+  ON private.google_health_connections(status);
+
+ALTER TABLE private.google_health_connections ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE private.google_health_connections FROM PUBLIC;
+REVOKE ALL ON TABLE private.google_health_connections FROM anon;
+REVOKE ALL ON TABLE private.google_health_connections FROM authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE private.google_health_connections TO service_role;
+
+CREATE OR REPLACE FUNCTION private.set_updated_at_google_health_connections()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = private, pg_temp
+AS $$
+BEGIN
+  NEW.updated_at := NOW();
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION private.set_updated_at_google_health_connections() FROM PUBLIC;
+REVOKE ALL ON FUNCTION private.set_updated_at_google_health_connections() FROM anon;
+REVOKE ALL ON FUNCTION private.set_updated_at_google_health_connections() FROM authenticated;
+GRANT EXECUTE ON FUNCTION private.set_updated_at_google_health_connections() TO service_role;
+
+DROP TRIGGER IF EXISTS trg_set_updated_at_google_health_connections
+  ON private.google_health_connections;
+
+CREATE TRIGGER trg_set_updated_at_google_health_connections
+BEFORE UPDATE ON private.google_health_connections
+FOR EACH ROW EXECUTE FUNCTION private.set_updated_at_google_health_connections();


### PR DESCRIPTION
## 概要
- Google Health OAuth token を保管するための private.google_health_connections migration を追加しました。
- Google Health token 暗号化 / 復号 helper を追加しました。
- service_role 専用 Supabase client helper を追加しました。
- Supabase 型定義に private schema の型を手動追加しました。

## 変更内容
- token 保管テーブルは private schema に作成し、anon / authenticated への直接権限を付与しない設計にしています。
- token カラムは encrypted_access_token / encrypted_refresh_token の JSONB のみで、平文 token カラムは作成していません。
- 暗号化は AES-256-GCM を使い、payload に version / alg / kid / iv / tag / data を持たせています。
- service role client は既存の user-scoped createClient() と分離しています。

## セキュリティ確認
- token / refresh token / client secret はコード、ログ、レスポンスに出さない前提の helper 名・エラー名にしています。
- token 保管テーブルは RLS 有効化のうえ、通常 role への直接権限を revoke しています。
- SUPABASE_SERVICE_ROLE_KEY と GOOGLE_HEALTH_TOKEN_ENCRYPTION_KEY はサーバー専用 env 前提です。

## 検証結果
- npm test -- --runTestsByPath src/lib/googleHealth/tokenCrypto.test.ts src/lib/supabase/serviceRole.test.ts
- npx tsc --noEmit
- npm run lint
- git diff --cached --check

## 補足
- 実 DB への migration 適用は未実施です。remote DB 適用時は明示確認が必要です。
- OAuth 認可 API、保存 API の stored token 切り替え、設定画面 UI は後続 Issue で扱います。

Closes #694