### PR TITLE
Sync Supabase types after Google Health token migration

### DIFF
--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -63,15 +63,7 @@ export type Database = {
           updated_at?: string
           user_id?: string
         }
-        Relationships: [
-          {
-            foreignKeyName: "google_health_connections_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: true
-            referencedRelation: "users"
-            referencedColumns: ["id"]
-          },
-        ]
+        Relationships: []
       }
     }
     Views: {


### PR DESCRIPTION
## 概要
- remote DB へ #694 の migration 適用後、`supabase gen types` の生成結果に合わせて `types.ts` を同期しました。

## 変更内容
- `private.google_health_connections.Relationships` を生成結果に合わせて `[]` にしました。
- `types.ts` 末尾のプロジェクト独自 alias 群はアプリ内で利用しているため残しています。

## 確認結果
- `npx supabase db push` で `20260605010000_create_google_health_connections.sql` を remote DB に適用済みです。
- `npx supabase migration list` で local / remote ともに `20260605010000` が揃っていることを確認しました。
- `npx supabase gen types --linked --schema public --schema private > /tmp/body-comp-tracker-v2-types.generated.ts` を実行しました。
- 生成結果との差分は、独自 alias 群を除くと今回の `Relationships: []` の同期のみでした。

## 検証結果
- `npx tsc --noEmit`
- `git diff --check`

## 補足
- 実 DB への migration 適用は完了済みです。
- この PR は schema 適用後の型同期のみです。OAuth 実装や保存 API の切り替えは後続 Issue で扱います。

Refs #694