### PR TITLE
Google Health保存APIを保存済みOAuth token実行へ切り替える

### DIFF
--- a/src/app/api/google-health/daily-metrics/route.test.ts
+++ b/src/app/api/google-health/daily-metrics/route.test.ts
@@ -8,6 +8,10 @@ jest.mock("@/lib/googleHealth/dailyMetrics", () => ({
   fetchGoogleHealthDailyMetrics: jest.fn(),
 }));
 
+jest.mock("@/lib/googleHealth/connections", () => ({
+  resolveGoogleHealthStoredAccessToken: jest.fn(),
+}));
+
 jest.mock("@/lib/googleHealth/saveDailyMetrics", () => ({
   saveGoogleHealthDailyMetrics: jest.fn(),
 }));
@@ -18,6 +22,7 @@ jest.mock("@/lib/cache/revalidate", () => ({
 
 import { NextRequest } from "next/server";
 import { revalidateAfterDailyLogMutation } from "@/lib/cache/revalidate";
+import { resolveGoogleHealthStoredAccessToken } from "@/lib/googleHealth/connections";
 import { fetchGoogleHealthDailyMetrics } from "@/lib/googleHealth/dailyMetrics";
 import { saveGoogleHealthDailyMetrics } from "@/lib/googleHealth/saveDailyMetrics";
 import { createClient, getCurrentUser } from "@/lib/supabase/server";
@@ -25,6 +30,7 @@ import { POST } from "./route";
 
 const mockCreateClient = createClient as jest.Mock;
 const mockGetCurrentUser = getCurrentUser as jest.Mock;
+const mockResolveStoredAccessToken = resolveGoogleHealthStoredAccessToken as jest.Mock;
 const mockFetchGoogleHealthDailyMetrics = fetchGoogleHealthDailyMetrics as jest.Mock;
 const mockSaveGoogleHealthDailyMetrics = saveGoogleHealthDailyMetrics as jest.Mock;
 const mockRevalidate = revalidateAfterDailyLogMutation as jest.Mock;
@@ -33,14 +39,19 @@ function makeRequest(args?: {
   start?: string;
   end?: string;
   authorization?: string;
+  origin?: string | null;
 }): NextRequest {
   const url = new URL("http://localhost/api/google-health/daily-metrics");
   if (args?.start) url.searchParams.set("start", args.start);
   if (args?.end) url.searchParams.set("end", args.end);
 
+  const headers = new Headers();
+  if (args?.authorization) headers.set("Authorization", args.authorization);
+  if (args?.origin !== null) headers.set("Origin", args?.origin ?? "http://localhost");
+
   return new NextRequest(url.toString(), {
     method: "POST",
-    headers: args?.authorization ? { Authorization: args.authorization } : undefined,
+    headers,
   });
 }
 
@@ -48,6 +59,7 @@ describe("POST /api/google-health/daily-metrics", () => {
   beforeEach(() => {
     mockCreateClient.mockReset();
     mockGetCurrentUser.mockReset();
+    mockResolveStoredAccessToken.mockReset();
     mockFetchGoogleHealthDailyMetrics.mockReset();
     mockSaveGoogleHealthDailyMetrics.mockReset();
     mockRevalidate.mockReset();
@@ -56,21 +68,57 @@ describe("POST /api/google-health/daily-metrics", () => {
   it("未認証の場合は 401 を返す", async () => {
     mockGetCurrentUser.mockResolvedValue(null);
 
-    const response = await POST(makeRequest({ authorization: "Bearer google-token" }));
+    const response = await POST(makeRequest());
 
     expect(response.status).toBe(401);
+    expect(mockResolveStoredAccessToken).not.toHaveBeenCalled();
     expect(mockFetchGoogleHealthDailyMetrics).not.toHaveBeenCalled();
     expect(mockSaveGoogleHealthDailyMetrics).not.toHaveBeenCalled();
   });
 
-  it("Google Health access token がない場合は 401 を返す", async () => {
+  it("same-origin ではない POST は 403 を返す", async () => {
     mockGetCurrentUser.mockResolvedValue({ id: "user-id" });
+
+    const response = await POST(makeRequest({ origin: null }));
+
+    expect(response.status).toBe(403);
+    expect(mockResolveStoredAccessToken).not.toHaveBeenCalled();
+    expect(mockFetchGoogleHealthDailyMetrics).not.toHaveBeenCalled();
+  });
+
+  it("Google Health 未連携の場合は 409 を返す", async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: "user-id" });
+    mockResolveStoredAccessToken.mockResolvedValue({
+      ok: false,
+      status: "not_connected",
+      statusCode: 409,
+      message: "Google Health is not connected.",
+      requiredScopes: ["scope-a", "scope-b"],
+    });
 
     const response = await POST(makeRequest());
     const body = await response.json();
 
-    expect(response.status).toBe(401);
+    expect(response.status).toBe(409);
+    expect(body.status).toBe("not_connected");
     expect(body.requiredScopes).toEqual(["scope-a", "scope-b"]);
+    expect(mockResolveStoredAccessToken).toHaveBeenCalledWith("user-id");
+    expect(mockFetchGoogleHealthDailyMetrics).not.toHaveBeenCalled();
+  });
+
+  it("保存済み token 取得で例外が出た場合は sanitized 500 を返す", async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: "user-id" });
+    mockResolveStoredAccessToken.mockRejectedValue(new Error("supabase_service_role_env_missing"));
+
+    const response = await POST(makeRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body).toEqual({
+      error: "Google Health connection lookup failed.",
+      status: "error",
+    });
+    expect(JSON.stringify(body)).not.toContain("supabase_service_role_env_missing");
     expect(mockFetchGoogleHealthDailyMetrics).not.toHaveBeenCalled();
   });
 
@@ -90,6 +138,12 @@ describe("POST /api/google-health/daily-metrics", () => {
     ];
 
     mockGetCurrentUser.mockResolvedValue({ id: "user-id" });
+    mockResolveStoredAccessToken.mockResolvedValue({
+      ok: true,
+      accessToken: "stored-google-token",
+      refreshed: false,
+      status: "connected",
+    });
     mockCreateClient.mockResolvedValue(supabase);
     mockFetchGoogleHealthDailyMetrics.mockResolvedValue({
       sourceResults: [
@@ -111,7 +165,6 @@ describe("POST /api/google-health/daily-metrics", () => {
     const response = await POST(makeRequest({
       start: "2026-06-02",
       end: "2026-06-02",
-      authorization: "Bearer google-token",
     }));
     const body = await response.json();
 
@@ -122,7 +175,7 @@ describe("POST /api/google-health/daily-metrics", () => {
         endDate: "2026-06-02",
         endExclusiveDate: "2026-06-03",
       },
-      accessToken: "google-token",
+      accessToken: "stored-google-token",
     });
     expect(mockSaveGoogleHealthDailyMetrics).toHaveBeenCalledWith(supabase, {
       userId: "user-id",
@@ -147,6 +200,12 @@ describe("POST /api/google-health/daily-metrics", () => {
 
   it("歩数取得が失敗した場合は保存しない", async () => {
     mockGetCurrentUser.mockResolvedValue({ id: "user-id" });
+    mockResolveStoredAccessToken.mockResolvedValue({
+      ok: true,
+      accessToken: "stored-google-token",
+      refreshed: false,
+      status: "connected",
+    });
     mockFetchGoogleHealthDailyMetrics.mockResolvedValue({
       sourceResults: [],
       stepsResult: {
@@ -162,10 +221,17 @@ describe("POST /api/google-health/daily-metrics", () => {
     const response = await POST(makeRequest({
       start: "2026-06-02",
       end: "2026-06-02",
-      authorization: "Bearer google-token",
     }));
+    const body = await response.json();
 
     expect(response.status).toBe(403);
+    expect(body.stepsResult).toEqual({
+      dataType: "steps",
+      source: "reconcile",
+      status: 403,
+      message: "Required OAuth scope(s) are missing for this operation.",
+    });
+    expect(JSON.stringify(body)).not.toContain("details");
     expect(mockCreateClient).not.toHaveBeenCalled();
     expect(mockSaveGoogleHealthDailyMetrics).not.toHaveBeenCalled();
     expect(mockRevalidate).not.toHaveBeenCalled();

--- a/src/app/api/google-health/daily-metrics/route.ts
+++ b/src/app/api/google-health/daily-metrics/route.ts
@@ -1,9 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { revalidateAfterDailyLogMutation } from "@/lib/cache/revalidate";
-import {
-  GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES,
-  fetchGoogleHealthDailyMetrics,
-} from "@/lib/googleHealth/dailyMetrics";
+import { fetchGoogleHealthDailyMetrics } from "@/lib/googleHealth/dailyMetrics";
+import { resolveGoogleHealthStoredAccessToken } from "@/lib/googleHealth/connections";
 import { resolveGoogleHealthPocRange } from "@/lib/googleHealth/poc";
 import type { GoogleHealthPocTargetResult } from "@/lib/googleHealth/poc";
 import { saveGoogleHealthDailyMetrics } from "@/lib/googleHealth/saveDailyMetrics";
@@ -13,10 +11,26 @@ export const dynamic = "force-dynamic";
 
 const REQUIRED_SOURCE_KEYS = new Set(["sleep", "heartRateVariability", "restingHeartRate"]);
 
-function getBearerToken(headers: Headers): string | null {
-  const authorization = headers.get("Authorization");
-  const match = authorization?.match(/^Bearer\s+(.+)$/i);
-  return match?.[1]?.trim() || null;
+function isSameOriginRequest(request: NextRequest): boolean {
+  const origin = request.headers.get("Origin");
+  if (origin) {
+    try {
+      return new URL(origin).origin === request.nextUrl.origin;
+    } catch {
+      return false;
+    }
+  }
+
+  const referer = request.headers.get("Referer");
+  if (referer) {
+    try {
+      return new URL(referer).origin === request.nextUrl.origin;
+    } catch {
+      return false;
+    }
+  }
+
+  return false;
 }
 
 function isRequiredSourceError(
@@ -25,21 +39,22 @@ function isRequiredSourceError(
   return !result.ok && REQUIRED_SOURCE_KEYS.has(result.key);
 }
 
+function sanitizeSourceError(result: Extract<GoogleHealthPocTargetResult, { ok: false }>) {
+  return {
+    key: result.key,
+    status: result.status,
+    message: result.message,
+  };
+}
+
 export async function POST(req: NextRequest) {
   const user = await getCurrentUser();
   if (!user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return NextResponse.json({ error: "auth_required" }, { status: 401 });
   }
 
-  const accessToken = getBearerToken(req.headers);
-  if (!accessToken) {
-    return NextResponse.json(
-      {
-        error: "Google Health API の access token が必要です。Authorization: Bearer <token> を指定してください。",
-        requiredScopes: GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES,
-      },
-      { status: 401 },
-    );
+  if (!isSameOriginRequest(req)) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
   }
 
   const rangeResult = resolveGoogleHealthPocRange(req.nextUrl.searchParams);
@@ -47,16 +62,47 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: rangeResult.message }, { status: 400 });
   }
 
+  let tokenResult;
+  try {
+    tokenResult = await resolveGoogleHealthStoredAccessToken(user.id);
+  } catch {
+    return NextResponse.json(
+      {
+        error: "Google Health connection lookup failed.",
+        status: "error",
+      },
+      { status: 500 },
+    );
+  }
+
+  if (!tokenResult.ok) {
+    return NextResponse.json(
+      {
+        error: tokenResult.message,
+        status: tokenResult.status,
+        requiredScopes: tokenResult.requiredScopes,
+        missingScopes: tokenResult.missingScopes,
+      },
+      { status: tokenResult.statusCode },
+    );
+  }
+
   const dailyResult = await fetchGoogleHealthDailyMetrics({
     range: rangeResult.range,
-    accessToken,
+    accessToken: tokenResult.accessToken,
   });
 
   if (!dailyResult.stepsResult.ok) {
     return NextResponse.json(
       {
         error: "Google Health 歩数の取得に失敗しました。",
-        stepsResult: dailyResult.stepsResult,
+        status: "google_health_api_error",
+        stepsResult: {
+          dataType: dailyResult.stepsResult.dataType,
+          source: dailyResult.stepsResult.source,
+          status: dailyResult.stepsResult.status,
+          message: dailyResult.stepsResult.message,
+        },
       },
       { status: dailyResult.stepsResult.status === 403 ? 403 : 502 },
     );
@@ -67,7 +113,8 @@ export async function POST(req: NextRequest) {
     return NextResponse.json(
       {
         error: "Google Health 日次メトリクスの取得に失敗しました。",
-        results: sourceErrors,
+        status: "google_health_api_error",
+        results: sourceErrors.map(sanitizeSourceError),
       },
       { status: sourceErrors.some((result) => result.status === 403) ? 403 : 502 },
     );

--- a/src/lib/googleHealth/connections.test.ts
+++ b/src/lib/googleHealth/connections.test.ts
@@ -1,11 +1,39 @@
-import { saveGoogleHealthOAuthConnection } from "./connections";
+jest.mock("./oauth", () => {
+  const actual = jest.requireActual("./oauth");
+  return {
+    ...actual,
+    getGoogleHealthOAuthConfig: jest.fn(() => ({
+      clientId: "google-client-id",
+      clientSecret: "google-client-secret",
+      redirectUri: "http://localhost/api/google-health/oauth/callback",
+      stateSecret: "0123456789abcdef0123456789abcdef",
+    })),
+    refreshGoogleHealthOAuthAccessToken: jest.fn(),
+  };
+});
+
+import {
+  resolveGoogleHealthStoredAccessToken,
+  saveGoogleHealthOAuthConnection,
+} from "./connections";
 import { GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES } from "./dailyMetrics";
+import { encryptGoogleHealthToken } from "./tokenCrypto";
+import { refreshGoogleHealthOAuthAccessToken } from "./oauth";
 import type { Json } from "@/lib/supabase/types";
 
 const originalEnv = process.env;
 const encryptionKey = Buffer.from("0123456789abcdef0123456789abcdef", "utf8").toString("base64url");
+const mockRefreshGoogleHealthOAuthAccessToken = refreshGoogleHealthOAuthAccessToken as jest.Mock;
 
-function makeClient(existing: { encrypted_refresh_token: Json | null } | null) {
+type ExistingConnection = {
+  encrypted_access_token?: Json | null;
+  encrypted_refresh_token: Json | null;
+  access_token_expires_at?: string | null;
+  granted_scopes?: string[];
+  status?: "not_connected" | "connected" | "scope_missing" | "reauthorization_required" | "error";
+};
+
+function makeClient(existing: ExistingConnection | null) {
   const maybeSingle = jest.fn().mockResolvedValue({ data: existing, error: null });
   const getEq = jest.fn().mockReturnValue({ maybeSingle });
   const getSelect = jest.fn().mockReturnValue({ eq: getEq });
@@ -20,15 +48,19 @@ function makeClient(existing: { encrypted_refresh_token: Json | null } | null) {
   }));
   const upsertSelect = jest.fn().mockReturnValue({ single });
   const upsert = jest.fn().mockReturnValue({ select: upsertSelect });
+  const updateEq = jest.fn().mockResolvedValue({ error: null });
+  const update = jest.fn().mockReturnValue({ eq: updateEq });
   const from = jest.fn().mockReturnValue({
     select: getSelect,
     upsert,
+    update,
   });
   const schema = jest.fn().mockReturnValue({ from });
 
   return {
     client: { schema },
     upsert,
+    update,
   };
 }
 
@@ -38,6 +70,7 @@ describe("Google Health connections", () => {
       ...originalEnv,
       GOOGLE_HEALTH_TOKEN_ENCRYPTION_KEY: encryptionKey,
     };
+    mockRefreshGoogleHealthOAuthAccessToken.mockReset();
   });
 
   afterEach(() => {
@@ -91,5 +124,91 @@ describe("Google Health connections", () => {
       status: "reauthorization_required",
       last_error_code: "reauthorization_required",
     }), { onConflict: "user_id" });
+  });
+
+  it("保存済み access token が期限内なら復号して返す", async () => {
+    const encryptedAccessToken = encryptGoogleHealthToken("stored-access-token");
+    const { client, update } = makeClient({
+      encrypted_access_token: encryptedAccessToken as unknown as Json,
+      encrypted_refresh_token: null,
+      access_token_expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      granted_scopes: [...GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES],
+      status: "connected",
+    });
+
+    const result = await resolveGoogleHealthStoredAccessToken("user-id", client as never);
+
+    expect(result).toEqual({
+      ok: true,
+      accessToken: "stored-access-token",
+      refreshed: false,
+      status: "connected",
+    });
+    expect(update).not.toHaveBeenCalled();
+    expect(mockRefreshGoogleHealthOAuthAccessToken).not.toHaveBeenCalled();
+  });
+
+  it("access token が期限切れ間近なら refresh token で更新して返す", async () => {
+    const encryptedAccessToken = encryptGoogleHealthToken("old-access-token");
+    const encryptedRefreshToken = encryptGoogleHealthToken("refresh-token");
+    const { client, update } = makeClient({
+      encrypted_access_token: encryptedAccessToken as unknown as Json,
+      encrypted_refresh_token: encryptedRefreshToken as unknown as Json,
+      access_token_expires_at: new Date(Date.now() + 60 * 1000).toISOString(),
+      granted_scopes: [...GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES],
+      status: "connected",
+    });
+    mockRefreshGoogleHealthOAuthAccessToken.mockResolvedValue({
+      accessToken: "new-access-token",
+      expiresIn: 3600,
+      grantedScopes: null,
+      tokenType: "Bearer",
+    });
+
+    const result = await resolveGoogleHealthStoredAccessToken("user-id", client as never);
+
+    expect(result).toEqual({
+      ok: true,
+      accessToken: "new-access-token",
+      refreshed: true,
+      status: "connected",
+    });
+    expect(mockRefreshGoogleHealthOAuthAccessToken).toHaveBeenCalledWith({
+      config: expect.objectContaining({ clientId: "google-client-id" }),
+      refreshToken: "refresh-token",
+    });
+    expect(update).toHaveBeenCalledWith(expect.objectContaining({
+      status: "connected",
+      last_error_code: null,
+      last_error_message: null,
+      granted_scopes: [...GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES],
+    }));
+  });
+
+  it("refresh token が invalid_grant の場合は reauthorization_required に更新する", async () => {
+    const encryptedAccessToken = encryptGoogleHealthToken("old-access-token");
+    const encryptedRefreshToken = encryptGoogleHealthToken("refresh-token");
+    const { client, update } = makeClient({
+      encrypted_access_token: encryptedAccessToken as unknown as Json,
+      encrypted_refresh_token: encryptedRefreshToken as unknown as Json,
+      access_token_expires_at: new Date(Date.now() - 60 * 1000).toISOString(),
+      granted_scopes: [...GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES],
+      status: "connected",
+    });
+    mockRefreshGoogleHealthOAuthAccessToken.mockRejectedValue(
+      new Error("google_health_oauth_token_refresh_invalid_grant"),
+    );
+
+    const result = await resolveGoogleHealthStoredAccessToken("user-id", client as never);
+
+    expect(result).toEqual(expect.objectContaining({
+      ok: false,
+      status: "reauthorization_required",
+      statusCode: 409,
+    }));
+    expect(update).toHaveBeenCalledWith(expect.objectContaining({
+      status: "reauthorization_required",
+      last_error_code: "google_health_oauth_token_refresh_invalid_grant",
+    }));
   });
 });

--- a/src/lib/googleHealth/connections.ts
+++ b/src/lib/googleHealth/connections.ts
@@ -11,7 +11,12 @@ import {
   encryptGoogleHealthToken,
 } from "./tokenCrypto";
 import {
+  GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES,
+} from "./dailyMetrics";
+import {
   getMissingGoogleHealthOAuthScopes,
+  getGoogleHealthOAuthConfig,
+  refreshGoogleHealthOAuthAccessToken,
   type GoogleHealthOAuthTokenResponse,
 } from "./oauth";
 
@@ -26,6 +31,24 @@ type SaveConnectionResult = {
   missingScopes: string[];
   status: GoogleHealthConnectionStatus;
 };
+
+export type GoogleHealthStoredAccessTokenResult =
+  | {
+      ok: true;
+      accessToken: string;
+      refreshed: boolean;
+      status: "connected";
+    }
+  | {
+      ok: false;
+      status: GoogleHealthConnectionStatus;
+      statusCode: number;
+      message: string;
+      requiredScopes: readonly string[];
+      missingScopes?: string[];
+    };
+
+const ACCESS_TOKEN_REFRESH_WINDOW_MS = 5 * 60 * 1000;
 
 function privateConnections(client: ServiceRoleClient) {
   return client.schema("private").from("google_health_connections");
@@ -52,6 +75,50 @@ function resolveStatus(args: {
   if (args.missingScopes.length > 0) return "scope_missing";
   if (!args.encryptedRefreshToken) return "reauthorization_required";
   return "connected";
+}
+
+function isAccessTokenUsable(expiresAt: string | null, now = Date.now()): boolean {
+  if (!expiresAt) return false;
+  const expiresAtMs = Date.parse(expiresAt);
+  return Number.isFinite(expiresAtMs) && expiresAtMs > now + ACCESS_TOKEN_REFRESH_WINDOW_MS;
+}
+
+function toAccessTokenResultError(args: {
+  status: GoogleHealthConnectionStatus;
+  statusCode: number;
+  message: string;
+  missingScopes?: string[];
+}): GoogleHealthStoredAccessTokenResult {
+  return {
+    ok: false,
+    status: args.status,
+    statusCode: args.statusCode,
+    message: args.message,
+    requiredScopes: GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES,
+    missingScopes: args.missingScopes,
+  };
+}
+
+function isRefreshReauthorizationError(error: unknown): boolean {
+  return error instanceof Error && (
+    error.message === "google_health_oauth_token_refresh_invalid_grant" ||
+    error.message === "google_health_oauth_token_refresh_invalid_client" ||
+    error.message === "google_health_oauth_token_refresh_unauthorized_client"
+  );
+}
+
+async function updateGoogleHealthConnection(
+  client: ServiceRoleClient,
+  userId: string,
+  payload: GoogleHealthConnectionUpdate,
+): Promise<void> {
+  const { error } = await privateConnections(client)
+    .update(payload)
+    .eq("user_id", userId);
+
+  if (error) {
+    throw new Error("google_health_connection_update_failed");
+  }
 }
 
 export async function getGoogleHealthConnectionByUserId(
@@ -113,6 +180,141 @@ export async function saveGoogleHealthOAuthConnection(args: {
   }
 
   return { connection: data, missingScopes, status };
+}
+
+export async function resolveGoogleHealthStoredAccessToken(
+  userId: string,
+  client: ServiceRoleClient = createServiceRoleClient(),
+): Promise<GoogleHealthStoredAccessTokenResult> {
+  const connection = await getGoogleHealthConnectionByUserId(userId, client);
+  if (!connection) {
+    return toAccessTokenResultError({
+      status: "not_connected",
+      statusCode: 409,
+      message: "Google Health is not connected.",
+    });
+  }
+
+  const missingScopes = getMissingGoogleHealthOAuthScopes(connection.granted_scopes);
+  if (missingScopes.length > 0) {
+    await updateGoogleHealthConnection(client, userId, {
+      status: "scope_missing",
+      last_checked_at: new Date().toISOString(),
+      last_error_code: "scope_missing",
+      last_error_message: "Required Google Health OAuth scopes are missing.",
+    });
+    return toAccessTokenResultError({
+      status: "scope_missing",
+      statusCode: 403,
+      message: "Required Google Health OAuth scopes are missing.",
+      missingScopes,
+    });
+  }
+
+  if (connection.status !== "connected") {
+    return toAccessTokenResultError({
+      status: connection.status,
+      statusCode: 409,
+      message: `Google Health connection status is ${connection.status}.`,
+    });
+  }
+
+  if (!connection.encrypted_access_token) {
+    await updateGoogleHealthConnection(client, userId, {
+      status: "reauthorization_required",
+      last_checked_at: new Date().toISOString(),
+      last_error_code: "reauthorization_required",
+      last_error_message: "Google Health OAuth access token is missing.",
+    });
+    return toAccessTokenResultError({
+      status: "reauthorization_required",
+      statusCode: 409,
+      message: "Google Health reauthorization is required.",
+    });
+  }
+
+  if (isAccessTokenUsable(connection.access_token_expires_at)) {
+    return {
+      ok: true,
+      accessToken: decryptGoogleHealthToken(connection.encrypted_access_token),
+      refreshed: false,
+      status: "connected",
+    };
+  }
+
+  if (!connection.encrypted_refresh_token) {
+    await updateGoogleHealthConnection(client, userId, {
+      status: "reauthorization_required",
+      last_checked_at: new Date().toISOString(),
+      last_error_code: "reauthorization_required",
+      last_error_message: "Google Health OAuth refresh token is missing.",
+    });
+    return toAccessTokenResultError({
+      status: "reauthorization_required",
+      statusCode: 409,
+      message: "Google Health reauthorization is required.",
+    });
+  }
+
+  try {
+    const refreshToken = decryptGoogleHealthToken(connection.encrypted_refresh_token);
+    const refreshed = await refreshGoogleHealthOAuthAccessToken({
+      config: getGoogleHealthOAuthConfig(),
+      refreshToken,
+    });
+    const grantedScopes = refreshed.grantedScopes ?? connection.granted_scopes;
+    const refreshedMissingScopes = getMissingGoogleHealthOAuthScopes(grantedScopes);
+    const nextStatus: GoogleHealthConnectionStatus = refreshedMissingScopes.length > 0
+      ? "scope_missing"
+      : "connected";
+
+    await updateGoogleHealthConnection(client, userId, {
+      encrypted_access_token: encryptedTokenToJson(encryptGoogleHealthToken(refreshed.accessToken)),
+      access_token_expires_at: buildAccessTokenExpiresAt(refreshed.expiresIn),
+      granted_scopes: grantedScopes,
+      status: nextStatus,
+      last_checked_at: new Date().toISOString(),
+      last_error_code: nextStatus === "connected" ? null : "scope_missing",
+      last_error_message: nextStatus === "connected"
+        ? null
+        : "Required Google Health OAuth scopes are missing.",
+      encryption_key_version: GOOGLE_HEALTH_TOKEN_ENCRYPTION_KEY_VERSION,
+    });
+
+    if (refreshedMissingScopes.length > 0) {
+      return toAccessTokenResultError({
+        status: "scope_missing",
+        statusCode: 403,
+        message: "Required Google Health OAuth scopes are missing.",
+        missingScopes: refreshedMissingScopes,
+      });
+    }
+
+    return {
+      ok: true,
+      accessToken: refreshed.accessToken,
+      refreshed: true,
+      status: "connected",
+    };
+  } catch (error) {
+    const reauthorizationRequired = isRefreshReauthorizationError(error);
+    await updateGoogleHealthConnection(client, userId, {
+      status: reauthorizationRequired ? "reauthorization_required" : "error",
+      last_checked_at: new Date().toISOString(),
+      last_error_code: error instanceof Error ? error.message : "google_health_oauth_token_refresh_failed",
+      last_error_message: reauthorizationRequired
+        ? "Google Health OAuth refresh token is no longer valid."
+        : "Google Health OAuth token refresh failed.",
+    });
+
+    return toAccessTokenResultError({
+      status: reauthorizationRequired ? "reauthorization_required" : "error",
+      statusCode: reauthorizationRequired ? 409 : 502,
+      message: reauthorizationRequired
+        ? "Google Health reauthorization is required."
+        : "Google Health OAuth token refresh failed.",
+    });
+  }
 }
 
 export async function markGoogleHealthConnectionError(args: {

--- a/src/lib/googleHealth/oauth.test.ts
+++ b/src/lib/googleHealth/oauth.test.ts
@@ -4,6 +4,7 @@ import {
   buildGoogleHealthOAuthAuthorizationUrl,
   createGoogleHealthOAuthStateCookieValue,
   exchangeGoogleHealthOAuthCode,
+  refreshGoogleHealthOAuthAccessToken,
   generateGoogleHealthPkcePair,
   getGoogleHealthOAuthConfig,
   getMissingGoogleHealthOAuthScopes,
@@ -166,6 +167,57 @@ describe("Google Health OAuth helpers", () => {
       codeVerifier: "code-verifier",
       fetchFn,
     })).rejects.toThrow("google_health_oauth_token_exchange_failed");
+  });
+
+  it("refresh token で access token を更新する", async () => {
+    const fetchFn = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({
+        access_token: "new-access-token",
+        expires_in: 3600,
+        scope: "scope-a scope-b",
+        token_type: "Bearer",
+      }),
+    });
+
+    const token = await refreshGoogleHealthOAuthAccessToken({
+      config,
+      refreshToken: "refresh-token",
+      fetchFn,
+    });
+
+    expect(fetchFn).toHaveBeenCalledWith(GOOGLE_OAUTH_TOKEN_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: expect.any(URLSearchParams),
+    });
+    const body = fetchFn.mock.calls[0][1].body as URLSearchParams;
+    expect(body.get("client_id")).toBe(config.clientId);
+    expect(body.get("client_secret")).toBe(config.clientSecret);
+    expect(body.get("grant_type")).toBe("refresh_token");
+    expect(body.get("refresh_token")).toBe("refresh-token");
+    expect(token).toEqual({
+      accessToken: "new-access-token",
+      expiresIn: 3600,
+      grantedScopes: ["scope-a", "scope-b"],
+      tokenType: "Bearer",
+    });
+  });
+
+  it("refresh token 失敗時は safe reason を返す", async () => {
+    const fetchFn = jest.fn().mockResolvedValue({
+      ok: false,
+      json: jest.fn().mockResolvedValue({
+        error: "invalid_grant",
+        error_description: "secret detail",
+      }),
+    });
+
+    await expect(refreshGoogleHealthOAuthAccessToken({
+      config,
+      refreshToken: "refresh-token",
+      fetchFn,
+    })).rejects.toThrow("google_health_oauth_token_refresh_invalid_grant");
   });
 
   it("不足 scope を検出する", () => {

--- a/src/lib/googleHealth/oauth.ts
+++ b/src/lib/googleHealth/oauth.ts
@@ -57,6 +57,13 @@ export type GoogleHealthOAuthTokenResponse = {
   tokenType: string | null;
 };
 
+export type GoogleHealthOAuthRefreshTokenResponse = {
+  accessToken: string;
+  expiresIn: number | null;
+  grantedScopes: string[] | null;
+  tokenType: string | null;
+};
+
 function readRequiredEnv(env: EnvLike, key: string): string {
   const value = env[key]?.trim();
   if (!value) throw new Error("google_health_oauth_config_missing");
@@ -270,12 +277,12 @@ function parseExpiresIn(value: unknown): number | null {
   return Math.floor(value);
 }
 
-function getTokenExchangeErrorReason(payload: unknown): string {
+function getTokenErrorReason(payload: unknown, prefix: string): string {
   const record = asRecord(payload);
   const error = typeof record?.error === "string" ? record.error : null;
   return error && SAFE_TOKEN_ERROR_REASONS.has(error)
-    ? `google_health_oauth_token_exchange_${error}`
-    : "google_health_oauth_token_exchange_failed";
+    ? `${prefix}_${error}`
+    : `${prefix}_failed`;
 }
 
 export async function exchangeGoogleHealthOAuthCode(args: {
@@ -308,7 +315,7 @@ export async function exchangeGoogleHealthOAuthCode(args: {
   }
 
   if (!response.ok) {
-    throw new Error(getTokenExchangeErrorReason(payload));
+    throw new Error(getTokenErrorReason(payload, "google_health_oauth_token_exchange"));
   }
 
   const record = asRecord(payload);
@@ -327,6 +334,55 @@ export async function exchangeGoogleHealthOAuthCode(args: {
     refreshToken,
     expiresIn: parseExpiresIn(record?.expires_in),
     grantedScopes: parseGrantedScopes(record?.scope),
+    tokenType,
+  };
+}
+
+export async function refreshGoogleHealthOAuthAccessToken(args: {
+  config: GoogleHealthOAuthConfig;
+  refreshToken: string;
+  fetchFn?: FetchLike;
+}): Promise<GoogleHealthOAuthRefreshTokenResponse> {
+  const fetchFn = args.fetchFn ?? fetch;
+  const body = new URLSearchParams({
+    client_id: args.config.clientId,
+    client_secret: args.config.clientSecret,
+    grant_type: "refresh_token",
+    refresh_token: args.refreshToken,
+  });
+
+  const response = await fetchFn(GOOGLE_OAUTH_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body,
+  });
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch {
+    payload = null;
+  }
+
+  if (!response.ok) {
+    throw new Error(getTokenErrorReason(payload, "google_health_oauth_token_refresh"));
+  }
+
+  const record = asRecord(payload);
+  const accessToken = typeof record?.access_token === "string" ? record.access_token : null;
+  if (!accessToken) {
+    throw new Error("google_health_oauth_token_response_invalid");
+  }
+
+  const tokenType = typeof record?.token_type === "string" ? record.token_type : null;
+  const grantedScopes = typeof record?.scope === "string" && record.scope.trim().length > 0
+    ? parseGrantedScopes(record.scope)
+    : null;
+
+  return {
+    accessToken,
+    expiresIn: parseExpiresIn(record?.expires_in),
+    grantedScopes,
     tokenType,
   };
 }


### PR DESCRIPTION
## 概要
Google Health 日次メトリクス保存 API を、手動 `Authorization: Bearer <token>` ではなく、保存済み OAuth token で実行するように切り替えます。

Closes #696

## 変更内容
- `POST /api/google-health/daily-metrics` の token 解決を保存済み connection 参照に変更
- cookie 認証の state-changing API として `Origin` / `Referer` の same-origin 検証を追加
- 保存済み access token が期限切れ間近の場合、refresh token で更新して encrypted access token / expires を再保存
- 未連携、scope 不足、再認可必要、refresh 失敗を区別して JSON レスポンス化
- Google Health API 失敗レスポンスから raw details を返さず、key/status/message などに限定
- OAuth refresh token endpoint helper と関連テストを追加

## 判断理由
- token 保管・復号・refresh は #694/#695 の private schema / service role / 暗号化 helper に集約しました。
- 手動 token header は廃止し、UI/API 利用者が毎回 Google access token を入力しない前提にしました。
- cookie 認証だけで保存 API が動くため、same-origin 検証を route 側に入れています。
- token / refresh token / client secret / raw Google response はレスポンスに含めないようにしています。

## 検証結果
- `npm run test -- --runInBand src/lib/googleHealth/oauth.test.ts src/lib/googleHealth/connections.test.ts src/app/api/google-health/daily-metrics/route.test.ts`
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- `git diff --cached --check`

## 補足
- 実行には #695 で保存済み Google Health connection が `connected` になっている必要があります。
- 手動 curl で確認する場合は cookie 認証に加えて same-origin header が必要です。
- 設定画面 UI 連携は #687、運用ログ整理は #689 の範囲です。
