### PR TITLE
Google Health連携状態を設定画面に表示する

### DIFF
--- a/src/app/api/google-health/status/route.test.ts
+++ b/src/app/api/google-health/status/route.test.ts
@@ -1,0 +1,93 @@
+jest.mock("@/lib/supabase/server", () => ({
+  getCurrentUser: jest.fn(),
+}));
+
+jest.mock("@/lib/googleHealth/status", () => ({
+  buildGoogleHealthStatusError: jest.fn(() => ({
+    status: "error",
+    requiredScopes: ["scope-a", "scope-b"],
+    grantedScopes: [],
+    missingScopes: [],
+    lastCheckedAt: null,
+    lastSyncAt: null,
+    lastErrorCode: "google_health_connection_status_lookup_failed",
+  })),
+  getGoogleHealthStatusForUser: jest.fn(),
+}));
+
+import { getGoogleHealthStatusForUser } from "@/lib/googleHealth/status";
+import { getCurrentUser } from "@/lib/supabase/server";
+import { GET } from "./route";
+
+const mockGetCurrentUser = getCurrentUser as jest.Mock;
+const mockGetStatusForUser = getGoogleHealthStatusForUser as jest.Mock;
+
+describe("GET /api/google-health/status", () => {
+  beforeEach(() => {
+    mockGetCurrentUser.mockReset();
+    mockGetStatusForUser.mockReset();
+  });
+
+  it("未認証の場合は 401 を返す", async () => {
+    mockGetCurrentUser.mockResolvedValue(null);
+
+    const response = await GET();
+
+    expect(response.status).toBe(401);
+    expect(mockGetStatusForUser).not.toHaveBeenCalled();
+  });
+
+  it("連携状態を sanitized response として返す", async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: "user-id" });
+    mockGetStatusForUser.mockResolvedValue({
+      status: "connected",
+      requiredScopes: ["scope-a", "scope-b"],
+      grantedScopes: ["scope-a", "scope-b"],
+      missingScopes: [],
+      lastCheckedAt: "2026-06-05T23:00:00.000Z",
+      lastSyncAt: "2026-06-05T23:30:00.000Z",
+      lastErrorCode: null,
+    });
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockGetStatusForUser).toHaveBeenCalledWith("user-id");
+    expect(body).toEqual({
+      ok: true,
+      status: "connected",
+      requiredScopes: ["scope-a", "scope-b"],
+      grantedScopes: ["scope-a", "scope-b"],
+      missingScopes: [],
+      lastCheckedAt: "2026-06-05T23:00:00.000Z",
+      lastSyncAt: "2026-06-05T23:30:00.000Z",
+      lastErrorCode: null,
+    });
+    expect(JSON.stringify(body)).not.toContain("token");
+    expect(JSON.stringify(body)).not.toContain("client_secret");
+    expect(JSON.stringify(body)).not.toContain("auth_code");
+  });
+
+  it("lookup 失敗時は sanitized 500 を返す", async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: "user-id" });
+    mockGetStatusForUser.mockRejectedValue(new Error("supabase_service_role_env_missing"));
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body).toEqual({
+      ok: false,
+      error: "Google Health connection status lookup failed.",
+      status: "error",
+      requiredScopes: ["scope-a", "scope-b"],
+      grantedScopes: [],
+      missingScopes: [],
+      lastCheckedAt: null,
+      lastSyncAt: null,
+      lastErrorCode: "google_health_connection_status_lookup_failed",
+    });
+    expect(JSON.stringify(body)).not.toContain("supabase_service_role_env_missing");
+  });
+});

--- a/src/app/api/google-health/status/route.ts
+++ b/src/app/api/google-health/status/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import {
+  buildGoogleHealthStatusError,
+  getGoogleHealthStatusForUser,
+  type GoogleHealthStatusApiResponse,
+} from "@/lib/googleHealth/status";
+import { getCurrentUser } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const user = await getCurrentUser();
+  if (!user) {
+    return NextResponse.json({ error: "auth_required" }, { status: 401 });
+  }
+
+  try {
+    const status = await getGoogleHealthStatusForUser(user.id);
+    return NextResponse.json<GoogleHealthStatusApiResponse>({
+      ok: true,
+      ...status,
+    });
+  } catch {
+    return NextResponse.json<GoogleHealthStatusApiResponse>(
+      {
+        ok: false,
+        error: "Google Health connection status lookup failed.",
+        ...buildGoogleHealthStatusError("google_health_connection_status_lookup_failed"),
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -4,24 +4,43 @@ import { ImportSection } from "@/components/settings/ImportSection";
 import { StepImportSection } from "@/components/settings/StepImportSection";
 import { DataQualityPanel } from "@/components/settings/DataQualityPanel";
 import { ThemeSection } from "@/components/settings/ThemeSection";
+import { GoogleHealthSection } from "@/components/settings/GoogleHealthSection";
 import { calcDataQuality } from "@/lib/utils/calcDataQuality";
 import { fetchSettingsRows } from "@/lib/queries/settings";
 import { fetchDailyLogsForSettings } from "@/lib/queries/dailyLogs";
 import { fetchSleepSessionsForRange } from "@/lib/queries/sleepSessions";
 import { toJstDateStr, addDaysStr } from "@/lib/utils/date";
 import { PageShell } from "@/components/ui/PageShell";
+import {
+  buildGoogleHealthNotConnectedStatus,
+  buildGoogleHealthStatusError,
+  getGoogleHealthStatusForUser,
+} from "@/lib/googleHealth/status";
+import { getCurrentUser } from "@/lib/supabase/server";
 
 export const revalidate = 0;
+
+async function fetchGoogleHealthStatusForSettings(userId: string | null) {
+  if (!userId) return buildGoogleHealthNotConnectedStatus();
+
+  try {
+    return await getGoogleHealthStatusForUser(userId);
+  } catch {
+    return buildGoogleHealthStatusError("google_health_connection_status_lookup_failed");
+  }
+}
 
 export default async function SettingsPage() {
   // データ品質の睡眠セッションチェック用: JST 基準で直近 14 日分を取得する
   const today = toJstDateStr();
   const d14Start = addDaysStr(today, -13) ?? today;
+  const user = await getCurrentUser();
 
-  const [settingsRowsResult, logsResult, recentSleepSessions] = await Promise.all([
+  const [settingsRowsResult, logsResult, recentSleepSessions, googleHealthStatus] = await Promise.all([
     fetchSettingsRows(),
     fetchDailyLogsForSettings(),
     fetchSleepSessionsForRange(d14Start, today),
+    fetchGoogleHealthStatusForSettings(user?.id ?? null),
   ]);
 
   // QueryResult を展開。エラー時はフォールバック値で graceful degradation を維持する。
@@ -53,6 +72,7 @@ export default async function SettingsPage() {
 
       <div className="space-y-6">
         <ThemeSection />
+        <GoogleHealthSection initialStatus={googleHealthStatus} />
         <SettingsForm initialSettings={settingsRows} currentWeight={currentWeight} />
         <DataQualityPanel report={qualityReport} />
 

--- a/src/components/settings/GoogleHealthSection.integration.test.tsx
+++ b/src/components/settings/GoogleHealthSection.integration.test.tsx
@@ -1,0 +1,89 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { GoogleHealthSection } from "./GoogleHealthSection";
+import type { GoogleHealthStatusSnapshot } from "@/lib/googleHealth/status";
+
+const ACTIVITY_SCOPE = "https://www.googleapis.com/auth/googlehealth.activity_and_fitness.readonly";
+const HEALTH_METRICS_SCOPE = "https://www.googleapis.com/auth/googlehealth.health_metrics_and_measurements.readonly";
+const SLEEP_SCOPE = "https://www.googleapis.com/auth/googlehealth.sleep.readonly";
+const REQUIRED_SCOPES = [ACTIVITY_SCOPE, HEALTH_METRICS_SCOPE, SLEEP_SCOPE];
+
+function makeStatus(
+  overrides: Partial<GoogleHealthStatusSnapshot> = {},
+): GoogleHealthStatusSnapshot {
+  return {
+    status: "not_connected",
+    requiredScopes: REQUIRED_SCOPES,
+    grantedScopes: [],
+    missingScopes: REQUIRED_SCOPES,
+    lastCheckedAt: null,
+    lastSyncAt: null,
+    lastErrorCode: null,
+    ...overrides,
+  };
+}
+
+describe("GoogleHealthSection", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("未連携の場合は OAuth 連携への主ボタンを表示する", () => {
+    render(<GoogleHealthSection initialStatus={makeStatus()} />);
+
+    const link = screen.getByRole("link", { name: "Google Health と同期" });
+    expect(screen.getByText("未連携")).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/api/google-health/oauth/start");
+    expect(screen.queryByRole("button", { name: "連携を解除" })).not.toBeInTheDocument();
+  });
+
+  it("scope 不足の場合は再認可への主ボタンと不足 scope を表示する", () => {
+    render(
+      <GoogleHealthSection
+        initialStatus={makeStatus({
+          status: "scope_missing",
+          grantedScopes: [ACTIVITY_SCOPE],
+          missingScopes: [HEALTH_METRICS_SCOPE, SLEEP_SCOPE],
+          lastCheckedAt: "2026-06-05T23:00:00.000Z",
+          lastErrorCode: "scope_missing",
+        })}
+      />,
+    );
+
+    const link = screen.getByRole("link", { name: "再認可して同期" });
+    expect(screen.getByText("権限不足")).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/api/google-health/oauth/start?prompt=consent");
+    expect(screen.getByText("心拍・HRV")).toBeInTheDocument();
+    expect(screen.getByText("睡眠")).toBeInTheDocument();
+    expect(screen.getByText("scope_missing")).toBeInTheDocument();
+  });
+
+  it("連携済みの場合は解除操作で未連携表示へ更新する", async () => {
+    jest.spyOn(window, "confirm").mockReturnValue(true);
+    const fetchMock = jest.fn().mockResolvedValue({ ok: true });
+    Object.defineProperty(global, "fetch", {
+      value: fetchMock,
+      writable: true,
+    });
+
+    render(
+      <GoogleHealthSection
+        initialStatus={makeStatus({
+          status: "connected",
+          grantedScopes: REQUIRED_SCOPES,
+          missingScopes: [],
+          lastCheckedAt: "2026-06-05T23:00:00.000Z",
+          lastSyncAt: "2026-06-05T23:30:00.000Z",
+        })}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "連携を解除" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/google-health/oauth/disconnect", { method: "POST" });
+    });
+    expect(await screen.findByText("Google Health 連携を解除しました。")).toBeInTheDocument();
+    expect(screen.getByText("未連携")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Google Health と同期" })).toBeInTheDocument();
+  });
+});

--- a/src/components/settings/GoogleHealthSection.tsx
+++ b/src/components/settings/GoogleHealthSection.tsx
@@ -1,0 +1,329 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Activity,
+  AlertCircle,
+  CheckCircle2,
+  Loader2,
+  RefreshCw,
+  ShieldCheck,
+  Unlink,
+} from "lucide-react";
+import type {
+  GoogleHealthStatusApiResponse,
+  GoogleHealthStatusSnapshot,
+} from "@/lib/googleHealth/status";
+
+type GoogleHealthSectionProps = {
+  initialStatus: GoogleHealthStatusSnapshot;
+};
+
+type ActionPhase = "idle" | "refreshing" | "disconnecting";
+
+const STATUS_LABELS: Record<GoogleHealthStatusSnapshot["status"], {
+  label: string;
+  description: string;
+  badgeClassName: string;
+  iconClassName: string;
+}> = {
+  not_connected: {
+    label: "未連携",
+    description: "Google Health のデータ取得には連携が必要です。",
+    badgeClassName: "bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300",
+    iconClassName: "text-slate-400 dark:text-slate-500",
+  },
+  connected: {
+    label: "連携済み",
+    description: "必要な権限が揃っています。",
+    badgeClassName: "bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300",
+    iconClassName: "text-emerald-500 dark:text-emerald-400",
+  },
+  scope_missing: {
+    label: "権限不足",
+    description: "Google Health の必要な権限が不足しています。",
+    badgeClassName: "bg-amber-50 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300",
+    iconClassName: "text-amber-500 dark:text-amber-400",
+  },
+  reauthorization_required: {
+    label: "再認可が必要",
+    description: "Google Health へのアクセスを再認可してください。",
+    badgeClassName: "bg-amber-50 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300",
+    iconClassName: "text-amber-500 dark:text-amber-400",
+  },
+  error: {
+    label: "確認エラー",
+    description: "Google Health の連携状態を確認できませんでした。",
+    badgeClassName: "bg-rose-50 text-rose-700 dark:bg-rose-900/30 dark:text-rose-300",
+    iconClassName: "text-rose-500 dark:text-rose-400",
+  },
+};
+
+const CONNECT_URL = "/api/google-health/oauth/start";
+const REAUTHORIZE_URL = "/api/google-health/oauth/start?prompt=consent";
+
+function getScopeLabel(scope: string): string {
+  if (scope.includes("activity_and_fitness")) return "歩数・活動";
+  if (scope.includes("health_metrics_and_measurements")) return "心拍・HRV";
+  if (scope.includes("sleep")) return "睡眠";
+  return scope;
+}
+
+function formatJstDateTime(value: string | null): string {
+  if (!value) return "未記録";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "未記録";
+
+  return new Intl.DateTimeFormat("ja-JP", {
+    timeZone: "Asia/Tokyo",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(date);
+}
+
+function buildDisconnectedStatus(current: GoogleHealthStatusSnapshot): GoogleHealthStatusSnapshot {
+  return {
+    status: "not_connected",
+    requiredScopes: current.requiredScopes,
+    grantedScopes: [],
+    missingScopes: current.requiredScopes,
+    lastCheckedAt: null,
+    lastSyncAt: null,
+    lastErrorCode: null,
+  };
+}
+
+function buildClientErrorStatus(current: GoogleHealthStatusSnapshot): GoogleHealthStatusSnapshot {
+  return {
+    ...current,
+    status: "error",
+    lastErrorCode: "google_health_status_client_error",
+  };
+}
+
+function snapshotFromApiResponse(
+  body: GoogleHealthStatusApiResponse,
+): GoogleHealthStatusSnapshot {
+  if (body.ok) {
+    const { ok, ...snapshot } = body;
+    void ok;
+    return snapshot;
+  }
+
+  const { ok, error, ...snapshot } = body;
+  void ok;
+  void error;
+  return snapshot;
+}
+
+export function GoogleHealthSection({ initialStatus }: GoogleHealthSectionProps) {
+  const [status, setStatus] = useState<GoogleHealthStatusSnapshot>(initialStatus);
+  const [phase, setPhase] = useState<ActionPhase>("idle");
+  const [message, setMessage] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const isWorking = phase !== "idle";
+  const statusMeta = STATUS_LABELS[status.status];
+  const grantedScopeSet = new Set(status.grantedScopes);
+
+  async function refreshStatus() {
+    setPhase("refreshing");
+    setMessage(null);
+    setErrorMessage(null);
+
+    try {
+      const response = await fetch("/api/google-health/status", { method: "GET" });
+      const contentType = response.headers.get("content-type") ?? "";
+      if (!contentType.includes("application/json")) {
+        throw new Error("unexpected_response");
+      }
+      const body = await response.json() as GoogleHealthStatusApiResponse;
+      setStatus(snapshotFromApiResponse(body));
+      if (!response.ok || !body.ok) {
+        setErrorMessage("連携状態の確認に失敗しました。");
+      }
+    } catch {
+      setStatus((current) => buildClientErrorStatus(current));
+      setErrorMessage("連携状態の確認に失敗しました。");
+    } finally {
+      setPhase("idle");
+    }
+  }
+
+  async function disconnect() {
+    if (!window.confirm("Google Health 連携を解除しますか？保存済みの日次データは削除されません。")) {
+      return;
+    }
+
+    setPhase("disconnecting");
+    setMessage(null);
+    setErrorMessage(null);
+
+    try {
+      const response = await fetch("/api/google-health/oauth/disconnect", { method: "POST" });
+      if (!response.ok) {
+        throw new Error("disconnect_failed");
+      }
+      setStatus((current) => buildDisconnectedStatus(current));
+      setMessage("Google Health 連携を解除しました。");
+    } catch {
+      setErrorMessage("Google Health 連携の解除に失敗しました。");
+    } finally {
+      setPhase("idle");
+    }
+  }
+
+  const primaryAction =
+    status.status === "not_connected"
+      ? {
+          href: CONNECT_URL,
+          label: "Google Health と同期",
+        }
+      : status.status === "scope_missing" || status.status === "reauthorization_required"
+        ? {
+            href: REAUTHORIZE_URL,
+            label: "再認可して同期",
+          }
+        : null;
+
+  return (
+    <section className="rounded-2xl border border-slate-100 bg-white p-5 shadow-sm dark:border-slate-700 dark:bg-slate-900 dark:shadow-none">
+      <div className="mb-5 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex items-start gap-3">
+          <div className="rounded-xl bg-blue-50 p-2 text-blue-600 dark:bg-blue-900/30 dark:text-blue-300">
+            <Activity size={18} aria-hidden="true" />
+          </div>
+          <div>
+            <div className="flex flex-wrap items-center gap-2">
+              <h2 className="text-sm font-semibold text-slate-700 dark:text-slate-200">
+                Google Health
+              </h2>
+              <span className={`rounded-full px-2.5 py-1 text-xs font-medium ${statusMeta.badgeClassName}`}>
+                {statusMeta.label}
+              </span>
+            </div>
+            <p className="mt-1 text-xs text-slate-400 dark:text-slate-500">
+              {statusMeta.description}
+            </p>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          {primaryAction && (
+            <a
+              href={primaryAction.href}
+              className="inline-flex items-center justify-center gap-1.5 rounded-lg bg-blue-600 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-400"
+            >
+              <ShieldCheck size={15} aria-hidden="true" />
+              {primaryAction.label}
+            </a>
+          )}
+          {status.status === "error" && (
+            <button
+              type="button"
+              onClick={refreshStatus}
+              disabled={isWorking}
+              className="inline-flex items-center justify-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-600 transition-colors hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
+            >
+              {phase === "refreshing" ? (
+                <Loader2 size={15} className="animate-spin" aria-hidden="true" />
+              ) : (
+                <RefreshCw size={15} aria-hidden="true" />
+              )}
+              状態を再確認
+            </button>
+          )}
+          {status.status !== "not_connected" && (
+            <button
+              type="button"
+              onClick={disconnect}
+              disabled={isWorking}
+              className="inline-flex items-center justify-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-500 transition-colors hover:border-rose-200 hover:bg-rose-50 hover:text-rose-600 disabled:cursor-not-allowed disabled:opacity-60 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 dark:hover:border-rose-700/60 dark:hover:bg-rose-900/20 dark:hover:text-rose-300"
+            >
+              {phase === "disconnecting" ? (
+                <Loader2 size={15} className="animate-spin" aria-hidden="true" />
+              ) : (
+                <Unlink size={15} aria-hidden="true" />
+              )}
+              連携を解除
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div aria-live="polite" className="space-y-3">
+        {message && (
+          <div className="rounded-xl border border-emerald-100 bg-emerald-50 px-4 py-3 text-sm text-emerald-700 dark:border-emerald-700/50 dark:bg-emerald-900/20 dark:text-emerald-300">
+            {message}
+          </div>
+        )}
+        {errorMessage && (
+          <div className="rounded-xl border border-rose-100 bg-rose-50 px-4 py-3 text-sm text-rose-700 dark:border-rose-700/50 dark:bg-rose-900/20 dark:text-rose-300">
+            {errorMessage}
+          </div>
+        )}
+      </div>
+
+      <div className="mt-5 grid grid-cols-1 gap-3 md:grid-cols-2">
+        <div className="rounded-xl border border-slate-100 bg-slate-50 px-4 py-3 dark:border-slate-700 dark:bg-slate-800/70">
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500">
+            権限
+          </p>
+          <div className="mt-3 space-y-2">
+            {status.requiredScopes.map((scope) => {
+              const isGranted = grantedScopeSet.has(scope);
+              return (
+                <div key={scope} className="flex items-center justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-slate-600 dark:text-slate-300">
+                      {getScopeLabel(scope)}
+                    </p>
+                    <p className="truncate text-xs text-slate-400 dark:text-slate-500" title={scope}>
+                      {scope}
+                    </p>
+                  </div>
+                  {isGranted ? (
+                    <CheckCircle2 size={16} className="flex-shrink-0 text-emerald-500 dark:text-emerald-400" aria-label="許可済み" />
+                  ) : (
+                    <AlertCircle size={16} className="flex-shrink-0 text-amber-500 dark:text-amber-400" aria-label="不足" />
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-slate-100 bg-slate-50 px-4 py-3 dark:border-slate-700 dark:bg-slate-800/70">
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500">
+            状態
+          </p>
+          <dl className="mt-3 space-y-3">
+            <div>
+              <dt className="text-xs text-slate-400 dark:text-slate-500">最終確認</dt>
+              <dd className="mt-0.5 text-sm font-medium text-slate-600 dark:text-slate-300">
+                {formatJstDateTime(status.lastCheckedAt)}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs text-slate-400 dark:text-slate-500">最終同期</dt>
+              <dd className="mt-0.5 text-sm font-medium text-slate-600 dark:text-slate-300">
+                {status.lastSyncAt ? formatJstDateTime(status.lastSyncAt) : "未同期"}
+              </dd>
+            </div>
+            {status.lastErrorCode && (
+              <div>
+                <dt className="text-xs text-slate-400 dark:text-slate-500">エラーコード</dt>
+                <dd className="mt-0.5 break-all text-sm font-medium text-slate-600 dark:text-slate-300">
+                  {status.lastErrorCode}
+                </dd>
+              </div>
+            )}
+          </dl>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/lib/googleHealth/status.test.ts
+++ b/src/lib/googleHealth/status.test.ts
@@ -1,0 +1,95 @@
+import type { GoogleHealthConnectionRow } from "@/lib/supabase/types";
+import {
+  buildGoogleHealthConnectionStatus,
+  buildGoogleHealthNotConnectedStatus,
+  buildGoogleHealthStatusError,
+} from "./status";
+import { GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES } from "./dailyMetrics";
+
+function makeConnection(
+  overrides: Partial<GoogleHealthConnectionRow> = {},
+): GoogleHealthConnectionRow {
+  return {
+    id: "connection-id",
+    user_id: "user-id",
+    encrypted_access_token: { ciphertext: "encrypted-access-token" },
+    encrypted_refresh_token: { ciphertext: "encrypted-refresh-token" },
+    access_token_expires_at: "2026-06-06T00:00:00.000Z",
+    granted_scopes: [...GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES],
+    status: "connected",
+    last_checked_at: "2026-06-05T23:00:00.000Z",
+    last_sync_at: "2026-06-05T23:30:00.000Z",
+    last_error_code: null,
+    last_error_message: null,
+    encryption_key_version: 1,
+    created_at: "2026-06-05T22:00:00.000Z",
+    updated_at: "2026-06-05T23:30:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("Google Health status helpers", () => {
+  it("未連携 status を作る", () => {
+    const status = buildGoogleHealthNotConnectedStatus();
+
+    expect(status).toEqual({
+      status: "not_connected",
+      requiredScopes: [...GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES],
+      grantedScopes: [],
+      missingScopes: [...GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES],
+      lastCheckedAt: null,
+      lastSyncAt: null,
+      lastErrorCode: null,
+    });
+  });
+
+  it("連携済み connection を sanitized status に変換する", () => {
+    const status = buildGoogleHealthConnectionStatus(makeConnection());
+
+    expect(status).toEqual({
+      status: "connected",
+      requiredScopes: [...GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES],
+      grantedScopes: [...GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES],
+      missingScopes: [],
+      lastCheckedAt: "2026-06-05T23:00:00.000Z",
+      lastSyncAt: "2026-06-05T23:30:00.000Z",
+      lastErrorCode: null,
+    });
+    expect(JSON.stringify(status)).not.toContain("encrypted-access-token");
+    expect(JSON.stringify(status)).not.toContain("encrypted-refresh-token");
+  });
+
+  it("必須 scope が不足している場合は scope_missing にする", () => {
+    const status = buildGoogleHealthConnectionStatus(makeConnection({
+      granted_scopes: [GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES[0]],
+    }));
+
+    expect(status.status).toBe("scope_missing");
+    expect(status.missingScopes).toEqual([
+      GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES[1],
+      GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES[2],
+    ]);
+  });
+
+  it("connected でも token 保存状態が不足していれば再認可扱いにする", () => {
+    const status = buildGoogleHealthConnectionStatus(makeConnection({
+      encrypted_refresh_token: null,
+    }));
+
+    expect(status.status).toBe("reauthorization_required");
+  });
+
+  it("lookup error 用の sanitized status を作る", () => {
+    const status = buildGoogleHealthStatusError("lookup_failed");
+
+    expect(status).toEqual({
+      status: "error",
+      requiredScopes: [...GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES],
+      grantedScopes: [],
+      missingScopes: [],
+      lastCheckedAt: null,
+      lastSyncAt: null,
+      lastErrorCode: "lookup_failed",
+    });
+  });
+});

--- a/src/lib/googleHealth/status.ts
+++ b/src/lib/googleHealth/status.ts
@@ -1,0 +1,96 @@
+import { createServiceRoleClient } from "@/lib/supabase/serviceRole";
+import type {
+  GoogleHealthConnectionRow,
+  GoogleHealthConnectionStatus,
+} from "@/lib/supabase/types";
+import { getGoogleHealthConnectionByUserId } from "./connections";
+import { GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES } from "./dailyMetrics";
+import { getMissingGoogleHealthOAuthScopes } from "./oauth";
+
+type ServiceRoleClient = ReturnType<typeof createServiceRoleClient>;
+
+export type GoogleHealthStatusSnapshot = {
+  status: GoogleHealthConnectionStatus;
+  requiredScopes: string[];
+  grantedScopes: string[];
+  missingScopes: string[];
+  lastCheckedAt: string | null;
+  lastSyncAt: string | null;
+  lastErrorCode: string | null;
+};
+
+export type GoogleHealthStatusApiResponse =
+  | ({ ok: true } & GoogleHealthStatusSnapshot)
+  | ({
+      ok: false;
+      error: string;
+    } & GoogleHealthStatusSnapshot);
+
+const REQUIRED_SCOPES = [...GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES];
+
+export function buildGoogleHealthNotConnectedStatus(): GoogleHealthStatusSnapshot {
+  return {
+    status: "not_connected",
+    requiredScopes: REQUIRED_SCOPES,
+    grantedScopes: [],
+    missingScopes: REQUIRED_SCOPES,
+    lastCheckedAt: null,
+    lastSyncAt: null,
+    lastErrorCode: null,
+  };
+}
+
+export function buildGoogleHealthStatusError(
+  lastErrorCode = "google_health_connection_status_failed",
+): GoogleHealthStatusSnapshot {
+  return {
+    status: "error",
+    requiredScopes: REQUIRED_SCOPES,
+    grantedScopes: [],
+    missingScopes: [],
+    lastCheckedAt: null,
+    lastSyncAt: null,
+    lastErrorCode,
+  };
+}
+
+function resolveVisibleStatus(args: {
+  connection: GoogleHealthConnectionRow;
+  missingScopes: readonly string[];
+}): GoogleHealthConnectionStatus {
+  if (args.missingScopes.length > 0) return "scope_missing";
+  if (
+    args.connection.status === "connected" &&
+    (!args.connection.encrypted_access_token || !args.connection.encrypted_refresh_token)
+  ) {
+    return "reauthorization_required";
+  }
+  return args.connection.status;
+}
+
+export function buildGoogleHealthConnectionStatus(
+  connection: GoogleHealthConnectionRow | null,
+): GoogleHealthStatusSnapshot {
+  if (!connection) return buildGoogleHealthNotConnectedStatus();
+
+  const grantedScopes = connection.granted_scopes ?? [];
+  const missingScopes = getMissingGoogleHealthOAuthScopes(grantedScopes);
+
+  return {
+    status: resolveVisibleStatus({ connection, missingScopes }),
+    requiredScopes: REQUIRED_SCOPES,
+    grantedScopes,
+    missingScopes,
+    lastCheckedAt: connection.last_checked_at,
+    lastSyncAt: connection.last_sync_at,
+    lastErrorCode: connection.last_error_code,
+  };
+}
+
+export async function getGoogleHealthStatusForUser(
+  userId: string,
+  client: ServiceRoleClient = createServiceRoleClient(),
+): Promise<GoogleHealthStatusSnapshot> {
+  const connection = await getGoogleHealthConnectionByUserId(userId, client);
+  return buildGoogleHealthConnectionStatus(connection);
+}


### PR DESCRIPTION
## 概要
Google Health の連携状態を設定画面で確認できるようにし、未連携・連携済み・scope 不足・再認可必要・エラーを区別して表示します。

## 変更内容
- `GET /api/google-health/status` を追加し、連携状態・scope・最終確認/同期時刻だけを返すようにしました。
- `private.google_health_connections` の行を UI 用の sanitized status に変換する helper を追加しました。
- 設定画面に `GoogleHealthSection` を追加し、状態に応じた OAuth 連携 / 再認可導線と補助操作の連携解除を表示しました。
- status API / helper / UI の関連テストを追加しました。

## 判断理由
- token / refresh token / client secret / auth code / raw Google response は API 応答や UI に出さない方針です。
- 同期実行ボタンは別 Issue で扱うため、#687 では接続状態の確認と OAuth 導線に絞っています。
- 必須 scope は `GOOGLE_HEALTH_DAILY_REQUIRED_SCOPES` を正として判定します。

## 検証結果
- `npm run test -- src/lib/googleHealth/status.test.ts src/app/api/google-health/status/route.test.ts src/components/settings/GoogleHealthSection.integration.test.tsx`
- `npm run lint`
- `npx tsc --noEmit`

## 補足
- `supabase/.branches/` は未追跡のまま残しており、この PR には含めていません。

Closes #687
