### PR TITLE
Google Healthの手動同期ボタンを追加する

### DIFF
--- a/src/app/api/google-health/daily-metrics/route.test.ts
+++ b/src/app/api/google-health/daily-metrics/route.test.ts
@@ -9,6 +9,7 @@ jest.mock("@/lib/googleHealth/dailyMetrics", () => ({
 }));
 
 jest.mock("@/lib/googleHealth/connections", () => ({
+  markGoogleHealthConnectionSynced: jest.fn(),
   resolveGoogleHealthStoredAccessToken: jest.fn(),
 }));
 
@@ -22,7 +23,10 @@ jest.mock("@/lib/cache/revalidate", () => ({
 
 import { NextRequest } from "next/server";
 import { revalidateAfterDailyLogMutation } from "@/lib/cache/revalidate";
-import { resolveGoogleHealthStoredAccessToken } from "@/lib/googleHealth/connections";
+import {
+  markGoogleHealthConnectionSynced,
+  resolveGoogleHealthStoredAccessToken,
+} from "@/lib/googleHealth/connections";
 import { fetchGoogleHealthDailyMetrics } from "@/lib/googleHealth/dailyMetrics";
 import { saveGoogleHealthDailyMetrics } from "@/lib/googleHealth/saveDailyMetrics";
 import { createClient, getCurrentUser } from "@/lib/supabase/server";
@@ -31,6 +35,7 @@ import { POST } from "./route";
 const mockCreateClient = createClient as jest.Mock;
 const mockGetCurrentUser = getCurrentUser as jest.Mock;
 const mockResolveStoredAccessToken = resolveGoogleHealthStoredAccessToken as jest.Mock;
+const mockMarkConnectionSynced = markGoogleHealthConnectionSynced as jest.Mock;
 const mockFetchGoogleHealthDailyMetrics = fetchGoogleHealthDailyMetrics as jest.Mock;
 const mockSaveGoogleHealthDailyMetrics = saveGoogleHealthDailyMetrics as jest.Mock;
 const mockRevalidate = revalidateAfterDailyLogMutation as jest.Mock;
@@ -60,6 +65,7 @@ describe("POST /api/google-health/daily-metrics", () => {
     mockCreateClient.mockReset();
     mockGetCurrentUser.mockReset();
     mockResolveStoredAccessToken.mockReset();
+    mockMarkConnectionSynced.mockReset();
     mockFetchGoogleHealthDailyMetrics.mockReset();
     mockSaveGoogleHealthDailyMetrics.mockReset();
     mockRevalidate.mockReset();
@@ -161,6 +167,7 @@ describe("POST /api/google-health/daily-metrics", () => {
       savedDates: ["2026-06-02"],
       skippedDates: [],
     });
+    mockMarkConnectionSynced.mockResolvedValue(undefined);
 
     const response = await POST(makeRequest({
       start: "2026-06-02",
@@ -182,6 +189,7 @@ describe("POST /api/google-health/daily-metrics", () => {
       metrics: dailyMetrics,
       stepsSource: "reconcile",
     });
+    expect(mockMarkConnectionSynced).toHaveBeenCalledWith({ userId: "user-id" });
     expect(mockRevalidate).toHaveBeenCalledTimes(1);
     expect(body).toEqual({
       ok: true,
@@ -234,6 +242,50 @@ describe("POST /api/google-health/daily-metrics", () => {
     expect(JSON.stringify(body)).not.toContain("details");
     expect(mockCreateClient).not.toHaveBeenCalled();
     expect(mockSaveGoogleHealthDailyMetrics).not.toHaveBeenCalled();
+    expect(mockRevalidate).not.toHaveBeenCalled();
+  });
+
+  it("last_sync_at の更新に失敗した場合は sanitized 500 を返す", async () => {
+    const supabase = { from: jest.fn() };
+
+    mockGetCurrentUser.mockResolvedValue({ id: "user-id" });
+    mockResolveStoredAccessToken.mockResolvedValue({
+      ok: true,
+      accessToken: "stored-google-token",
+      refreshed: false,
+      status: "connected",
+    });
+    mockCreateClient.mockResolvedValue(supabase);
+    mockFetchGoogleHealthDailyMetrics.mockResolvedValue({
+      sourceResults: [
+        { ok: true, key: "sleep", dataPoints: [] },
+        { ok: true, key: "heartRateVariability", dataPoints: [] },
+        { ok: true, key: "restingHeartRate", dataPoints: [] },
+      ],
+      stepsResult: { ok: true, source: "reconcile" },
+      dailyMetrics: [],
+    });
+    mockSaveGoogleHealthDailyMetrics.mockResolvedValue({
+      ok: true,
+      savedCount: 0,
+      skippedCount: 0,
+      savedDates: [],
+      skippedDates: [],
+    });
+    mockMarkConnectionSynced.mockRejectedValue(new Error("supabase_service_role_env_missing"));
+
+    const response = await POST(makeRequest({
+      start: "2026-06-02",
+      end: "2026-06-02",
+    }));
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body).toEqual({
+      error: "Google Health sync timestamp update failed.",
+      status: "error",
+    });
+    expect(JSON.stringify(body)).not.toContain("supabase_service_role_env_missing");
     expect(mockRevalidate).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/google-health/daily-metrics/route.ts
+++ b/src/app/api/google-health/daily-metrics/route.ts
@@ -1,7 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { revalidateAfterDailyLogMutation } from "@/lib/cache/revalidate";
 import { fetchGoogleHealthDailyMetrics } from "@/lib/googleHealth/dailyMetrics";
-import { resolveGoogleHealthStoredAccessToken } from "@/lib/googleHealth/connections";
+import {
+  markGoogleHealthConnectionSynced,
+  resolveGoogleHealthStoredAccessToken,
+} from "@/lib/googleHealth/connections";
 import { resolveGoogleHealthPocRange } from "@/lib/googleHealth/poc";
 import type { GoogleHealthPocTargetResult } from "@/lib/googleHealth/poc";
 import { saveGoogleHealthDailyMetrics } from "@/lib/googleHealth/saveDailyMetrics";
@@ -129,6 +132,18 @@ export async function POST(req: NextRequest) {
 
   if (!saveResult.ok) {
     return NextResponse.json({ error: saveResult.message }, { status: 500 });
+  }
+
+  try {
+    await markGoogleHealthConnectionSynced({ userId: user.id });
+  } catch {
+    return NextResponse.json(
+      {
+        error: "Google Health sync timestamp update failed.",
+        status: "error",
+      },
+      { status: 500 },
+    );
   }
 
   if (saveResult.savedCount > 0) {

--- a/src/components/settings/GoogleHealthSection.integration.test.tsx
+++ b/src/components/settings/GoogleHealthSection.integration.test.tsx
@@ -24,8 +24,21 @@ function makeStatus(
 
 describe("GoogleHealthSection", () => {
   afterEach(() => {
+    jest.useRealTimers();
     jest.restoreAllMocks();
+    Reflect.deleteProperty(global, "fetch");
   });
+
+  function jsonResponse(body: unknown, status = 200) {
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      headers: {
+        get: (key: string) => key.toLowerCase() === "content-type" ? "application/json" : null,
+      },
+      json: jest.fn().mockResolvedValue(body),
+    };
+  }
 
   it("未連携の場合は OAuth 連携への主ボタンを表示する", () => {
     render(<GoogleHealthSection initialStatus={makeStatus()} />);
@@ -85,5 +98,90 @@ describe("GoogleHealthSection", () => {
     expect(await screen.findByText("Google Health 連携を解除しました。")).toBeInTheDocument();
     expect(screen.getByText("未連携")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Google Health と同期" })).toBeInTheDocument();
+  });
+
+  it("連携済みの場合は JST 直近7日で同期して status を再取得する", async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-06-07T03:00:00.000Z"));
+    const fetchMock = jest.fn()
+      .mockResolvedValueOnce(jsonResponse({
+        ok: true,
+        savedCount: 2,
+        skippedCount: 1,
+        savedDates: ["2026-06-05", "2026-06-06"],
+        skippedDates: ["2026-06-07"],
+      }))
+      .mockResolvedValueOnce(jsonResponse({
+        ok: true,
+        status: "connected",
+        requiredScopes: REQUIRED_SCOPES,
+        grantedScopes: REQUIRED_SCOPES,
+        missingScopes: [],
+        lastCheckedAt: "2026-06-07T03:10:00.000Z",
+        lastSyncAt: "2026-06-07T03:10:00.000Z",
+        lastErrorCode: null,
+      }));
+    Object.defineProperty(global, "fetch", {
+      value: fetchMock,
+      writable: true,
+    });
+
+    render(
+      <GoogleHealthSection
+        initialStatus={makeStatus({
+          status: "connected",
+          grantedScopes: REQUIRED_SCOPES,
+          missingScopes: [],
+          lastCheckedAt: "2026-06-05T23:00:00.000Z",
+          lastSyncAt: null,
+        })}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "今すぐ同期" }));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/google-health/daily-metrics?start=2026-06-01&end=2026-06-07",
+      { method: "POST" },
+    );
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/google-health/status", { method: "GET" });
+    });
+    expect(await screen.findByText("同期しました。保存: 2日 / スキップ: 1日")).toBeInTheDocument();
+    expect(screen.getAllByText("2026/06/07 12:10")).toHaveLength(2);
+  });
+
+  it("同期 API が scope 不足を返した場合は再認可導線へ切り替える", async () => {
+    const fetchMock = jest.fn().mockResolvedValue(jsonResponse({
+      error: "Required Google Health OAuth scopes are missing.",
+      status: "scope_missing",
+      requiredScopes: REQUIRED_SCOPES,
+      missingScopes: [HEALTH_METRICS_SCOPE],
+    }, 403));
+    Object.defineProperty(global, "fetch", {
+      value: fetchMock,
+      writable: true,
+    });
+
+    render(
+      <GoogleHealthSection
+        initialStatus={makeStatus({
+          status: "connected",
+          grantedScopes: REQUIRED_SCOPES,
+          missingScopes: [],
+          lastCheckedAt: "2026-06-05T23:00:00.000Z",
+        })}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "今すぐ同期" }));
+
+    expect(await screen.findByText("Google Health の再認可が必要です。")).toBeInTheDocument();
+    expect(screen.getByText("権限不足")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "再認可して同期" })).toHaveAttribute(
+      "href",
+      "/api/google-health/oauth/start?prompt=consent",
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/settings/GoogleHealthSection.tsx
+++ b/src/components/settings/GoogleHealthSection.tsx
@@ -14,12 +14,27 @@ import type {
   GoogleHealthStatusApiResponse,
   GoogleHealthStatusSnapshot,
 } from "@/lib/googleHealth/status";
+import { addDaysStr, toJstDateStr } from "@/lib/utils/date";
 
 type GoogleHealthSectionProps = {
   initialStatus: GoogleHealthStatusSnapshot;
 };
 
-type ActionPhase = "idle" | "refreshing" | "disconnecting";
+type ActionPhase = "idle" | "refreshing" | "syncing" | "disconnecting";
+
+type GoogleHealthSyncSuccessResponse = {
+  ok: true;
+  savedCount: number;
+  skippedCount: number;
+  savedDates: string[];
+  skippedDates: string[];
+};
+
+type GoogleHealthSyncErrorResponse = {
+  error?: string;
+  status?: string;
+  missingScopes?: string[];
+};
 
 const STATUS_LABELS: Record<GoogleHealthStatusSnapshot["status"], {
   label: string;
@@ -61,6 +76,13 @@ const STATUS_LABELS: Record<GoogleHealthStatusSnapshot["status"], {
 
 const CONNECT_URL = "/api/google-health/oauth/start";
 const REAUTHORIZE_URL = "/api/google-health/oauth/start?prompt=consent";
+const GOOGLE_HEALTH_VISIBLE_STATUSES = new Set<GoogleHealthStatusSnapshot["status"]>([
+  "not_connected",
+  "connected",
+  "scope_missing",
+  "reauthorization_required",
+  "error",
+]);
 
 function getScopeLabel(scope: string): string {
   if (scope.includes("activity_and_fitness")) return "歩数・活動";
@@ -120,6 +142,42 @@ function snapshotFromApiResponse(
   return snapshot;
 }
 
+function isVisibleStatus(value: unknown): value is GoogleHealthStatusSnapshot["status"] {
+  return typeof value === "string" && GOOGLE_HEALTH_VISIBLE_STATUSES.has(value as GoogleHealthStatusSnapshot["status"]);
+}
+
+function isSyncSuccessResponse(value: GoogleHealthSyncSuccessResponse | GoogleHealthSyncErrorResponse): value is GoogleHealthSyncSuccessResponse {
+  return "ok" in value && value.ok === true;
+}
+
+function buildDefaultSyncRange(): { start: string; end: string } {
+  const end = toJstDateStr();
+  return {
+    start: addDaysStr(end, -6) ?? end,
+    end,
+  };
+}
+
+function buildSyncUrl(): string {
+  const range = buildDefaultSyncRange();
+  const params = new URLSearchParams(range);
+  return `/api/google-health/daily-metrics?${params.toString()}`;
+}
+
+function buildSyncSuccessMessage(result: GoogleHealthSyncSuccessResponse): string {
+  return `同期しました。保存: ${result.savedCount.toLocaleString()}日 / スキップ: ${result.skippedCount.toLocaleString()}日`;
+}
+
+function buildSyncErrorMessage(result: GoogleHealthSyncErrorResponse): string {
+  if (result.status === "scope_missing" || result.status === "reauthorization_required") {
+    return "Google Health の再認可が必要です。";
+  }
+  if (result.status === "not_connected") {
+    return "Google Health 連携が必要です。";
+  }
+  return "Google Health 同期に失敗しました。";
+}
+
 export function GoogleHealthSection({ initialStatus }: GoogleHealthSectionProps) {
   const [status, setStatus] = useState<GoogleHealthStatusSnapshot>(initialStatus);
   const [phase, setPhase] = useState<ActionPhase>("idle");
@@ -129,25 +187,80 @@ export function GoogleHealthSection({ initialStatus }: GoogleHealthSectionProps)
   const statusMeta = STATUS_LABELS[status.status];
   const grantedScopeSet = new Set(status.grantedScopes);
 
+  async function fetchStatusSnapshot(): Promise<GoogleHealthStatusSnapshot> {
+    const response = await fetch("/api/google-health/status", { method: "GET" });
+    const contentType = response.headers.get("content-type") ?? "";
+    if (!contentType.includes("application/json")) {
+      throw new Error("unexpected_response");
+    }
+    const body = await response.json() as GoogleHealthStatusApiResponse;
+    if (!response.ok || !body.ok) {
+      throw new Error("status_fetch_failed");
+    }
+    return snapshotFromApiResponse(body);
+  }
+
   async function refreshStatus() {
     setPhase("refreshing");
     setMessage(null);
     setErrorMessage(null);
 
     try {
-      const response = await fetch("/api/google-health/status", { method: "GET" });
+      setStatus(await fetchStatusSnapshot());
+    } catch {
+      setStatus((current) => buildClientErrorStatus(current));
+      setErrorMessage("連携状態の確認に失敗しました。");
+    } finally {
+      setPhase("idle");
+    }
+  }
+
+  function applySyncErrorStatus(result: GoogleHealthSyncErrorResponse) {
+    if (!isVisibleStatus(result.status)) return;
+
+    setStatus((current) => ({
+      ...current,
+      status: result.status as GoogleHealthStatusSnapshot["status"],
+      missingScopes: result.missingScopes ?? current.missingScopes,
+      lastErrorCode: result.status ?? current.lastErrorCode,
+    }));
+  }
+
+  async function syncNow() {
+    if (status.status !== "connected") return;
+
+    setPhase("syncing");
+    setMessage(null);
+    setErrorMessage(null);
+
+    try {
+      const response = await fetch(buildSyncUrl(), { method: "POST" });
       const contentType = response.headers.get("content-type") ?? "";
       if (!contentType.includes("application/json")) {
         throw new Error("unexpected_response");
       }
-      const body = await response.json() as GoogleHealthStatusApiResponse;
-      setStatus(snapshotFromApiResponse(body));
-      if (!response.ok || !body.ok) {
-        setErrorMessage("連携状態の確認に失敗しました。");
+      const body = await response.json() as GoogleHealthSyncSuccessResponse | GoogleHealthSyncErrorResponse;
+
+      if (!response.ok || !isSyncSuccessResponse(body)) {
+        const errorBody = isSyncSuccessResponse(body) ? {} : body;
+        applySyncErrorStatus(errorBody);
+        setErrorMessage(buildSyncErrorMessage(errorBody));
+        return;
+      }
+
+      let statusRefreshFailed = false;
+      try {
+        setStatus(await fetchStatusSnapshot());
+      } catch {
+        statusRefreshFailed = true;
+      }
+
+      setMessage(buildSyncSuccessMessage(body));
+      if (statusRefreshFailed) {
+        setErrorMessage("同期は完了しましたが、最終同期の再取得に失敗しました。");
       }
     } catch {
-      setStatus((current) => buildClientErrorStatus(current));
-      setErrorMessage("連携状態の確認に失敗しました。");
+      setErrorMessage("Google Health 同期に失敗しました。");
     } finally {
       setPhase("idle");
     }
@@ -212,6 +325,21 @@ export function GoogleHealthSection({ initialStatus }: GoogleHealthSectionProps)
         </div>
 
         <div className="flex flex-wrap gap-2">
+          {status.status === "connected" && (
+            <button
+              type="button"
+              onClick={syncNow}
+              disabled={isWorking}
+              className="inline-flex items-center justify-center gap-1.5 rounded-lg bg-blue-600 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-blue-500 dark:hover:bg-blue-400"
+            >
+              {phase === "syncing" ? (
+                <Loader2 size={15} className="animate-spin" aria-hidden="true" />
+              ) : (
+                <RefreshCw size={15} aria-hidden="true" />
+              )}
+              {phase === "syncing" ? "同期中..." : "今すぐ同期"}
+            </button>
+          )}
           {primaryAction && (
             <a
               href={primaryAction.href}

--- a/src/lib/googleHealth/connections.test.ts
+++ b/src/lib/googleHealth/connections.test.ts
@@ -13,6 +13,7 @@ jest.mock("./oauth", () => {
 });
 
 import {
+  markGoogleHealthConnectionSynced,
   resolveGoogleHealthStoredAccessToken,
   saveGoogleHealthOAuthConnection,
 } from "./connections";
@@ -210,5 +211,26 @@ describe("Google Health connections", () => {
       status: "reauthorization_required",
       last_error_code: "google_health_oauth_token_refresh_invalid_grant",
     }));
+  });
+
+  it("同期成功時に last_sync_at と connected status を更新する", async () => {
+    const { client, update } = makeClient({
+      encrypted_refresh_token: null,
+      status: "error",
+    });
+
+    await markGoogleHealthConnectionSynced({
+      userId: "user-id",
+      syncedAt: "2026-06-07T03:10:00.000Z",
+      client: client as never,
+    });
+
+    expect(update).toHaveBeenCalledWith({
+      status: "connected",
+      last_checked_at: "2026-06-07T03:10:00.000Z",
+      last_sync_at: "2026-06-07T03:10:00.000Z",
+      last_error_code: null,
+      last_error_message: null,
+    });
   });
 });

--- a/src/lib/googleHealth/connections.ts
+++ b/src/lib/googleHealth/connections.ts
@@ -340,6 +340,29 @@ export async function markGoogleHealthConnectionError(args: {
   }
 }
 
+export async function markGoogleHealthConnectionSynced(args: {
+  userId: string;
+  syncedAt?: string;
+  client?: ServiceRoleClient;
+}): Promise<void> {
+  const client = args.client ?? createServiceRoleClient();
+  const syncedAt = args.syncedAt ?? new Date().toISOString();
+
+  const { error } = await privateConnections(client)
+    .update({
+      status: "connected",
+      last_checked_at: syncedAt,
+      last_sync_at: syncedAt,
+      last_error_code: null,
+      last_error_message: null,
+    })
+    .eq("user_id", args.userId);
+
+  if (error) {
+    throw new Error("google_health_connection_sync_update_failed");
+  }
+}
+
 export async function deleteGoogleHealthConnection(
   userId: string,
   client: ServiceRoleClient = createServiceRoleClient(),


### PR DESCRIPTION
## 概要
設定画面の Google Health セクションに、連携済み状態で実行できる手動同期ボタンを追加しました。

## 変更内容
- `connected` 状態で `今すぐ同期` ボタンを表示し、JST 直近 7 日分を `POST /api/google-health/daily-metrics` に送るようにしました。
- 同期成功時に保存件数・スキップ件数を画面表示し、`GET /api/google-health/status` を再取得して最終同期表示を更新するようにしました。
- 同期 API 成功時に `private.google_health_connections.last_sync_at` を更新する helper を追加しました。
- scope 不足・再認可必要などの同期失敗時は、token や raw response を出さずに sanitized なメッセージと適切な再認可導線を表示します。
- UI / API / connection helper の関連テストを追加・更新しました。

## 判断理由
- 同期対象は初期仕様どおり JST 直近 7 日に固定し、任意範囲選択や自動同期はスコープ外にしています。
- Google Health token は引き続きサーバー側だけで利用し、ブラウザには渡しません。
- `last_sync_at` 更新は同期成功の可視化に必要なため、保存 API 側で実施します。

## 検証結果
- `npm run test -- src/components/settings/GoogleHealthSection.integration.test.tsx src/app/api/google-health/daily-metrics/route.test.ts src/lib/googleHealth/connections.test.ts`
- `npm run lint`
- `npx tsc --noEmit`

## 補足
- `supabase/.branches/` は未追跡のまま残しており、この PR には含めていません。

Closes #703
