### PR TITLE
Google Health OAuth認可・callback・連携解除APIを実装する

### DIFF
--- a/src/app/api/google-health/oauth/callback/route.test.ts
+++ b/src/app/api/google-health/oauth/callback/route.test.ts
@@ -180,4 +180,55 @@ describe("GET /api/google-health/oauth/callback", () => {
 
     expect(response.headers.get("location")).toBe("http://localhost/settings?google_health=scope_missing");
   });
+
+  it("token exchange 失敗時は sanitized reason を返す", async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: "user-id", email: "owner@example.com" });
+    fetchSpy.mockResolvedValue(new Response(JSON.stringify({
+      error: "invalid_grant",
+      error_description: "sensitive detail",
+    }), { status: 400 }));
+
+    const response = await GET(makeRequest(
+      { code: "authorization-code", state: "state-value" },
+      makeStateCookie(),
+    ));
+    const location = response.headers.get("location") ?? "";
+
+    expect(location).toBe(
+      "http://localhost/settings?google_health=error&reason=google_health_oauth_token_exchange_failed",
+    );
+    expect(location).not.toContain("sensitive");
+    expect(mockSaveConnection).not.toHaveBeenCalled();
+    expect(mockMarkError).toHaveBeenCalledWith({
+      userId: "user-id",
+      code: "oauth_token_exchange_failed",
+      message: "google_health_oauth_token_exchange_failed",
+    });
+  });
+
+  it("connection 保存失敗時は安全なエラー名だけを reason に含める", async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: "user-id", email: "owner@example.com" });
+    fetchSpy.mockResolvedValue(new Response(JSON.stringify({
+      access_token: "google-access-token",
+      refresh_token: "google-refresh-token",
+      expires_in: 3600,
+      scope: GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES.join(" "),
+      token_type: "Bearer",
+    }), { status: 200 }));
+    mockSaveConnection.mockRejectedValue(new Error("supabase_service_role_env_missing"));
+
+    const response = await GET(makeRequest(
+      { code: "authorization-code", state: "state-value" },
+      makeStateCookie(),
+    ));
+
+    expect(response.headers.get("location")).toBe(
+      "http://localhost/settings?google_health=error&reason=supabase_service_role_env_missing",
+    );
+    expect(mockMarkError).toHaveBeenCalledWith({
+      userId: "user-id",
+      code: "oauth_connection_save_failed",
+      message: "supabase_service_role_env_missing",
+    });
+  });
 });

--- a/src/app/api/google-health/oauth/callback/route.test.ts
+++ b/src/app/api/google-health/oauth/callback/route.test.ts
@@ -195,14 +195,14 @@ describe("GET /api/google-health/oauth/callback", () => {
     const location = response.headers.get("location") ?? "";
 
     expect(location).toBe(
-      "http://localhost/settings?google_health=error&reason=google_health_oauth_token_exchange_failed",
+      "http://localhost/settings?google_health=error&reason=google_health_oauth_token_exchange_invalid_grant",
     );
     expect(location).not.toContain("sensitive");
     expect(mockSaveConnection).not.toHaveBeenCalled();
     expect(mockMarkError).toHaveBeenCalledWith({
       userId: "user-id",
       code: "oauth_token_exchange_failed",
-      message: "google_health_oauth_token_exchange_failed",
+      message: "google_health_oauth_token_exchange_invalid_grant",
     });
   });
 

--- a/src/app/api/google-health/oauth/callback/route.test.ts
+++ b/src/app/api/google-health/oauth/callback/route.test.ts
@@ -1,0 +1,183 @@
+jest.mock("@/lib/supabase/server", () => ({
+  getCurrentUser: jest.fn(),
+}));
+
+jest.mock("@/lib/googleHealth/connections", () => ({
+  markGoogleHealthConnectionError: jest.fn(),
+  saveGoogleHealthOAuthConnection: jest.fn(),
+}));
+
+import { NextRequest } from "next/server";
+import {
+  GOOGLE_HEALTH_OAUTH_STATE_COOKIE,
+  createGoogleHealthOAuthStateCookieValue,
+} from "@/lib/googleHealth/oauth";
+import { GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES } from "@/lib/googleHealth/dailyMetrics";
+import {
+  markGoogleHealthConnectionError,
+  saveGoogleHealthOAuthConnection,
+} from "@/lib/googleHealth/connections";
+import { getCurrentUser } from "@/lib/supabase/server";
+import { GET } from "./route";
+
+const mockGetCurrentUser = getCurrentUser as jest.Mock;
+const mockSaveConnection = saveGoogleHealthOAuthConnection as jest.Mock;
+const mockMarkError = markGoogleHealthConnectionError as jest.Mock;
+
+const originalEnv = process.env;
+const stateSecret = "0123456789abcdef0123456789abcdef";
+
+function setOAuthEnv() {
+  process.env = {
+    ...originalEnv,
+    GOOGLE_OAUTH_CLIENT_ID: "google-client-id",
+    GOOGLE_OAUTH_CLIENT_SECRET: "google-client-secret",
+    GOOGLE_OAUTH_REDIRECT_URI: "http://localhost/api/google-health/oauth/callback",
+    GOOGLE_HEALTH_OAUTH_STATE_SECRET: stateSecret,
+  };
+}
+
+function makeStateCookie(args?: {
+  state?: string;
+  userId?: string;
+  expiresAt?: number;
+}): string {
+  const value = createGoogleHealthOAuthStateCookieValue(
+    {
+      state: args?.state ?? "state-value",
+      codeVerifier: "code-verifier",
+      userId: args?.userId ?? "user-id",
+      expiresAt: args?.expiresAt ?? Math.floor(Date.now() / 1000) + 600,
+    },
+    stateSecret,
+  );
+  return `${GOOGLE_HEALTH_OAUTH_STATE_COOKIE}=${value}`;
+}
+
+function makeRequest(params: Record<string, string>, cookie?: string): NextRequest {
+  const url = new URL("http://localhost/api/google-health/oauth/callback");
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return new NextRequest(url.toString(), {
+    headers: cookie ? { cookie } : undefined,
+  });
+}
+
+describe("GET /api/google-health/oauth/callback", () => {
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    mockGetCurrentUser.mockReset();
+    mockSaveConnection.mockReset();
+    mockMarkError.mockReset();
+    setOAuthEnv();
+    fetchSpy = jest.spyOn(global, "fetch");
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    process.env = originalEnv;
+  });
+
+  it("authorization code を token に交換して connection を保存する", async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: "user-id", email: "owner@example.com" });
+    fetchSpy.mockResolvedValue(new Response(JSON.stringify({
+      access_token: "google-access-token",
+      refresh_token: "google-refresh-token",
+      expires_in: 3600,
+      scope: GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES.join(" "),
+      token_type: "Bearer",
+    }), { status: 200 }));
+    mockSaveConnection.mockResolvedValue({
+      connection: { id: "connection-id" },
+      missingScopes: [],
+      status: "connected",
+    });
+
+    const response = await GET(makeRequest(
+      { code: "authorization-code", state: "state-value" },
+      makeStateCookie(),
+    ));
+    const location = response.headers.get("location") ?? "";
+    const setCookie = response.headers.get("set-cookie") ?? "";
+
+    expect(response.status).toBe(307);
+    expect(location).toBe("http://localhost/settings?google_health=connected");
+    expect(location).not.toContain("google-access-token");
+    expect(setCookie).toContain(`${GOOGLE_HEALTH_OAUTH_STATE_COOKIE}=`);
+    expect(setCookie).toContain("Max-Age=0");
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const tokenBody = fetchSpy.mock.calls[0][1].body as URLSearchParams;
+    expect(tokenBody.get("code")).toBe("authorization-code");
+    expect(tokenBody.get("code_verifier")).toBe("code-verifier");
+    expect(mockSaveConnection).toHaveBeenCalledWith({
+      userId: "user-id",
+      token: {
+        accessToken: "google-access-token",
+        refreshToken: "google-refresh-token",
+        expiresIn: 3600,
+        grantedScopes: [...GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES],
+        tokenType: "Bearer",
+      },
+    });
+  });
+
+  it("state が一致しない場合は token exchange しない", async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: "user-id", email: "owner@example.com" });
+
+    const response = await GET(makeRequest(
+      { code: "authorization-code", state: "different-state" },
+      makeStateCookie(),
+    ));
+
+    expect(response.headers.get("location")).toBe(
+      "http://localhost/settings?google_health=error&reason=google_health_oauth_state_mismatch",
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(mockSaveConnection).not.toHaveBeenCalled();
+    expect(mockMarkError).toHaveBeenCalledWith({
+      userId: "user-id",
+      code: "oauth_state_mismatch",
+      message: undefined,
+    });
+  });
+
+  it("Google OAuth が error を返した場合は sanitized reason で settings へ戻す", async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: "user-id", email: "owner@example.com" });
+
+    const response = await GET(makeRequest({
+      error: "access_denied",
+      error_description: "sensitive detail",
+    }, makeStateCookie()));
+
+    const location = response.headers.get("location") ?? "";
+    expect(location).toBe("http://localhost/settings?google_health=error&reason=google_oauth_error");
+    expect(location).not.toContain("sensitive");
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(mockSaveConnection).not.toHaveBeenCalled();
+  });
+
+  it("保存結果が scope_missing の場合は settings へ status を渡す", async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: "user-id", email: "owner@example.com" });
+    fetchSpy.mockResolvedValue(new Response(JSON.stringify({
+      access_token: "google-access-token",
+      expires_in: 3600,
+      scope: GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES[0],
+      token_type: "Bearer",
+    }), { status: 200 }));
+    mockSaveConnection.mockResolvedValue({
+      connection: { id: "connection-id" },
+      missingScopes: [GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES[1]],
+      status: "scope_missing",
+    });
+
+    const response = await GET(makeRequest(
+      { code: "authorization-code", state: "state-value" },
+      makeStateCookie(),
+    ));
+
+    expect(response.headers.get("location")).toBe("http://localhost/settings?google_health=scope_missing");
+  });
+});

--- a/src/app/api/google-health/oauth/callback/route.ts
+++ b/src/app/api/google-health/oauth/callback/route.ts
@@ -15,6 +15,12 @@ export const dynamic = "force-dynamic";
 
 const SAFE_CALLBACK_FAILURE_REASONS = new Set([
   "google_health_oauth_token_exchange_failed",
+  "google_health_oauth_token_exchange_invalid_request",
+  "google_health_oauth_token_exchange_invalid_client",
+  "google_health_oauth_token_exchange_invalid_grant",
+  "google_health_oauth_token_exchange_unauthorized_client",
+  "google_health_oauth_token_exchange_unsupported_grant_type",
+  "google_health_oauth_token_exchange_redirect_uri_mismatch",
   "google_health_oauth_token_response_invalid",
   "supabase_service_role_env_missing",
   "google_health_token_encryption_key_missing",

--- a/src/app/api/google-health/oauth/callback/route.ts
+++ b/src/app/api/google-health/oauth/callback/route.ts
@@ -13,6 +13,16 @@ import { getCurrentUser } from "@/lib/supabase/server";
 
 export const dynamic = "force-dynamic";
 
+const SAFE_CALLBACK_FAILURE_REASONS = new Set([
+  "google_health_oauth_token_exchange_failed",
+  "google_health_oauth_token_response_invalid",
+  "supabase_service_role_env_missing",
+  "google_health_token_encryption_key_missing",
+  "google_health_token_encryption_key_invalid",
+  "google_health_connection_fetch_failed",
+  "google_health_connection_upsert_failed",
+]);
+
 function settingsRedirect(request: NextRequest, status: string, reason?: string): NextResponse {
   const url = new URL("/settings", request.nextUrl.origin);
   url.searchParams.set("google_health", status);
@@ -39,6 +49,11 @@ async function tryMarkConnectionError(userId: string, code: string, message?: st
   } catch {
     // OAuth callback must never expose service-role or token storage details to the browser.
   }
+}
+
+function getSafeCallbackFailureReason(error: unknown, fallback: string): string {
+  if (!(error instanceof Error)) return fallback;
+  return SAFE_CALLBACK_FAILURE_REASONS.has(error.message) ? error.message : fallback;
 }
 
 export async function GET(request: NextRequest) {
@@ -95,20 +110,33 @@ export async function GET(request: NextRequest) {
     return clearStateCookie(settingsRedirect(request, "error", "google_health_oauth_state_user_mismatch"));
   }
 
+  let token;
   try {
-    const token = await exchangeGoogleHealthOAuthCode({
+    token = await exchangeGoogleHealthOAuthCode({
       config,
       code,
       codeVerifier: statePayload.codeVerifier,
     });
+  } catch (error) {
+    const reason = getSafeCallbackFailureReason(error, "google_health_oauth_token_exchange_failed");
+    await tryMarkConnectionError(
+      user.id,
+      "oauth_token_exchange_failed",
+      error instanceof Error ? error.message : null,
+    );
+    return clearStateCookie(settingsRedirect(request, "error", reason));
+  }
+
+  try {
     const result = await saveGoogleHealthOAuthConnection({ userId: user.id, token });
     return clearStateCookie(settingsRedirect(request, result.status));
   } catch (error) {
+    const reason = getSafeCallbackFailureReason(error, "google_health_connection_save_failed");
     await tryMarkConnectionError(
       user.id,
-      "oauth_callback_failed",
+      "oauth_connection_save_failed",
       error instanceof Error ? error.message : null,
     );
-    return clearStateCookie(settingsRedirect(request, "error", "oauth_callback_failed"));
+    return clearStateCookie(settingsRedirect(request, "error", reason));
   }
 }

--- a/src/app/api/google-health/oauth/callback/route.ts
+++ b/src/app/api/google-health/oauth/callback/route.ts
@@ -1,0 +1,114 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  GOOGLE_HEALTH_OAUTH_STATE_COOKIE,
+  exchangeGoogleHealthOAuthCode,
+  getGoogleHealthOAuthConfig,
+  parseGoogleHealthOAuthStateCookieValue,
+} from "@/lib/googleHealth/oauth";
+import {
+  markGoogleHealthConnectionError,
+  saveGoogleHealthOAuthConnection,
+} from "@/lib/googleHealth/connections";
+import { getCurrentUser } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+
+function settingsRedirect(request: NextRequest, status: string, reason?: string): NextResponse {
+  const url = new URL("/settings", request.nextUrl.origin);
+  url.searchParams.set("google_health", status);
+  if (reason) {
+    url.searchParams.set("reason", reason);
+  }
+  return NextResponse.redirect(url);
+}
+
+function clearStateCookie(response: NextResponse): NextResponse {
+  response.cookies.set(GOOGLE_HEALTH_OAUTH_STATE_COOKIE, "", {
+    httpOnly: true,
+    maxAge: 0,
+    path: "/",
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+  });
+  return response;
+}
+
+async function tryMarkConnectionError(userId: string, code: string, message?: string | null) {
+  try {
+    await markGoogleHealthConnectionError({ userId, code, message });
+  } catch {
+    // OAuth callback must never expose service-role or token storage details to the browser.
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const user = await getCurrentUser();
+  if (!user) {
+    return clearStateCookie(settingsRedirect(request, "error", "auth_required"));
+  }
+
+  let config;
+  try {
+    config = getGoogleHealthOAuthConfig();
+  } catch (error) {
+    await tryMarkConnectionError(user.id, "config_error");
+    const reason = error instanceof Error ? error.message : "google_health_oauth_config_error";
+    return clearStateCookie(settingsRedirect(request, "error", reason));
+  }
+
+  const googleError = request.nextUrl.searchParams.get("error");
+  if (googleError) {
+    await tryMarkConnectionError(user.id, "google_oauth_error");
+    return clearStateCookie(settingsRedirect(request, "error", "google_oauth_error"));
+  }
+
+  const code = request.nextUrl.searchParams.get("code");
+  const returnedState = request.nextUrl.searchParams.get("state");
+  const cookieValue = request.cookies.get(GOOGLE_HEALTH_OAUTH_STATE_COOKIE)?.value;
+
+  if (!code || !returnedState || !cookieValue) {
+    await tryMarkConnectionError(user.id, "oauth_callback_invalid");
+    return clearStateCookie(settingsRedirect(request, "error", "oauth_callback_invalid"));
+  }
+
+  let statePayload;
+  try {
+    statePayload = parseGoogleHealthOAuthStateCookieValue(cookieValue, config.stateSecret);
+  } catch (error) {
+    await tryMarkConnectionError(user.id, "oauth_state_invalid");
+    const reason = error instanceof Error ? error.message : "google_health_oauth_state_invalid";
+    return clearStateCookie(settingsRedirect(request, "error", reason));
+  }
+
+  if (statePayload.expiresAt <= Math.floor(Date.now() / 1000)) {
+    await tryMarkConnectionError(user.id, "oauth_state_expired");
+    return clearStateCookie(settingsRedirect(request, "error", "google_health_oauth_state_expired"));
+  }
+
+  if (statePayload.state !== returnedState) {
+    await tryMarkConnectionError(user.id, "oauth_state_mismatch");
+    return clearStateCookie(settingsRedirect(request, "error", "google_health_oauth_state_mismatch"));
+  }
+
+  if (statePayload.userId !== user.id) {
+    await tryMarkConnectionError(user.id, "oauth_state_user_mismatch");
+    return clearStateCookie(settingsRedirect(request, "error", "google_health_oauth_state_user_mismatch"));
+  }
+
+  try {
+    const token = await exchangeGoogleHealthOAuthCode({
+      config,
+      code,
+      codeVerifier: statePayload.codeVerifier,
+    });
+    const result = await saveGoogleHealthOAuthConnection({ userId: user.id, token });
+    return clearStateCookie(settingsRedirect(request, result.status));
+  } catch (error) {
+    await tryMarkConnectionError(
+      user.id,
+      "oauth_callback_failed",
+      error instanceof Error ? error.message : null,
+    );
+    return clearStateCookie(settingsRedirect(request, "error", "oauth_callback_failed"));
+  }
+}

--- a/src/app/api/google-health/oauth/disconnect/route.test.ts
+++ b/src/app/api/google-health/oauth/disconnect/route.test.ts
@@ -1,0 +1,118 @@
+jest.mock("@/lib/supabase/server", () => ({
+  getCurrentUser: jest.fn(),
+}));
+
+jest.mock("@/lib/supabase/serviceRole", () => ({
+  createServiceRoleClient: jest.fn(),
+}));
+
+jest.mock("@/lib/googleHealth/connections", () => ({
+  deleteGoogleHealthConnection: jest.fn(),
+  decryptGoogleHealthConnectionRevokeToken: jest.fn(),
+  getGoogleHealthConnectionByUserId: jest.fn(),
+}));
+
+jest.mock("@/lib/googleHealth/oauth", () => ({
+  revokeGoogleHealthOAuthToken: jest.fn(),
+}));
+
+import { NextRequest } from "next/server";
+import {
+  deleteGoogleHealthConnection,
+  decryptGoogleHealthConnectionRevokeToken,
+  getGoogleHealthConnectionByUserId,
+} from "@/lib/googleHealth/connections";
+import { revokeGoogleHealthOAuthToken } from "@/lib/googleHealth/oauth";
+import { createServiceRoleClient } from "@/lib/supabase/serviceRole";
+import { getCurrentUser } from "@/lib/supabase/server";
+import { POST } from "./route";
+
+const mockGetCurrentUser = getCurrentUser as jest.Mock;
+const mockCreateServiceRoleClient = createServiceRoleClient as jest.Mock;
+const mockGetConnection = getGoogleHealthConnectionByUserId as jest.Mock;
+const mockDeleteConnection = deleteGoogleHealthConnection as jest.Mock;
+const mockDecryptRevokeToken = decryptGoogleHealthConnectionRevokeToken as jest.Mock;
+const mockRevokeToken = revokeGoogleHealthOAuthToken as jest.Mock;
+
+function makeRequest(origin?: string): NextRequest {
+  return new NextRequest("http://localhost/api/google-health/oauth/disconnect", {
+    method: "POST",
+    headers: origin ? { Origin: origin } : undefined,
+  });
+}
+
+describe("POST /api/google-health/oauth/disconnect", () => {
+  beforeEach(() => {
+    mockGetCurrentUser.mockReset();
+    mockCreateServiceRoleClient.mockReset();
+    mockGetConnection.mockReset();
+    mockDeleteConnection.mockReset();
+    mockDecryptRevokeToken.mockReset();
+    mockRevokeToken.mockReset();
+    mockCreateServiceRoleClient.mockReturnValue({ kind: "service-role-client" });
+  });
+
+  it("未認証の場合は 401 を返す", async () => {
+    mockGetCurrentUser.mockResolvedValue(null);
+
+    const response = await POST(makeRequest("http://localhost"));
+
+    expect(response.status).toBe(401);
+    expect(mockCreateServiceRoleClient).not.toHaveBeenCalled();
+  });
+
+  it("same-origin ではない POST は拒否する", async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: "user-id", email: "owner@example.com" });
+
+    const response = await POST(makeRequest("https://attacker.example"));
+
+    expect(response.status).toBe(403);
+    expect(mockCreateServiceRoleClient).not.toHaveBeenCalled();
+  });
+
+  it("Google token を revoke して connection を削除する", async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: "user-id", email: "owner@example.com" });
+    const connection = {
+      encrypted_access_token: { data: "access" },
+      encrypted_refresh_token: { data: "refresh" },
+    };
+    mockGetConnection.mockResolvedValue(connection);
+    mockDecryptRevokeToken.mockReturnValue("refresh-token");
+    mockRevokeToken.mockResolvedValue({ ok: true, status: 200 });
+
+    const response = await POST(makeRequest("http://localhost"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockGetConnection).toHaveBeenCalledWith("user-id", { kind: "service-role-client" });
+    expect(mockDecryptRevokeToken).toHaveBeenCalledWith(connection);
+    expect(mockRevokeToken).toHaveBeenCalledWith({ token: "refresh-token" });
+    expect(mockDeleteConnection).toHaveBeenCalledWith("user-id", { kind: "service-role-client" });
+    expect(body).toEqual({
+      ok: true,
+      disconnected: true,
+      revokeAttempted: true,
+      revoked: true,
+    });
+    expect(JSON.stringify(body)).not.toContain("refresh-token");
+  });
+
+  it("revoke が失敗しても connection は削除する", async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: "user-id", email: "owner@example.com" });
+    mockGetConnection.mockResolvedValue({ encrypted_access_token: null, encrypted_refresh_token: null });
+    mockDecryptRevokeToken.mockReturnValue(null);
+
+    const response = await POST(makeRequest("http://localhost"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockRevokeToken).not.toHaveBeenCalled();
+    expect(mockDeleteConnection).toHaveBeenCalledWith("user-id", { kind: "service-role-client" });
+    expect(body).toEqual({
+      ok: true,
+      disconnected: true,
+      revokeAttempted: false,
+      revoked: false,
+    });
+  });
+});

--- a/src/app/api/google-health/oauth/disconnect/route.ts
+++ b/src/app/api/google-health/oauth/disconnect/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  deleteGoogleHealthConnection,
+  decryptGoogleHealthConnectionRevokeToken,
+  getGoogleHealthConnectionByUserId,
+} from "@/lib/googleHealth/connections";
+import { revokeGoogleHealthOAuthToken } from "@/lib/googleHealth/oauth";
+import { createServiceRoleClient } from "@/lib/supabase/serviceRole";
+import { getCurrentUser } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+
+function isSameOriginRequest(request: NextRequest): boolean {
+  const origin = request.headers.get("Origin");
+  if (!origin) return false;
+
+  try {
+    return new URL(origin).origin === request.nextUrl.origin;
+  } catch {
+    return false;
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const user = await getCurrentUser();
+  if (!user) {
+    return NextResponse.json({ error: "auth_required" }, { status: 401 });
+  }
+
+  if (!isSameOriginRequest(request)) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+
+  const client = createServiceRoleClient();
+  const connection = await getGoogleHealthConnectionByUserId(user.id, client);
+  let revokeAttempted = false;
+  let revoked = false;
+
+  if (connection) {
+    try {
+      const revokeToken = decryptGoogleHealthConnectionRevokeToken(connection);
+      if (revokeToken) {
+        revokeAttempted = true;
+        const revokeResult = await revokeGoogleHealthOAuthToken({ token: revokeToken });
+        revoked = revokeResult.ok;
+      }
+    } catch {
+      revokeAttempted = false;
+      revoked = false;
+    }
+  }
+
+  await deleteGoogleHealthConnection(user.id, client);
+
+  return NextResponse.json({
+    ok: true,
+    disconnected: true,
+    revokeAttempted,
+    revoked,
+  });
+}

--- a/src/app/api/google-health/oauth/start/route.test.ts
+++ b/src/app/api/google-health/oauth/start/route.test.ts
@@ -1,0 +1,83 @@
+jest.mock("@/lib/supabase/server", () => ({
+  getCurrentUser: jest.fn(),
+}));
+
+import { NextRequest } from "next/server";
+import { GOOGLE_HEALTH_OAUTH_STATE_COOKIE } from "@/lib/googleHealth/oauth";
+import { getCurrentUser } from "@/lib/supabase/server";
+import { GET } from "./route";
+
+const mockGetCurrentUser = getCurrentUser as jest.Mock;
+
+const originalEnv = process.env;
+
+function makeRequest(params?: Record<string, string>): NextRequest {
+  const url = new URL("http://localhost/api/google-health/oauth/start");
+  for (const [key, value] of Object.entries(params ?? {})) {
+    url.searchParams.set(key, value);
+  }
+  return new NextRequest(url.toString());
+}
+
+function setOAuthEnv() {
+  process.env = {
+    ...originalEnv,
+    GOOGLE_OAUTH_CLIENT_ID: "google-client-id",
+    GOOGLE_OAUTH_CLIENT_SECRET: "google-client-secret",
+    GOOGLE_OAUTH_REDIRECT_URI: "http://localhost/api/google-health/oauth/callback",
+    GOOGLE_HEALTH_OAUTH_STATE_SECRET: "0123456789abcdef0123456789abcdef",
+  };
+}
+
+describe("GET /api/google-health/oauth/start", () => {
+  beforeEach(() => {
+    mockGetCurrentUser.mockReset();
+    setOAuthEnv();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("未認証の場合は 401 を返す", async () => {
+    mockGetCurrentUser.mockResolvedValue(null);
+
+    const response = await GET(makeRequest());
+
+    expect(response.status).toBe(401);
+  });
+
+  it("Google OAuth 認可 URL へ redirect し、httpOnly state cookie を設定する", async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: "user-id", email: "owner@example.com" });
+
+    const response = await GET(makeRequest({ prompt: "consent" }));
+    const location = response.headers.get("location");
+    const cookie = response.headers.get("set-cookie") ?? "";
+
+    expect(response.status).toBe(307);
+    expect(location).not.toBeNull();
+    const url = new URL(location!);
+    expect(url.origin + url.pathname).toBe("https://accounts.google.com/o/oauth2/v2/auth");
+    expect(url.searchParams.get("client_id")).toBe("google-client-id");
+    expect(url.searchParams.get("redirect_uri")).toBe("http://localhost/api/google-health/oauth/callback");
+    expect(url.searchParams.get("access_type")).toBe("offline");
+    expect(url.searchParams.get("include_granted_scopes")).toBe("true");
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(url.searchParams.get("prompt")).toBe("consent");
+
+    expect(cookie).toContain(`${GOOGLE_HEALTH_OAUTH_STATE_COOKIE}=`);
+    expect(cookie).toContain("HttpOnly");
+    expect(cookie.toLowerCase()).toContain("samesite=lax");
+    expect(cookie).toContain("Path=/");
+  });
+
+  it("許可されない prompt は 400 を返す", async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: "user-id", email: "owner@example.com" });
+
+    const response = await GET(makeRequest({ prompt: "select_account" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("google_health_oauth_prompt_invalid");
+  });
+});

--- a/src/app/api/google-health/oauth/start/route.ts
+++ b/src/app/api/google-health/oauth/start/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  GOOGLE_HEALTH_OAUTH_STATE_COOKIE,
+  GOOGLE_HEALTH_OAUTH_STATE_TTL_SECONDS,
+  buildGoogleHealthOAuthAuthorizationUrl,
+  createGoogleHealthOAuthStateCookieValue,
+  generateGoogleHealthOAuthState,
+  generateGoogleHealthPkcePair,
+  getGoogleHealthOAuthConfig,
+  parseGoogleHealthOAuthPrompt,
+} from "@/lib/googleHealth/oauth";
+import { getCurrentUser } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+
+function setStateCookie(response: NextResponse, value: string): NextResponse {
+  response.cookies.set(GOOGLE_HEALTH_OAUTH_STATE_COOKIE, value, {
+    httpOnly: true,
+    maxAge: GOOGLE_HEALTH_OAUTH_STATE_TTL_SECONDS,
+    path: "/",
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+  });
+  return response;
+}
+
+export async function GET(request: NextRequest) {
+  const user = await getCurrentUser();
+  if (!user) {
+    return NextResponse.json({ error: "auth_required" }, { status: 401 });
+  }
+
+  let prompt: "consent" | null;
+  try {
+    prompt = parseGoogleHealthOAuthPrompt(request.nextUrl.searchParams.get("prompt"));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "google_health_oauth_prompt_invalid";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+
+  let config;
+  try {
+    config = getGoogleHealthOAuthConfig();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "google_health_oauth_config_error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+
+  const state = generateGoogleHealthOAuthState();
+  const { codeVerifier, codeChallenge } = generateGoogleHealthPkcePair();
+  const expiresAt = Math.floor(Date.now() / 1000) + GOOGLE_HEALTH_OAUTH_STATE_TTL_SECONDS;
+  const cookieValue = createGoogleHealthOAuthStateCookieValue(
+    {
+      state,
+      codeVerifier,
+      userId: user.id,
+      expiresAt,
+    },
+    config.stateSecret,
+  );
+
+  const authorizationUrl = buildGoogleHealthOAuthAuthorizationUrl({
+    config,
+    state,
+    codeChallenge,
+    prompt,
+  });
+
+  return setStateCookie(NextResponse.redirect(authorizationUrl), cookieValue);
+}

--- a/src/lib/googleHealth/connections.test.ts
+++ b/src/lib/googleHealth/connections.test.ts
@@ -1,0 +1,95 @@
+import { saveGoogleHealthOAuthConnection } from "./connections";
+import { GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES } from "./dailyMetrics";
+import type { Json } from "@/lib/supabase/types";
+
+const originalEnv = process.env;
+const encryptionKey = Buffer.from("0123456789abcdef0123456789abcdef", "utf8").toString("base64url");
+
+function makeClient(existing: { encrypted_refresh_token: Json | null } | null) {
+  const maybeSingle = jest.fn().mockResolvedValue({ data: existing, error: null });
+  const getEq = jest.fn().mockReturnValue({ maybeSingle });
+  const getSelect = jest.fn().mockReturnValue({ eq: getEq });
+  const single = jest.fn().mockImplementation(() => Promise.resolve({
+    data: {
+      id: "connection-id",
+      created_at: "2026-06-05T00:00:00.000Z",
+      updated_at: "2026-06-05T00:00:00.000Z",
+      ...upsert.mock.calls[0][0],
+    },
+    error: null,
+  }));
+  const upsertSelect = jest.fn().mockReturnValue({ single });
+  const upsert = jest.fn().mockReturnValue({ select: upsertSelect });
+  const from = jest.fn().mockReturnValue({
+    select: getSelect,
+    upsert,
+  });
+  const schema = jest.fn().mockReturnValue({ from });
+
+  return {
+    client: { schema },
+    upsert,
+  };
+}
+
+describe("Google Health connections", () => {
+  beforeEach(() => {
+    process.env = {
+      ...originalEnv,
+      GOOGLE_HEALTH_TOKEN_ENCRYPTION_KEY: encryptionKey,
+    };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("refresh token が返らない場合は既存の暗号化済み refresh token を維持する", async () => {
+    const existingRefreshToken = { v: 1, alg: "A256GCM", kid: "1", iv: "iv", tag: "tag", data: "data" };
+    const { client, upsert } = makeClient({ encrypted_refresh_token: existingRefreshToken });
+
+    const result = await saveGoogleHealthOAuthConnection({
+      userId: "user-id",
+      client: client as never,
+      token: {
+        accessToken: "access-token",
+        refreshToken: null,
+        expiresIn: 3600,
+        grantedScopes: [...GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES],
+        tokenType: "Bearer",
+      },
+    });
+
+    expect(result.status).toBe("connected");
+    expect(upsert).toHaveBeenCalledWith(expect.objectContaining({
+      user_id: "user-id",
+      encrypted_refresh_token: existingRefreshToken,
+      status: "connected",
+      last_error_code: null,
+      last_error_message: null,
+    }), { onConflict: "user_id" });
+  });
+
+  it("refresh token がなく既存 connection もない場合は reauthorization_required にする", async () => {
+    const { client, upsert } = makeClient(null);
+
+    const result = await saveGoogleHealthOAuthConnection({
+      userId: "user-id",
+      client: client as never,
+      token: {
+        accessToken: "access-token",
+        refreshToken: null,
+        expiresIn: null,
+        grantedScopes: [...GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES],
+        tokenType: "Bearer",
+      },
+    });
+
+    expect(result.status).toBe("reauthorization_required");
+    expect(upsert).toHaveBeenCalledWith(expect.objectContaining({
+      encrypted_refresh_token: null,
+      status: "reauthorization_required",
+      last_error_code: "reauthorization_required",
+    }), { onConflict: "user_id" });
+  });
+});

--- a/src/lib/googleHealth/connections.ts
+++ b/src/lib/googleHealth/connections.ts
@@ -1,0 +1,159 @@
+import { createServiceRoleClient } from "@/lib/supabase/serviceRole";
+import type {
+  Database,
+  GoogleHealthConnectionRow,
+  GoogleHealthConnectionStatus,
+  Json,
+} from "@/lib/supabase/types";
+import {
+  GOOGLE_HEALTH_TOKEN_ENCRYPTION_KEY_VERSION,
+  decryptGoogleHealthToken,
+  encryptGoogleHealthToken,
+} from "./tokenCrypto";
+import {
+  getMissingGoogleHealthOAuthScopes,
+  type GoogleHealthOAuthTokenResponse,
+} from "./oauth";
+
+type ServiceRoleClient = ReturnType<typeof createServiceRoleClient>;
+type GoogleHealthConnectionUpdate =
+  Database["private"]["Tables"]["google_health_connections"]["Update"];
+type GoogleHealthConnectionInsert =
+  Database["private"]["Tables"]["google_health_connections"]["Insert"];
+
+type SaveConnectionResult = {
+  connection: GoogleHealthConnectionRow;
+  missingScopes: string[];
+  status: GoogleHealthConnectionStatus;
+};
+
+function privateConnections(client: ServiceRoleClient) {
+  return client.schema("private").from("google_health_connections");
+}
+
+function encryptedTokenToJson(value: ReturnType<typeof encryptGoogleHealthToken>): Json {
+  return value as unknown as Json;
+}
+
+function buildAccessTokenExpiresAt(expiresIn: number | null, now = Date.now()): string | null {
+  if (!expiresIn) return null;
+  return new Date(now + expiresIn * 1000).toISOString();
+}
+
+function sanitizeErrorMessage(message: string | null | undefined): string | null {
+  if (!message) return null;
+  return message.length > 500 ? message.slice(0, 500) : message;
+}
+
+function resolveStatus(args: {
+  missingScopes: readonly string[];
+  encryptedRefreshToken: Json | null;
+}): GoogleHealthConnectionStatus {
+  if (args.missingScopes.length > 0) return "scope_missing";
+  if (!args.encryptedRefreshToken) return "reauthorization_required";
+  return "connected";
+}
+
+export async function getGoogleHealthConnectionByUserId(
+  userId: string,
+  client: ServiceRoleClient = createServiceRoleClient(),
+): Promise<GoogleHealthConnectionRow | null> {
+  const { data, error } = await privateConnections(client)
+    .select("*")
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error("google_health_connection_fetch_failed");
+  }
+
+  return data;
+}
+
+export async function saveGoogleHealthOAuthConnection(args: {
+  userId: string;
+  token: GoogleHealthOAuthTokenResponse;
+  client?: ServiceRoleClient;
+}): Promise<SaveConnectionResult> {
+  const client = args.client ?? createServiceRoleClient();
+  const existing = await getGoogleHealthConnectionByUserId(args.userId, client);
+
+  const encryptedAccessToken = encryptedTokenToJson(encryptGoogleHealthToken(args.token.accessToken));
+  const encryptedRefreshToken = args.token.refreshToken
+    ? encryptedTokenToJson(encryptGoogleHealthToken(args.token.refreshToken))
+    : existing?.encrypted_refresh_token ?? null;
+  const missingScopes = getMissingGoogleHealthOAuthScopes(args.token.grantedScopes);
+  const status = resolveStatus({ missingScopes, encryptedRefreshToken });
+  const lastCheckedAt = new Date().toISOString();
+
+  const payload: GoogleHealthConnectionInsert = {
+    user_id: args.userId,
+    encrypted_access_token: encryptedAccessToken,
+    encrypted_refresh_token: encryptedRefreshToken,
+    access_token_expires_at: buildAccessTokenExpiresAt(args.token.expiresIn),
+    granted_scopes: args.token.grantedScopes,
+    status,
+    last_checked_at: lastCheckedAt,
+    last_error_code: status === "connected" ? null : status,
+    last_error_message: status === "connected"
+      ? null
+      : status === "scope_missing"
+        ? "Required Google Health OAuth scopes are missing."
+        : "Google Health OAuth refresh token is missing.",
+    encryption_key_version: GOOGLE_HEALTH_TOKEN_ENCRYPTION_KEY_VERSION,
+  };
+
+  const { data, error } = await privateConnections(client)
+    .upsert(payload, { onConflict: "user_id" })
+    .select("*")
+    .single();
+
+  if (error) {
+    throw new Error("google_health_connection_upsert_failed");
+  }
+
+  return { connection: data, missingScopes, status };
+}
+
+export async function markGoogleHealthConnectionError(args: {
+  userId: string;
+  code: string;
+  message?: string | null;
+  client?: ServiceRoleClient;
+}): Promise<void> {
+  const client = args.client ?? createServiceRoleClient();
+  const payload: GoogleHealthConnectionUpdate = {
+    status: "error",
+    last_checked_at: new Date().toISOString(),
+    last_error_code: args.code,
+    last_error_message: sanitizeErrorMessage(args.message),
+  };
+
+  const { error } = await privateConnections(client)
+    .update(payload)
+    .eq("user_id", args.userId);
+
+  if (error) {
+    throw new Error("google_health_connection_error_update_failed");
+  }
+}
+
+export async function deleteGoogleHealthConnection(
+  userId: string,
+  client: ServiceRoleClient = createServiceRoleClient(),
+): Promise<void> {
+  const { error } = await privateConnections(client)
+    .delete()
+    .eq("user_id", userId);
+
+  if (error) {
+    throw new Error("google_health_connection_delete_failed");
+  }
+}
+
+export function decryptGoogleHealthConnectionRevokeToken(
+  connection: Pick<GoogleHealthConnectionRow, "encrypted_access_token" | "encrypted_refresh_token">,
+): string | null {
+  const payload = connection.encrypted_refresh_token ?? connection.encrypted_access_token;
+  return payload ? decryptGoogleHealthToken(payload) : null;
+}

--- a/src/lib/googleHealth/oauth.test.ts
+++ b/src/lib/googleHealth/oauth.test.ts
@@ -137,7 +137,27 @@ describe("Google Health OAuth helpers", () => {
   it("token exchange 失敗時は sanitized error を返す", async () => {
     const fetchFn = jest.fn().mockResolvedValue({
       ok: false,
-      json: jest.fn().mockResolvedValue({ error_description: "secret detail" }),
+      json: jest.fn().mockResolvedValue({
+        error: "invalid_grant",
+        error_description: "secret detail",
+      }),
+    });
+
+    await expect(exchangeGoogleHealthOAuthCode({
+      config,
+      code: "authorization-code",
+      codeVerifier: "code-verifier",
+      fetchFn,
+    })).rejects.toThrow("google_health_oauth_token_exchange_invalid_grant");
+  });
+
+  it("想定外の token exchange error は generic reason に丸める", async () => {
+    const fetchFn = jest.fn().mockResolvedValue({
+      ok: false,
+      json: jest.fn().mockResolvedValue({
+        error: "unexpected_error",
+        error_description: "secret detail",
+      }),
     });
 
     await expect(exchangeGoogleHealthOAuthCode({

--- a/src/lib/googleHealth/oauth.test.ts
+++ b/src/lib/googleHealth/oauth.test.ts
@@ -1,0 +1,155 @@
+import {
+  GOOGLE_HEALTH_OAUTH_STATE_TTL_SECONDS,
+  GOOGLE_OAUTH_TOKEN_URL,
+  buildGoogleHealthOAuthAuthorizationUrl,
+  createGoogleHealthOAuthStateCookieValue,
+  exchangeGoogleHealthOAuthCode,
+  generateGoogleHealthPkcePair,
+  getGoogleHealthOAuthConfig,
+  getMissingGoogleHealthOAuthScopes,
+  parseGoogleHealthOAuthPrompt,
+  parseGoogleHealthOAuthStateCookieValue,
+} from "./oauth";
+import { GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES } from "./dailyMetrics";
+
+const config = {
+  clientId: "google-client-id",
+  clientSecret: "google-client-secret",
+  redirectUri: "https://example.com/api/google-health/oauth/callback",
+  stateSecret: "0123456789abcdef0123456789abcdef",
+};
+
+describe("Google Health OAuth helpers", () => {
+  it("required env から OAuth config を作成する", () => {
+    expect(getGoogleHealthOAuthConfig({
+      GOOGLE_OAUTH_CLIENT_ID: config.clientId,
+      GOOGLE_OAUTH_CLIENT_SECRET: config.clientSecret,
+      GOOGLE_OAUTH_REDIRECT_URI: config.redirectUri,
+      GOOGLE_HEALTH_OAUTH_STATE_SECRET: config.stateSecret,
+    })).toEqual(config);
+  });
+
+  it("state secret が短い場合は拒否する", () => {
+    expect(() => getGoogleHealthOAuthConfig({
+      GOOGLE_OAUTH_CLIENT_ID: config.clientId,
+      GOOGLE_OAUTH_CLIENT_SECRET: config.clientSecret,
+      GOOGLE_OAUTH_REDIRECT_URI: config.redirectUri,
+      GOOGLE_HEALTH_OAUTH_STATE_SECRET: "short",
+    })).toThrow("google_health_oauth_state_secret_invalid");
+  });
+
+  it("認可 URL に必要な Google OAuth パラメータを含める", () => {
+    const url = buildGoogleHealthOAuthAuthorizationUrl({
+      config,
+      state: "state-value",
+      codeChallenge: "code-challenge",
+      prompt: "consent",
+    });
+
+    expect(url.origin + url.pathname).toBe("https://accounts.google.com/o/oauth2/v2/auth");
+    expect(url.searchParams.get("client_id")).toBe(config.clientId);
+    expect(url.searchParams.get("redirect_uri")).toBe(config.redirectUri);
+    expect(url.searchParams.get("response_type")).toBe("code");
+    expect(url.searchParams.get("access_type")).toBe("offline");
+    expect(url.searchParams.get("include_granted_scopes")).toBe("true");
+    expect(url.searchParams.get("state")).toBe("state-value");
+    expect(url.searchParams.get("code_challenge")).toBe("code-challenge");
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(url.searchParams.get("prompt")).toBe("consent");
+    expect(url.searchParams.get("scope")).toBe(GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES.join(" "));
+  });
+
+  it("prompt は consent のみ許可する", () => {
+    expect(parseGoogleHealthOAuthPrompt(null)).toBeNull();
+    expect(parseGoogleHealthOAuthPrompt("")).toBeNull();
+    expect(parseGoogleHealthOAuthPrompt("consent")).toBe("consent");
+    expect(() => parseGoogleHealthOAuthPrompt("select_account"))
+      .toThrow("google_health_oauth_prompt_invalid");
+  });
+
+  it("PKCE verifier と S256 challenge を生成する", () => {
+    const { codeVerifier, codeChallenge } = generateGoogleHealthPkcePair();
+
+    expect(codeVerifier).toHaveLength(43);
+    expect(codeChallenge).toHaveLength(43);
+    expect(codeVerifier).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(codeChallenge).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  it("state cookie payload を署名して検証できる", () => {
+    const payload = {
+      state: "state-value",
+      codeVerifier: "code-verifier",
+      userId: "user-id",
+      expiresAt: Math.floor(Date.now() / 1000) + GOOGLE_HEALTH_OAUTH_STATE_TTL_SECONDS,
+    };
+
+    const value = createGoogleHealthOAuthStateCookieValue(payload, config.stateSecret);
+
+    expect(parseGoogleHealthOAuthStateCookieValue(value, config.stateSecret)).toEqual(payload);
+    expect(() => parseGoogleHealthOAuthStateCookieValue(`${value}x`, config.stateSecret))
+      .toThrow("google_health_oauth_state_invalid");
+  });
+
+  it("authorization code を token endpoint に交換する", async () => {
+    const fetchFn = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({
+        access_token: "access-token",
+        refresh_token: "refresh-token",
+        expires_in: 3600,
+        scope: "scope-a scope-b",
+        token_type: "Bearer",
+      }),
+    });
+
+    const token = await exchangeGoogleHealthOAuthCode({
+      config,
+      code: "authorization-code",
+      codeVerifier: "code-verifier",
+      fetchFn,
+    });
+
+    expect(fetchFn).toHaveBeenCalledWith(GOOGLE_OAUTH_TOKEN_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: expect.any(URLSearchParams),
+    });
+    const body = fetchFn.mock.calls[0][1].body as URLSearchParams;
+    expect(body.get("client_id")).toBe(config.clientId);
+    expect(body.get("client_secret")).toBe(config.clientSecret);
+    expect(body.get("code")).toBe("authorization-code");
+    expect(body.get("code_verifier")).toBe("code-verifier");
+    expect(body.get("grant_type")).toBe("authorization_code");
+    expect(token).toEqual({
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      expiresIn: 3600,
+      grantedScopes: ["scope-a", "scope-b"],
+      tokenType: "Bearer",
+    });
+  });
+
+  it("token exchange 失敗時は sanitized error を返す", async () => {
+    const fetchFn = jest.fn().mockResolvedValue({
+      ok: false,
+      json: jest.fn().mockResolvedValue({ error_description: "secret detail" }),
+    });
+
+    await expect(exchangeGoogleHealthOAuthCode({
+      config,
+      code: "authorization-code",
+      codeVerifier: "code-verifier",
+      fetchFn,
+    })).rejects.toThrow("google_health_oauth_token_exchange_failed");
+  });
+
+  it("不足 scope を検出する", () => {
+    expect(getMissingGoogleHealthOAuthScopes([
+      GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES[0],
+    ])).toEqual([
+      GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES[1],
+      GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES[2],
+    ]);
+  });
+});

--- a/src/lib/googleHealth/oauth.test.ts
+++ b/src/lib/googleHealth/oauth.test.ts
@@ -85,9 +85,13 @@ describe("Google Health OAuth helpers", () => {
     };
 
     const value = createGoogleHealthOAuthStateCookieValue(payload, config.stateSecret);
+    const parts = value.split(".");
+    expect(parts).toHaveLength(4);
+    const authTag = parts[2]!;
+    parts[2] = authTag.startsWith("A") ? `B${authTag.slice(1)}` : `A${authTag.slice(1)}`;
 
     expect(parseGoogleHealthOAuthStateCookieValue(value, config.stateSecret)).toEqual(payload);
-    expect(() => parseGoogleHealthOAuthStateCookieValue(`${value}x`, config.stateSecret))
+    expect(() => parseGoogleHealthOAuthStateCookieValue(parts.join("."), config.stateSecret))
       .toThrow("google_health_oauth_state_invalid");
   });
 

--- a/src/lib/googleHealth/oauth.ts
+++ b/src/lib/googleHealth/oauth.ts
@@ -1,8 +1,8 @@
 import {
+  createCipheriv,
+  createDecipheriv,
   createHash,
-  createHmac,
   randomBytes,
-  timingSafeEqual,
 } from "crypto";
 import { GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES } from "./dailyMetrics";
 
@@ -17,7 +17,12 @@ const GOOGLE_OAUTH_CLIENT_ID_ENV = "GOOGLE_OAUTH_CLIENT_ID";
 const GOOGLE_OAUTH_CLIENT_SECRET_ENV = "GOOGLE_OAUTH_CLIENT_SECRET";
 const GOOGLE_OAUTH_REDIRECT_URI_ENV = "GOOGLE_OAUTH_REDIRECT_URI";
 const GOOGLE_HEALTH_OAUTH_STATE_SECRET_ENV = "GOOGLE_HEALTH_OAUTH_STATE_SECRET";
-const MIN_STATE_SECRET_BYTES = 32;
+const STATE_COOKIE_ALGORITHM = "aes-256-gcm";
+const STATE_COOKIE_VERSION = "v1";
+const STATE_SECRET_BYTES = 32;
+const STATE_IV_BYTES = 12;
+const STATE_AUTH_TAG_BYTES = 16;
+const STATE_AAD = Buffer.from("body-comp-tracker-v2:google-health-oauth-state:v1", "utf8");
 
 type EnvLike = Record<string, string | undefined>;
 type FetchLike = (input: string, init: RequestInit) => Promise<Response>;
@@ -62,6 +67,26 @@ function fromBase64Url(value: string): Buffer {
   }
 }
 
+function parseStateSecretKey(value: string): Buffer {
+  const normalized = value.trim();
+
+  if (/^[0-9a-f]{64}$/i.test(normalized)) {
+    return Buffer.from(normalized, "hex");
+  }
+
+  try {
+    const decoded = Buffer.from(normalized, "base64url");
+    if (decoded.byteLength === STATE_SECRET_BYTES) return decoded;
+  } catch {
+    // Fall back to exactly 32 bytes of raw UTF-8 below.
+  }
+
+  const raw = Buffer.from(normalized, "utf8");
+  if (raw.byteLength === STATE_SECRET_BYTES) return raw;
+
+  throw new Error("google_health_oauth_state_secret_invalid");
+}
+
 function asRecord(value: unknown): Record<string, unknown> | null {
   return value !== null && typeof value === "object" && !Array.isArray(value)
     ? value as Record<string, unknown>
@@ -89,16 +114,6 @@ function parseJsonPayload(value: Buffer): GoogleHealthOAuthStatePayload {
   }
 }
 
-function signStatePayload(encodedPayload: string, secret: string): string {
-  return createHmac("sha256", secret).update(encodedPayload).digest("base64url");
-}
-
-function timingSafeEqualString(a: string, b: string): boolean {
-  const aBuffer = Buffer.from(a);
-  const bBuffer = Buffer.from(b);
-  return aBuffer.byteLength === bBuffer.byteLength && timingSafeEqual(aBuffer, bBuffer);
-}
-
 function normalizePrompt(value: string | null): "consent" | null {
   if (value === null || value === "") return null;
   if (value === "consent") return "consent";
@@ -111,9 +126,7 @@ export function getGoogleHealthOAuthConfig(env: EnvLike = process.env): GoogleHe
   const redirectUri = readRequiredEnv(env, GOOGLE_OAUTH_REDIRECT_URI_ENV);
   const stateSecret = readRequiredEnv(env, GOOGLE_HEALTH_OAUTH_STATE_SECRET_ENV);
 
-  if (Buffer.byteLength(stateSecret, "utf8") < MIN_STATE_SECRET_BYTES) {
-    throw new Error("google_health_oauth_state_secret_invalid");
-  }
+  parseStateSecretKey(stateSecret);
 
   try {
     new URL(redirectUri);
@@ -145,25 +158,64 @@ export function createGoogleHealthOAuthStateCookieValue(
   payload: GoogleHealthOAuthStatePayload,
   secret: string,
 ): string {
-  const encodedPayload = toBase64Url(Buffer.from(JSON.stringify(payload), "utf8"));
-  return `${encodedPayload}.${signStatePayload(encodedPayload, secret)}`;
+  const key = parseStateSecretKey(secret);
+  const iv = randomBytes(STATE_IV_BYTES);
+  const cipher = createCipheriv(STATE_COOKIE_ALGORITHM, key, iv);
+  cipher.setAAD(STATE_AAD);
+
+  const ciphertext = Buffer.concat([
+    cipher.update(JSON.stringify(payload), "utf8"),
+    cipher.final(),
+  ]);
+  const authTag = cipher.getAuthTag();
+
+  return [
+    STATE_COOKIE_VERSION,
+    toBase64Url(iv),
+    toBase64Url(authTag),
+    toBase64Url(ciphertext),
+  ].join(".");
 }
 
 export function parseGoogleHealthOAuthStateCookieValue(
   value: string,
   secret: string,
 ): GoogleHealthOAuthStatePayload {
-  const [encodedPayload, signature, extra] = value.split(".");
-  if (!encodedPayload || !signature || extra !== undefined) {
+  const [version, encodedIv, encodedAuthTag, encodedCiphertext, extra] = value.split(".");
+  if (
+    version !== STATE_COOKIE_VERSION ||
+    !encodedIv ||
+    !encodedAuthTag ||
+    !encodedCiphertext ||
+    extra !== undefined
+  ) {
     throw new Error("google_health_oauth_state_invalid");
   }
 
-  const expectedSignature = signStatePayload(encodedPayload, secret);
-  if (!timingSafeEqualString(signature, expectedSignature)) {
+  const key = parseStateSecretKey(secret);
+  const iv = fromBase64Url(encodedIv);
+  const authTag = fromBase64Url(encodedAuthTag);
+  const ciphertext = fromBase64Url(encodedCiphertext);
+
+  if (
+    iv.byteLength !== STATE_IV_BYTES ||
+    authTag.byteLength !== STATE_AUTH_TAG_BYTES ||
+    ciphertext.byteLength === 0
+  ) {
     throw new Error("google_health_oauth_state_invalid");
   }
 
-  return parseJsonPayload(fromBase64Url(encodedPayload));
+  try {
+    const decipher = createDecipheriv(STATE_COOKIE_ALGORITHM, key, iv);
+    decipher.setAAD(STATE_AAD);
+    decipher.setAuthTag(authTag);
+    return parseJsonPayload(Buffer.concat([
+      decipher.update(ciphertext),
+      decipher.final(),
+    ]));
+  } catch {
+    throw new Error("google_health_oauth_state_invalid");
+  }
 }
 
 export function buildGoogleHealthOAuthAuthorizationUrl(args: {

--- a/src/lib/googleHealth/oauth.ts
+++ b/src/lib/googleHealth/oauth.ts
@@ -1,0 +1,283 @@
+import {
+  createHash,
+  createHmac,
+  randomBytes,
+  timingSafeEqual,
+} from "crypto";
+import { GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES } from "./dailyMetrics";
+
+export const GOOGLE_HEALTH_OAUTH_STATE_COOKIE = "bc_google_health_oauth_state";
+export const GOOGLE_HEALTH_OAUTH_STATE_TTL_SECONDS = 10 * 60;
+
+export const GOOGLE_OAUTH_AUTHORIZE_URL = "https://accounts.google.com/o/oauth2/v2/auth";
+export const GOOGLE_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
+export const GOOGLE_OAUTH_REVOKE_URL = "https://oauth2.googleapis.com/revoke";
+
+const GOOGLE_OAUTH_CLIENT_ID_ENV = "GOOGLE_OAUTH_CLIENT_ID";
+const GOOGLE_OAUTH_CLIENT_SECRET_ENV = "GOOGLE_OAUTH_CLIENT_SECRET";
+const GOOGLE_OAUTH_REDIRECT_URI_ENV = "GOOGLE_OAUTH_REDIRECT_URI";
+const GOOGLE_HEALTH_OAUTH_STATE_SECRET_ENV = "GOOGLE_HEALTH_OAUTH_STATE_SECRET";
+const MIN_STATE_SECRET_BYTES = 32;
+
+type EnvLike = Record<string, string | undefined>;
+type FetchLike = (input: string, init: RequestInit) => Promise<Response>;
+
+export type GoogleHealthOAuthConfig = {
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+  stateSecret: string;
+};
+
+export type GoogleHealthOAuthStatePayload = {
+  state: string;
+  codeVerifier: string;
+  userId: string;
+  expiresAt: number;
+};
+
+export type GoogleHealthOAuthTokenResponse = {
+  accessToken: string;
+  refreshToken: string | null;
+  expiresIn: number | null;
+  grantedScopes: string[];
+  tokenType: string | null;
+};
+
+function readRequiredEnv(env: EnvLike, key: string): string {
+  const value = env[key]?.trim();
+  if (!value) throw new Error("google_health_oauth_config_missing");
+  return value;
+}
+
+function toBase64Url(value: Buffer): string {
+  return value.toString("base64url");
+}
+
+function fromBase64Url(value: string): Buffer {
+  try {
+    return Buffer.from(value, "base64url");
+  } catch {
+    throw new Error("google_health_oauth_state_invalid");
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function parseJsonPayload(value: Buffer): GoogleHealthOAuthStatePayload {
+  try {
+    const parsed = JSON.parse(value.toString("utf8"));
+    const record = asRecord(parsed);
+    if (!record) throw new Error("invalid");
+
+    const state = typeof record.state === "string" ? record.state : null;
+    const codeVerifier = typeof record.codeVerifier === "string" ? record.codeVerifier : null;
+    const userId = typeof record.userId === "string" ? record.userId : null;
+    const expiresAt = typeof record.expiresAt === "number" ? record.expiresAt : null;
+
+    if (!state || !codeVerifier || !userId || !expiresAt) {
+      throw new Error("invalid");
+    }
+
+    return { state, codeVerifier, userId, expiresAt };
+  } catch {
+    throw new Error("google_health_oauth_state_invalid");
+  }
+}
+
+function signStatePayload(encodedPayload: string, secret: string): string {
+  return createHmac("sha256", secret).update(encodedPayload).digest("base64url");
+}
+
+function timingSafeEqualString(a: string, b: string): boolean {
+  const aBuffer = Buffer.from(a);
+  const bBuffer = Buffer.from(b);
+  return aBuffer.byteLength === bBuffer.byteLength && timingSafeEqual(aBuffer, bBuffer);
+}
+
+function normalizePrompt(value: string | null): "consent" | null {
+  if (value === null || value === "") return null;
+  if (value === "consent") return "consent";
+  throw new Error("google_health_oauth_prompt_invalid");
+}
+
+export function getGoogleHealthOAuthConfig(env: EnvLike = process.env): GoogleHealthOAuthConfig {
+  const clientId = readRequiredEnv(env, GOOGLE_OAUTH_CLIENT_ID_ENV);
+  const clientSecret = readRequiredEnv(env, GOOGLE_OAUTH_CLIENT_SECRET_ENV);
+  const redirectUri = readRequiredEnv(env, GOOGLE_OAUTH_REDIRECT_URI_ENV);
+  const stateSecret = readRequiredEnv(env, GOOGLE_HEALTH_OAUTH_STATE_SECRET_ENV);
+
+  if (Buffer.byteLength(stateSecret, "utf8") < MIN_STATE_SECRET_BYTES) {
+    throw new Error("google_health_oauth_state_secret_invalid");
+  }
+
+  try {
+    new URL(redirectUri);
+  } catch {
+    throw new Error("google_health_oauth_redirect_uri_invalid");
+  }
+
+  return { clientId, clientSecret, redirectUri, stateSecret };
+}
+
+export function parseGoogleHealthOAuthPrompt(value: string | null): "consent" | null {
+  return normalizePrompt(value);
+}
+
+export function generateGoogleHealthOAuthState(): string {
+  return toBase64Url(randomBytes(32));
+}
+
+export function generateGoogleHealthPkcePair(): {
+  codeVerifier: string;
+  codeChallenge: string;
+} {
+  const codeVerifier = toBase64Url(randomBytes(32));
+  const codeChallenge = toBase64Url(createHash("sha256").update(codeVerifier).digest());
+  return { codeVerifier, codeChallenge };
+}
+
+export function createGoogleHealthOAuthStateCookieValue(
+  payload: GoogleHealthOAuthStatePayload,
+  secret: string,
+): string {
+  const encodedPayload = toBase64Url(Buffer.from(JSON.stringify(payload), "utf8"));
+  return `${encodedPayload}.${signStatePayload(encodedPayload, secret)}`;
+}
+
+export function parseGoogleHealthOAuthStateCookieValue(
+  value: string,
+  secret: string,
+): GoogleHealthOAuthStatePayload {
+  const [encodedPayload, signature, extra] = value.split(".");
+  if (!encodedPayload || !signature || extra !== undefined) {
+    throw new Error("google_health_oauth_state_invalid");
+  }
+
+  const expectedSignature = signStatePayload(encodedPayload, secret);
+  if (!timingSafeEqualString(signature, expectedSignature)) {
+    throw new Error("google_health_oauth_state_invalid");
+  }
+
+  return parseJsonPayload(fromBase64Url(encodedPayload));
+}
+
+export function buildGoogleHealthOAuthAuthorizationUrl(args: {
+  config: GoogleHealthOAuthConfig;
+  state: string;
+  codeChallenge: string;
+  prompt?: "consent" | null;
+}): URL {
+  const url = new URL(GOOGLE_OAUTH_AUTHORIZE_URL);
+  url.searchParams.set("client_id", args.config.clientId);
+  url.searchParams.set("redirect_uri", args.config.redirectUri);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("scope", GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES.join(" "));
+  url.searchParams.set("state", args.state);
+  url.searchParams.set("access_type", "offline");
+  url.searchParams.set("include_granted_scopes", "true");
+  url.searchParams.set("code_challenge", args.codeChallenge);
+  url.searchParams.set("code_challenge_method", "S256");
+  if (args.prompt) {
+    url.searchParams.set("prompt", args.prompt);
+  }
+  return url;
+}
+
+export function getMissingGoogleHealthOAuthScopes(
+  grantedScopes: readonly string[],
+  requiredScopes: readonly string[] = GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES,
+): string[] {
+  const granted = new Set(grantedScopes);
+  return requiredScopes.filter((scope) => !granted.has(scope));
+}
+
+function parseGrantedScopes(value: unknown): string[] {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return [...GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES];
+  }
+  return value.split(/\s+/).map((scope) => scope.trim()).filter(Boolean);
+}
+
+function parseExpiresIn(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return null;
+  }
+  return Math.floor(value);
+}
+
+export async function exchangeGoogleHealthOAuthCode(args: {
+  config: GoogleHealthOAuthConfig;
+  code: string;
+  codeVerifier: string;
+  fetchFn?: FetchLike;
+}): Promise<GoogleHealthOAuthTokenResponse> {
+  const fetchFn = args.fetchFn ?? fetch;
+  const body = new URLSearchParams({
+    client_id: args.config.clientId,
+    client_secret: args.config.clientSecret,
+    code: args.code,
+    grant_type: "authorization_code",
+    redirect_uri: args.config.redirectUri,
+    code_verifier: args.codeVerifier,
+  });
+
+  const response = await fetchFn(GOOGLE_OAUTH_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body,
+  });
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch {
+    payload = null;
+  }
+
+  if (!response.ok) {
+    throw new Error("google_health_oauth_token_exchange_failed");
+  }
+
+  const record = asRecord(payload);
+  const accessToken = typeof record?.access_token === "string" ? record.access_token : null;
+  if (!accessToken) {
+    throw new Error("google_health_oauth_token_response_invalid");
+  }
+
+  const refreshToken = typeof record?.refresh_token === "string" && record.refresh_token.length > 0
+    ? record.refresh_token
+    : null;
+  const tokenType = typeof record?.token_type === "string" ? record.token_type : null;
+
+  return {
+    accessToken,
+    refreshToken,
+    expiresIn: parseExpiresIn(record?.expires_in),
+    grantedScopes: parseGrantedScopes(record?.scope),
+    tokenType,
+  };
+}
+
+export async function revokeGoogleHealthOAuthToken(args: {
+  token: string;
+  fetchFn?: FetchLike;
+}): Promise<{ ok: boolean; status: number | null }> {
+  const fetchFn = args.fetchFn ?? fetch;
+  const body = new URLSearchParams({ token: args.token });
+
+  try {
+    const response = await fetchFn(GOOGLE_OAUTH_REVOKE_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body,
+    });
+    return { ok: response.ok, status: response.status };
+  } catch {
+    return { ok: false, status: null };
+  }
+}

--- a/src/lib/googleHealth/oauth.ts
+++ b/src/lib/googleHealth/oauth.ts
@@ -23,6 +23,14 @@ const STATE_SECRET_BYTES = 32;
 const STATE_IV_BYTES = 12;
 const STATE_AUTH_TAG_BYTES = 16;
 const STATE_AAD = Buffer.from("body-comp-tracker-v2:google-health-oauth-state:v1", "utf8");
+const SAFE_TOKEN_ERROR_REASONS = new Set([
+  "invalid_request",
+  "invalid_client",
+  "invalid_grant",
+  "unauthorized_client",
+  "unsupported_grant_type",
+  "redirect_uri_mismatch",
+]);
 
 type EnvLike = Record<string, string | undefined>;
 type FetchLike = (input: string, init: RequestInit) => Promise<Response>;
@@ -262,6 +270,14 @@ function parseExpiresIn(value: unknown): number | null {
   return Math.floor(value);
 }
 
+function getTokenExchangeErrorReason(payload: unknown): string {
+  const record = asRecord(payload);
+  const error = typeof record?.error === "string" ? record.error : null;
+  return error && SAFE_TOKEN_ERROR_REASONS.has(error)
+    ? `google_health_oauth_token_exchange_${error}`
+    : "google_health_oauth_token_exchange_failed";
+}
+
 export async function exchangeGoogleHealthOAuthCode(args: {
   config: GoogleHealthOAuthConfig;
   code: string;
@@ -292,7 +308,7 @@ export async function exchangeGoogleHealthOAuthCode(args: {
   }
 
   if (!response.ok) {
-    throw new Error("google_health_oauth_token_exchange_failed");
+    throw new Error(getTokenExchangeErrorReason(payload));
   }
 
   const record = asRecord(payload);


### PR DESCRIPTION
## 概要
Google Health OAuth の認可開始、callback、連携解除 API を追加します。

Closes #695

## 変更内容
- `GET /api/google-health/oauth/start` を追加
  - ログイン済みユーザーのみ Google OAuth 認可 URL へ redirect
  - state + PKCE code verifier を httpOnly / SameSite=Lax cookie に短 TTL で保存
  - `prompt=consent` のみ再認可用に許可
- `GET /api/google-health/oauth/callback` を追加
  - state cookie の署名、期限、state、user_id を検証
  - authorization code を Google token endpoint で交換
  - access token を暗号化保存し、refresh token が返らない場合は既存値を維持
  - scope 不足 / refresh token 不足を connection status に反映
- `POST /api/google-health/oauth/disconnect` を追加
  - ログイン済みかつ same-origin POST のみ許可
  - 保存済み token を revoke し、失敗してもローカル connection を削除
- OAuth helper / connection helper と単体テストを追加

## 判断理由
- token 保管は #694 の private schema / service role / AES-GCM helper に集約しました。
- OAuth callback は browser redirect のため、エラー詳細や token 値をレスポンス・URL に含めず sanitized reason のみにしています。
- disconnect は CSRF 対策として `Origin` を確認し、cookie 認証の state-changing API を same-origin に限定しています。

## 検証結果
- `npm run test -- --runInBand src/lib/googleHealth/oauth.test.ts src/lib/googleHealth/connections.test.ts src/app/api/google-health/oauth/start/route.test.ts src/app/api/google-health/oauth/callback/route.test.ts src/app/api/google-health/oauth/disconnect/route.test.ts`
- `npx tsc --noEmit`
- `npm run lint`
- `git diff --cached --check`

## 補足
- 実行には以下の server env が必要です。
  - `GOOGLE_OAUTH_CLIENT_ID`
  - `GOOGLE_OAUTH_CLIENT_SECRET`
  - `GOOGLE_OAUTH_REDIRECT_URI`
  - `GOOGLE_HEALTH_OAUTH_STATE_SECRET`
  - `GOOGLE_HEALTH_TOKEN_ENCRYPTION_KEY`
  - `SUPABASE_SERVICE_ROLE_KEY`
- 設定画面 UI 連携は #687、保存 API の保存済み token 化は #696 の範囲です。
