### PR TITLE
Google Health由来の日次メトリクスをホーム画面に表示する

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,6 +22,7 @@ import { calcMonthlyBehaviorStats } from "@/lib/utils/calcMonthlyBehaviorStats";
 import { resolveMonthlyPlanHistoryAnchor } from "@/lib/utils/monthlyPlanHistory";
 import { fetchDashboardDailyLogs, fetchPredictions, fetchCareerLogsForDashboard } from "@/lib/queries/dailyLogs";
 import { fetchSleepSessionsForRange } from "@/lib/queries/sleepSessions";
+import { fetchGoogleHealthDailyMetricsForRange } from "@/lib/queries/googleHealthDailyMetrics";
 import { fetchSettings } from "@/lib/queries/settings";
 import { fetchEnrichedLogs } from "@/lib/queries/analytics";
 import { mapToAppSettings } from "@/lib/domain/settings";
@@ -111,9 +112,14 @@ export default async function DashboardPage() {
   // 終端を today にすることで、当日の daily_log がまだない状態でも
   // 当日の sleep_session を取得できる（データ品質チェックの sleepUnloggedDays に正しく反映される）。
   const firstLogDate = logs.at(0)?.log_date ?? null;
-  const sleepSessions = firstLogDate
-    ? await fetchSleepSessionsForRange(firstLogDate, today)
-    : [];
+  const [sleepSessions, googleHealthMetricsResult] = firstLogDate
+    ? await Promise.all([
+        fetchSleepSessionsForRange(firstLogDate, today),
+        fetchGoogleHealthDailyMetricsForRange(firstLogDate, today),
+      ])
+    : [[], { kind: "ok" as const, data: [] }];
+  const googleHealthMetrics =
+    googleHealthMetricsResult.kind === "ok" ? googleHealthMetricsResult.data : [];
 
   // MAX(updated_at) を使って stale 判定する。
   // MAX(log_date) ではなく MAX(updated_at) を使うことで、過去日の行修正でも stale を正しく検知できる。
@@ -258,7 +264,7 @@ export default async function DashboardPage() {
       : [];
 
   // 月別行動・生活集計: buildMonthStats と同じ 3 ヶ月分を計算する
-  const monthlyBehaviorStats = calcMonthlyBehaviorStats(logs, 3, sleepSessions);
+  const monthlyBehaviorStats = calcMonthlyBehaviorStats(logs, 3, sleepSessions, googleHealthMetrics);
 
   return (
     <DashboardLayout
@@ -273,6 +279,11 @@ export default async function DashboardPage() {
           {settingsResult.kind === "error" && (
             <StatusNotice status="error">
               設定データの取得中にエラーが発生しました。一部の表示がデフォルト値になります。
+            </StatusNotice>
+          )}
+          {googleHealthMetricsResult.kind === "error" && (
+            <StatusNotice status="caution">
+              Google Health データの取得中にエラーが発生しました。日次メトリクス表示は一部欠落します。
             </StatusNotice>
           )}
           {readinessMetrics.days_to_contest !== null && readinessMetrics.days_to_contest < 0 && (
@@ -324,6 +335,7 @@ export default async function DashboardPage() {
           <LogsAndSummaryTabs
             logs={logs}
             sleepSessions={sleepSessions}
+            googleHealthMetrics={googleHealthMetrics}
             monthStats={monthStats}
             seasonMap={seasonMap}
             currentSeason={currentSeason}

--- a/src/components/dashboard/LogsAndSummaryTabs.tsx
+++ b/src/components/dashboard/LogsAndSummaryTabs.tsx
@@ -8,6 +8,7 @@ import { MonthlyGoalTable } from "./MonthlyGoalTable";
 import { MonthlyBehaviorSummary } from "./MonthlyBehaviorSummary";
 import { SeasonSummary } from "@/components/history/SeasonSummary";
 import type { DashboardDailyLog, SleepSession } from "@/lib/supabase/types";
+import type { GoogleHealthDailyMetricForDisplay } from "@/lib/googleHealth/displayMetrics";
 import type { MonthStats } from "@/components/history/SeasonSummary";
 import type { MonthlyGoalComparisonRow } from "@/lib/utils/monthlyGoalVisualization";
 import type { MonthlyBehaviorStats } from "@/lib/utils/calcMonthlyBehaviorStats";
@@ -15,6 +16,7 @@ import type { MonthlyBehaviorStats } from "@/lib/utils/calcMonthlyBehaviorStats"
 interface LogsAndSummaryTabsProps {
   logs: DashboardDailyLog[];
   sleepSessions?: Pick<SleepSession, "wake_date" | "wake_at" | "bed_at">[];
+  googleHealthMetrics?: GoogleHealthDailyMetricForDisplay[];
   monthStats: MonthStats[];
   seasonMap?: Map<string, string>;
   currentSeason?: string | null;
@@ -34,7 +36,7 @@ const TAB_LABELS: Record<Tab, string> = {
   monthly:  "月別",
 };
 
-export function LogsAndSummaryTabs({ logs, sleepSessions = [], monthStats, seasonMap, currentSeason, monthlyGoalSummaryRows, phase, monthlyBehaviorStats }: LogsAndSummaryTabsProps) {
+export function LogsAndSummaryTabs({ logs, sleepSessions = [], googleHealthMetrics = [], monthStats, seasonMap, currentSeason, monthlyGoalSummaryRows, phase, monthlyBehaviorStats }: LogsAndSummaryTabsProps) {
   const [tab, setTab] = useState<Tab>("logs");
 
   return (
@@ -64,16 +66,16 @@ export function LogsAndSummaryTabs({ logs, sleepSessions = [], monthStats, seaso
           <div role="tabpanel" id="panel-logs" aria-labelledby="tab-logs">
             {/* モバイル: カードリスト。sm+ ではテーブル表示に切り替え */}
             <div className="sm:hidden">
-              <RecentLogsCards logs={logs} sleepSessions={sleepSessions} seasonMap={seasonMap} currentSeason={currentSeason} />
+              <RecentLogsCards logs={logs} sleepSessions={sleepSessions} googleHealthMetrics={googleHealthMetrics} seasonMap={seasonMap} currentSeason={currentSeason} />
             </div>
             <div className="hidden sm:block">
-              <RecentLogsTable logs={logs} sleepSessions={sleepSessions} embedded seasonMap={seasonMap} currentSeason={currentSeason} />
+              <RecentLogsTable logs={logs} sleepSessions={sleepSessions} googleHealthMetrics={googleHealthMetrics} embedded seasonMap={seasonMap} currentSeason={currentSeason} />
             </div>
           </div>
         )}
         {tab === "calendar" && (
           <div role="tabpanel" id="panel-calendar" aria-labelledby="tab-calendar">
-            <MonthlyCalendar logs={logs} sleepSessions={sleepSessions} />
+            <MonthlyCalendar logs={logs} sleepSessions={sleepSessions} googleHealthMetrics={googleHealthMetrics} />
           </div>
         )}
         {tab === "monthly" && (

--- a/src/components/dashboard/MonthlyBehaviorSummary.tsx
+++ b/src/components/dashboard/MonthlyBehaviorSummary.tsx
@@ -147,7 +147,7 @@ export function MonthlyBehaviorSummary({ stats }: MonthlyBehaviorSummaryProps) {
                           </span>
                         )}
                         {s.cardioStats.avgRhrBpm !== null && (
-                          <span className="whitespace-nowrap tabular-nums text-slate-400 dark:text-slate-500">
+                          <span className="whitespace-nowrap tabular-nums text-slate-600 dark:text-slate-300">
                             安静時 {formatMetricAverage(s.cardioStats.avgRhrBpm, "bpm")}
                           </span>
                         )}

--- a/src/components/dashboard/MonthlyBehaviorSummary.tsx
+++ b/src/components/dashboard/MonthlyBehaviorSummary.tsx
@@ -48,6 +48,12 @@ const FLAG_KEYS = [
   "is_travel_day",
 ] as const;
 
+function formatMetricAverage(value: number | null, unit: string): string | null {
+  if (value === null) return null;
+  const formatted = Number.isInteger(value) ? value.toFixed(0) : value.toFixed(1);
+  return `${formatted}${unit}`;
+}
+
 export function MonthlyBehaviorSummary({ stats }: MonthlyBehaviorSummaryProps) {
   if (stats.length === 0) return null;
 
@@ -64,6 +70,7 @@ export function MonthlyBehaviorSummary({ stats }: MonthlyBehaviorSummaryProps) {
               <th className="pb-2 pr-3 text-right font-semibold uppercase tracking-wide text-slate-400 whitespace-nowrap">便通</th>
               <th className="pb-2 pr-3 font-semibold uppercase tracking-wide text-slate-400 whitespace-nowrap">トレーニング</th>
               <th className="pb-2 pr-3 font-semibold uppercase tracking-wide text-slate-400 whitespace-nowrap">生活リズム</th>
+              <th className="pb-2 pr-3 font-semibold uppercase tracking-wide text-slate-400 whitespace-nowrap">心肺機能</th>
               <th className="pb-2 pr-3 font-semibold uppercase tracking-wide text-slate-400 whitespace-nowrap">仕事</th>
               <th className="pb-2 font-semibold uppercase tracking-wide text-slate-400 whitespace-nowrap">特殊日</th>
             </tr>
@@ -130,6 +137,26 @@ export function MonthlyBehaviorSummary({ stats }: MonthlyBehaviorSummaryProps) {
                     )}
                   </td>
 
+                  {/* 心肺機能 */}
+                  <td className="py-2.5 pr-3 text-slate-600 dark:text-slate-300">
+                    {s.cardioStats ? (
+                      <span className="flex flex-col gap-0.5">
+                        {s.cardioStats.avgHrvMs !== null && (
+                          <span className="whitespace-nowrap tabular-nums text-slate-600 dark:text-slate-300">
+                            HRV {formatMetricAverage(s.cardioStats.avgHrvMs, "ms")}
+                          </span>
+                        )}
+                        {s.cardioStats.avgRhrBpm !== null && (
+                          <span className="whitespace-nowrap tabular-nums text-slate-400 dark:text-slate-500">
+                            安静時 {formatMetricAverage(s.cardioStats.avgRhrBpm, "bpm")}
+                          </span>
+                        )}
+                      </span>
+                    ) : (
+                      <span className="text-slate-300 dark:text-slate-600">—</span>
+                    )}
+                  </td>
+
                   {/* 仕事モード */}
                   <td className="py-2.5 pr-3 text-slate-600 dark:text-slate-300">
                     {workEntries.length > 0 ? (
@@ -174,7 +201,7 @@ export function MonthlyBehaviorSummary({ stats }: MonthlyBehaviorSummaryProps) {
         </table>
       </div>
       <p className="mt-1.5 text-[10px] text-slate-400 dark:text-slate-500">
-        ※ 未記録日は集計対象外。トレーニング・仕事モードの「—」は当月に有効な記録がないことを示す。
+        ※ 未記録日は集計対象外。生活リズム・心肺機能は Google Health 由来。トレーニング・仕事モードの「—」は当月に有効な記録がないことを示す。
       </p>
     </div>
   );

--- a/src/components/dashboard/MonthlyCalendar.tsx
+++ b/src/components/dashboard/MonthlyCalendar.tsx
@@ -41,6 +41,7 @@ import { DayPicker } from "react-day-picker";
 import { ja } from "date-fns/locale";
 import * as JapaneseHolidays from "japanese-holidays";
 import type { DashboardDailyLog, SleepSession } from "@/lib/supabase/types";
+import type { GoogleHealthDailyMetricForDisplay } from "@/lib/googleHealth/displayMetrics";
 import { buildCalendarDayMap, getMobileTrainingLabel, toDateKey, type CalendarDayData, type CalendarDayTagInfo } from "@/lib/utils/calendarUtils";
 import type { DayProps } from "react-day-picker";
 import { toJstDateStr } from "@/lib/utils/date";
@@ -480,16 +481,20 @@ function MobileDayDetailPanel({
 interface MonthlyCalendarProps {
   logs: DashboardDailyLog[];
   sleepSessions?: Pick<SleepSession, "wake_date" | "wake_at" | "bed_at">[];
+  googleHealthMetrics?: GoogleHealthDailyMetricForDisplay[];
 }
 
-export function MonthlyCalendar({ logs, sleepSessions = [] }: MonthlyCalendarProps) {
+export function MonthlyCalendar({ logs, sleepSessions = [], googleHealthMetrics = [] }: MonthlyCalendarProps) {
   const todayKey = toJstDateStr();
   const [y, m]   = todayKey.split("-").map(Number) as [number, number, number];
 
   const [month,       setMonth]       = useState<Date>(new Date(y, m - 1, 1));
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
 
-  const dayMap = useMemo(() => buildCalendarDayMap(logs, sleepSessions), [logs, sleepSessions]);
+  const dayMap = useMemo(
+    () => buildCalendarDayMap(logs, sleepSessions, googleHealthMetrics),
+    [logs, sleepSessions, googleHealthMetrics],
+  );
 
   // 再タップで解除するトグル。sm 以上（デスクトップ）では詳細パネルが非表示のため state 変更しない
   const handleSelectDay = useCallback((key: string) => {

--- a/src/components/dashboard/RecentLogsCards.tsx
+++ b/src/components/dashboard/RecentLogsCards.tsx
@@ -111,11 +111,19 @@ export function RecentLogsCards({ logs, sleepSessions = [], googleHealthMetrics 
                 const googleHealthLine = formatGoogleHealthDailyMetricLine(
                   googleHealthMetricByDate.get(log.log_date),
                 );
-                if (!firstLine && googleHealthLine === "Google Health データなし") return null;
+                if (!firstLine && googleHealthLine === "データなし") return null;
                 return (
                   <div className="mt-0.5 space-y-0.5 text-[10px] leading-snug text-slate-400 dark:text-slate-500">
-                    {firstLine && <div>{firstLine}</div>}
-                    <div>{googleHealthLine}</div>
+                    {firstLine && (
+                      <div className="grid grid-cols-[5.75rem_minmax(0,1fr)] gap-x-1">
+                        <span>日次ログ:</span>
+                        <span>{firstLine}</span>
+                      </div>
+                    )}
+                    <div className="grid grid-cols-[5.75rem_minmax(0,1fr)] gap-x-1">
+                      <span>Google Health:</span>
+                      <span>{googleHealthLine}</span>
+                    </div>
                   </div>
                 );
               })()}

--- a/src/components/dashboard/RecentLogsCards.tsx
+++ b/src/components/dashboard/RecentLogsCards.tsx
@@ -22,22 +22,34 @@ import { formatConditionSummary } from "@/lib/utils/trainingType";
 import { computeWeightDelta, buildRecentLogArrays } from "@/lib/utils/recentLogsUtils";
 import { calcFastingHours } from "@/lib/utils/calendarUtils";
 import { addDaysStr } from "@/lib/utils/date";
+import {
+  buildGoogleHealthDailyMetricMap,
+  formatGoogleHealthDailyMetricLine,
+  type GoogleHealthDailyMetricForDisplay,
+} from "@/lib/googleHealth/displayMetrics";
 
 interface RecentLogsCardsProps {
   logs: DashboardDailyLog[];
   sleepSessions?: Pick<SleepSession, "wake_date" | "wake_at">[];
+  googleHealthMetrics?: GoogleHealthDailyMetricForDisplay[];
   seasonMap?: Map<string, string>;
   currentSeason?: string | null;
 }
 
-export function RecentLogsCards({ logs, sleepSessions = [], seasonMap, currentSeason }: RecentLogsCardsProps) {
+export function RecentLogsCards({ logs, sleepSessions = [], googleHealthMetrics = [], seasonMap, currentSeason }: RecentLogsCardsProps) {
   const { sorted, ascending } = buildRecentLogArrays(logs);
+  const googleHealthMetricByDate = buildGoogleHealthDailyMetricMap(googleHealthMetrics);
   // 断食時間算出用: 日付 → ログ の高速参照テーブル（前日 D-1 の last_meal_end_time を参照するため）
   const logByDate = new Map(ascending.map((l) => [l.log_date, l]));
   // 断食時間算出用: wake_date → wake_at (JST HH:MM) の高速参照テーブル
   const wakeTimeByDate = new Map(
     sleepSessions
       .map((s) => [s.wake_date, extractJstHHMM(s.wake_at)] as [string, string | null])
+      .filter((entry): entry is [string, string] => entry[1] !== null)
+  );
+  const googleHealthWakeTimeByDate = new Map(
+    googleHealthMetrics
+      .map((metric) => [metric.metric_date, metric.sleep_wake_at ? extractJstHHMM(metric.sleep_wake_at) : null] as [string, string | null])
       .filter((entry): entry is [string, string] => entry[1] !== null)
   );
 
@@ -88,18 +100,22 @@ export function RecentLogsCards({ logs, sleepSessions = [], seasonMap, currentSe
               {(() => {
                 const prevDate    = addDaysStr(log.log_date, -1);
                 const prevDayLog  = prevDate ? (logByDate.get(prevDate) ?? null) : null;
-                const wakeUpTime  = wakeTimeByDate.get(log.log_date) ?? null;
+                const wakeUpTime  = googleHealthWakeTimeByDate.get(log.log_date) ?? wakeTimeByDate.get(log.log_date) ?? null;
                 const fastingHours = calcFastingHours(prevDayLog?.last_meal_end_time, wakeUpTime);
-                if (!conditionSummary && log.sleep_hours === null && fastingHours === null) return null;
+                const firstLine = [
+                  conditionSummary,
+                  fastingHours !== null ? `断食${fastingHours % 1 === 0 ? fastingHours.toFixed(0) : fastingHours.toFixed(1)}h` : null,
+                ]
+                  .filter(Boolean)
+                  .join(" / ");
+                const googleHealthLine = formatGoogleHealthDailyMetricLine(
+                  googleHealthMetricByDate.get(log.log_date),
+                );
+                if (!firstLine && googleHealthLine === "Google Health データなし") return null;
                 return (
-                  <div className="mt-0.5 text-[10px] leading-snug text-slate-400 dark:text-slate-500">
-                    {[
-                      conditionSummary,
-                      log.sleep_hours !== null ? `睡眠${log.sleep_hours}h` : null,
-                      fastingHours !== null ? `断食${fastingHours % 1 === 0 ? fastingHours.toFixed(0) : fastingHours.toFixed(1)}h` : null,
-                    ]
-                      .filter(Boolean)
-                      .join(" / ")}
+                  <div className="mt-0.5 space-y-0.5 text-[10px] leading-snug text-slate-400 dark:text-slate-500">
+                    {firstLine && <div>{firstLine}</div>}
+                    <div>{googleHealthLine}</div>
                   </div>
                 );
               })()}

--- a/src/components/dashboard/RecentLogsTable.tsx
+++ b/src/components/dashboard/RecentLogsTable.tsx
@@ -108,11 +108,19 @@ export function RecentLogsTable({ logs, sleepSessions = [], googleHealthMetrics 
                     const googleHealthLine = formatGoogleHealthDailyMetricLine(
                       googleHealthMetricByDate.get(log.log_date),
                     );
-                    if (!firstLine && googleHealthLine === "Google Health データなし") return null;
+                    if (!firstLine && googleHealthLine === "データなし") return null;
                     return (
                       <div className="mt-1 space-y-0.5 text-xs leading-snug text-slate-500 dark:text-slate-400">
-                        {firstLine && <div>{firstLine}</div>}
-                        <div>{googleHealthLine}</div>
+                        {firstLine && (
+                          <div className="grid grid-cols-[5.75rem_minmax(0,1fr)] gap-x-1">
+                            <span>日次ログ:</span>
+                            <span>{firstLine}</span>
+                          </div>
+                        )}
+                        <div className="grid grid-cols-[5.75rem_minmax(0,1fr)] gap-x-1">
+                          <span>Google Health:</span>
+                          <span>{googleHealthLine}</span>
+                        </div>
                       </div>
                     );
                   })()}

--- a/src/components/dashboard/RecentLogsTable.tsx
+++ b/src/components/dashboard/RecentLogsTable.tsx
@@ -8,23 +8,35 @@ import { formatConditionSummary } from "@/lib/utils/trainingType";
 import { computeWeightDelta, buildRecentLogArrays } from "@/lib/utils/recentLogsUtils";
 import { calcFastingHours } from "@/lib/utils/calendarUtils";
 import { addDaysStr } from "@/lib/utils/date";
+import {
+  buildGoogleHealthDailyMetricMap,
+  formatGoogleHealthDailyMetricLine,
+  type GoogleHealthDailyMetricForDisplay,
+} from "@/lib/googleHealth/displayMetrics";
 
 interface RecentLogsTableProps {
   logs: DashboardDailyLog[];
   sleepSessions?: Pick<SleepSession, "wake_date" | "wake_at">[];
+  googleHealthMetrics?: GoogleHealthDailyMetricForDisplay[];
   embedded?: boolean;
   seasonMap?: Map<string, string>;   // log_date → season name
   currentSeason?: string | null;
 }
 
-export function RecentLogsTable({ logs, sleepSessions = [], embedded = false, seasonMap, currentSeason }: RecentLogsTableProps) {
+export function RecentLogsTable({ logs, sleepSessions = [], googleHealthMetrics = [], embedded = false, seasonMap, currentSeason }: RecentLogsTableProps) {
   const { sorted, ascending } = buildRecentLogArrays(logs);
+  const googleHealthMetricByDate = buildGoogleHealthDailyMetricMap(googleHealthMetrics);
   // 断食時間算出用: 日付 → ログ の高速参照テーブル（前日 D-1 の last_meal_end_time を参照するため）
   const logByDate = new Map(ascending.map((l) => [l.log_date, l]));
   // 断食時間算出用: wake_date → wake_at (JST HH:MM) の高速参照テーブル
   const wakeTimeByDate = new Map(
     sleepSessions
       .map((s) => [s.wake_date, extractJstHHMM(s.wake_at)] as [string, string | null])
+      .filter((entry): entry is [string, string] => entry[1] !== null)
+  );
+  const googleHealthWakeTimeByDate = new Map(
+    googleHealthMetrics
+      .map((metric) => [metric.metric_date, metric.sleep_wake_at ? extractJstHHMM(metric.sleep_wake_at) : null] as [string, string | null])
       .filter((entry): entry is [string, string] => entry[1] !== null)
   );
 
@@ -85,18 +97,22 @@ export function RecentLogsTable({ logs, sleepSessions = [], embedded = false, se
                   {(() => {
                     const prevDate    = addDaysStr(log.log_date, -1);
                     const prevDayLog  = prevDate ? (logByDate.get(prevDate) ?? null) : null;
-                    const wakeUpTime  = wakeTimeByDate.get(log.log_date) ?? null;
+                    const wakeUpTime  = googleHealthWakeTimeByDate.get(log.log_date) ?? wakeTimeByDate.get(log.log_date) ?? null;
                     const fastingHours = calcFastingHours(prevDayLog?.last_meal_end_time, wakeUpTime);
-                    if (!conditionSummary && log.sleep_hours === null && fastingHours === null) return null;
+                    const firstLine = [
+                      conditionSummary,
+                      fastingHours !== null ? `断食${fastingHours % 1 === 0 ? fastingHours.toFixed(0) : fastingHours.toFixed(1)}h` : null,
+                    ]
+                      .filter(Boolean)
+                      .join(" / ");
+                    const googleHealthLine = formatGoogleHealthDailyMetricLine(
+                      googleHealthMetricByDate.get(log.log_date),
+                    );
+                    if (!firstLine && googleHealthLine === "Google Health データなし") return null;
                     return (
-                      <div className="mt-1 text-xs leading-snug text-slate-500 dark:text-slate-400">
-                        {[
-                          conditionSummary,
-                          log.sleep_hours !== null ? `睡眠${log.sleep_hours}h` : null,
-                          fastingHours !== null ? `断食${fastingHours % 1 === 0 ? fastingHours.toFixed(0) : fastingHours.toFixed(1)}h` : null,
-                        ]
-                          .filter(Boolean)
-                          .join(" / ")}
+                      <div className="mt-1 space-y-0.5 text-xs leading-snug text-slate-500 dark:text-slate-400">
+                        {firstLine && <div>{firstLine}</div>}
+                        <div>{googleHealthLine}</div>
                       </div>
                     );
                   })()}

--- a/src/lib/googleHealth/displayMetrics.test.ts
+++ b/src/lib/googleHealth/displayMetrics.test.ts
@@ -1,0 +1,53 @@
+import {
+  formatGoogleHealthDailyMetricLine,
+  formatMinutesAsHoursMinutes,
+  metricMinutesToHours,
+  type GoogleHealthDailyMetricForDisplay,
+} from "./displayMetrics";
+
+function makeMetric(
+  overrides: Partial<GoogleHealthDailyMetricForDisplay> = {},
+): GoogleHealthDailyMetricForDisplay {
+  return {
+    metric_date: "2026-06-04",
+    step_count: null,
+    sleep_minutes: null,
+    deep_sleep_minutes: null,
+    sleep_bed_at: null,
+    sleep_wake_at: null,
+    hrv_ms: null,
+    rhr_bpm: null,
+    ...overrides,
+  };
+}
+
+describe("googleHealth displayMetrics", () => {
+  test("minutes を 直近ログ用の h/m 表示に変換する", () => {
+    expect(formatMinutesAsHoursMinutes(450)).toBe("7h30m");
+    expect(formatMinutesAsHoursMinutes(60)).toBe("1h");
+    expect(formatMinutesAsHoursMinutes(45)).toBe("45m");
+    expect(formatMinutesAsHoursMinutes(null)).toBeNull();
+  });
+
+  test("minutes をカレンダー・月次用の時間数に変換する", () => {
+    expect(metricMinutesToHours(336)).toBe(5.6);
+    expect(metricMinutesToHours(null)).toBeNull();
+  });
+
+  test("Google Health の日次表示行を組み立てる", () => {
+    const line = formatGoogleHealthDailyMetricLine(makeMetric({
+      step_count: 12345,
+      sleep_minutes: 450,
+      deep_sleep_minutes: 63,
+      hrv_ms: 128.8,
+      rhr_bpm: 43,
+    }));
+
+    expect(line).toBe("Google Health  歩数 12,345歩 / 睡眠 7h30m / 深睡眠 1h03m / HRV 128.8ms / 安静時 43bpm");
+  });
+
+  test("値がない場合は 0 ではなくデータなし表示にする", () => {
+    expect(formatGoogleHealthDailyMetricLine(makeMetric())).toBe("Google Health データなし");
+    expect(formatGoogleHealthDailyMetricLine(null)).toBe("Google Health データなし");
+  });
+});

--- a/src/lib/googleHealth/displayMetrics.test.ts
+++ b/src/lib/googleHealth/displayMetrics.test.ts
@@ -43,11 +43,11 @@ describe("googleHealth displayMetrics", () => {
       rhr_bpm: 43,
     }));
 
-    expect(line).toBe("Google Health  歩数 12,345歩 / 睡眠 7h30m / 深睡眠 1h03m / HRV 128.8ms / 安静時 43bpm");
+    expect(line).toBe("歩数 12,345歩 / 睡眠 7h30m / 深睡眠 1h03m / HRV 128.8ms / 安静時 43bpm");
   });
 
   test("値がない場合は 0 ではなくデータなし表示にする", () => {
-    expect(formatGoogleHealthDailyMetricLine(makeMetric())).toBe("Google Health データなし");
-    expect(formatGoogleHealthDailyMetricLine(null)).toBe("Google Health データなし");
+    expect(formatGoogleHealthDailyMetricLine(makeMetric())).toBe("データなし");
+    expect(formatGoogleHealthDailyMetricLine(null)).toBe("データなし");
   });
 });

--- a/src/lib/googleHealth/displayMetrics.ts
+++ b/src/lib/googleHealth/displayMetrics.ts
@@ -1,0 +1,56 @@
+import type { GoogleHealthDailyMetricRow } from "@/lib/supabase/types";
+
+export type GoogleHealthDailyMetricForDisplay = Pick<
+  GoogleHealthDailyMetricRow,
+  | "metric_date"
+  | "step_count"
+  | "sleep_minutes"
+  | "deep_sleep_minutes"
+  | "sleep_bed_at"
+  | "sleep_wake_at"
+  | "hrv_ms"
+  | "rhr_bpm"
+>;
+
+export function buildGoogleHealthDailyMetricMap(
+  metrics: GoogleHealthDailyMetricForDisplay[],
+): Map<string, GoogleHealthDailyMetricForDisplay> {
+  return new Map(metrics.map((metric) => [metric.metric_date, metric]));
+}
+
+export function metricMinutesToHours(minutes: number | null | undefined): number | null {
+  if (minutes === null || minutes === undefined) return null;
+  return Math.round((minutes / 60) * 10) / 10;
+}
+
+export function formatMinutesAsHoursMinutes(minutes: number | null | undefined): string | null {
+  if (minutes === null || minutes === undefined) return null;
+  const hours = Math.floor(minutes / 60);
+  const restMinutes = minutes % 60;
+  if (hours <= 0) return `${restMinutes}m`;
+  if (restMinutes === 0) return `${hours}h`;
+  return `${hours}h${String(restMinutes).padStart(2, "0")}m`;
+}
+
+export function formatCompactNumber(value: number): string {
+  const rounded = Math.round(value * 10) / 10;
+  return Number.isInteger(rounded) ? rounded.toFixed(0) : rounded.toFixed(1);
+}
+
+export function formatGoogleHealthDailyMetricLine(
+  metric: GoogleHealthDailyMetricForDisplay | null | undefined,
+): string {
+  if (!metric) return "Google Health データなし";
+
+  const parts = [
+    metric.step_count !== null ? `歩数 ${metric.step_count.toLocaleString()}歩` : null,
+    metric.sleep_minutes !== null ? `睡眠 ${formatMinutesAsHoursMinutes(metric.sleep_minutes)}` : null,
+    metric.deep_sleep_minutes !== null ? `深睡眠 ${formatMinutesAsHoursMinutes(metric.deep_sleep_minutes)}` : null,
+    metric.hrv_ms !== null ? `HRV ${formatCompactNumber(metric.hrv_ms)}ms` : null,
+    metric.rhr_bpm !== null ? `安静時 ${formatCompactNumber(metric.rhr_bpm)}bpm` : null,
+  ].filter((part): part is string => part !== null);
+
+  return parts.length > 0
+    ? `Google Health  ${parts.join(" / ")}`
+    : "Google Health データなし";
+}

--- a/src/lib/googleHealth/displayMetrics.ts
+++ b/src/lib/googleHealth/displayMetrics.ts
@@ -40,7 +40,7 @@ export function formatCompactNumber(value: number): string {
 export function formatGoogleHealthDailyMetricLine(
   metric: GoogleHealthDailyMetricForDisplay | null | undefined,
 ): string {
-  if (!metric) return "Google Health データなし";
+  if (!metric) return "データなし";
 
   const parts = [
     metric.step_count !== null ? `歩数 ${metric.step_count.toLocaleString()}歩` : null,
@@ -50,7 +50,5 @@ export function formatGoogleHealthDailyMetricLine(
     metric.rhr_bpm !== null ? `安静時 ${formatCompactNumber(metric.rhr_bpm)}bpm` : null,
   ].filter((part): part is string => part !== null);
 
-  return parts.length > 0
-    ? `Google Health  ${parts.join(" / ")}`
-    : "Google Health データなし";
+  return parts.length > 0 ? parts.join(" / ") : "データなし";
 }

--- a/src/lib/queries/googleHealthDailyMetrics.ts
+++ b/src/lib/queries/googleHealthDailyMetrics.ts
@@ -1,0 +1,31 @@
+import { createClient } from "@/lib/supabase/server";
+import type { GoogleHealthDailyMetricForDisplay } from "@/lib/googleHealth/displayMetrics";
+import type { QueryResult } from "./queryResult";
+
+const GOOGLE_HEALTH_DAILY_METRIC_COLUMNS =
+  "metric_date, step_count, sleep_minutes, deep_sleep_minutes, sleep_bed_at, sleep_wake_at, hrv_ms, rhr_bpm";
+
+export async function fetchGoogleHealthDailyMetricsForRange(
+  startDate: string,
+  endDate: string,
+): Promise<QueryResult<GoogleHealthDailyMetricForDisplay[]>> {
+  if (startDate > endDate) return { kind: "ok", data: [] };
+
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("google_health_daily_metrics")
+    .select(GOOGLE_HEALTH_DAILY_METRIC_COLUMNS)
+    .gte("metric_date", startDate)
+    .lte("metric_date", endDate)
+    .order("metric_date", { ascending: true });
+
+  if (error) {
+    console.error("[fetchGoogleHealthDailyMetricsForRange] google_health_daily_metrics fetch error:", error.message, { code: error.code });
+    return { kind: "error", message: error.message };
+  }
+
+  return {
+    kind: "ok",
+    data: (data as unknown as GoogleHealthDailyMetricForDisplay[]) ?? [],
+  };
+}

--- a/src/lib/utils/__tests__/calcMonthlyBehaviorStats.test.ts
+++ b/src/lib/utils/__tests__/calcMonthlyBehaviorStats.test.ts
@@ -4,6 +4,7 @@ import {
   sortedWorkModeEntries,
 } from "../calcMonthlyBehaviorStats";
 import type { DashboardDailyLog } from "@/lib/supabase/types";
+import type { GoogleHealthDailyMetricForDisplay } from "@/lib/googleHealth/displayMetrics";
 
 /** テスト用に最低限のフィールドを持つ DashboardDailyLog を生成するヘルパー */
 function makeLog(
@@ -369,6 +370,46 @@ describe("calcMonthlyBehaviorStats — sleepStats", () => {
     expect(stats!.avgSleepHours).toBe(7.5);
     expect(stats!.medianBedTime).toBe("23:30");
     expect(stats!.medianWakeTime).toBe("07:00");
+  });
+
+  test("Google Health metrics を渡した場合は睡眠集計と心肺機能を Google Health 由来で計算する", () => {
+    const logs = [
+      makeLog("2026-06-03", { work_mode: "office" }),
+      makeLog("2026-06-04", { work_mode: "remote" }),
+    ];
+    const googleHealthMetrics: GoogleHealthDailyMetricForDisplay[] = [
+      {
+        metric_date: "2026-06-03",
+        step_count: 972,
+        sleep_minutes: 300,
+        deep_sleep_minutes: 54,
+        sleep_bed_at: "2026-06-02T15:34:00Z",
+        sleep_wake_at: "2026-06-02T20:29:00Z",
+        hrv_ms: 125.8,
+        rhr_bpm: 43,
+      },
+      {
+        metric_date: "2026-06-04",
+        step_count: 5126,
+        sleep_minutes: 336,
+        deep_sleep_minutes: 63,
+        sleep_bed_at: "2026-06-03T15:02:00Z",
+        sleep_wake_at: "2026-06-03T20:38:00Z",
+        hrv_ms: 128.8,
+        rhr_bpm: 45,
+      },
+    ];
+
+    const result = calcMonthlyBehaviorStats(logs, 0, [], googleHealthMetrics);
+    const stats = result[0]!;
+
+    expect(stats.sleepStats?.avgSleepHours).toBe(5.3);
+    expect(stats.sleepStats?.avgByWorkMode.office).toBe(5);
+    expect(stats.sleepStats?.avgByWorkMode.remote).toBe(5.6);
+    expect(stats.cardioStats).toEqual({
+      avgHrvMs: 127.3,
+      avgRhrBpm: 44,
+    });
   });
 });
 

--- a/src/lib/utils/calcMonthlyBehaviorStats.ts
+++ b/src/lib/utils/calcMonthlyBehaviorStats.ts
@@ -6,17 +6,21 @@
  *   - トレーニング部位別日数 (training_type の有効値ごと)
  *   - 仕事モード別日数 (work_mode の有効値ごと)
  *   - 特殊日フラグ別日数 (is_cheat_day / is_refeed_day / is_eating_out / is_travel_day)
- *   - 睡眠リズム (sleepStats: calcMonthlySleepStats の結果, #581)
+ *   - 睡眠リズム (sleepStats: calcMonthlySleepStats の結果, #581 / Google Health 対応 #688)
+ *   - 心肺機能 (Google Health 由来の HRV / 安静時心拍数の月平均)
  *
  * null 扱いの方針 (既存仕様に準拠):
  *   - had_bowel_movement: null = 未記録 → 集計対象外。true のみ日数としてカウント。false は「便通なし」だがカウントしない
  *   - training_type: null = 未記録 → 集計対象外。"off" は「オフ日」として有効値かつカウント対象
  *   - work_mode: null = 未記録 → 集計対象外。"off" は「休日」として有効値かつカウント対象
  *   - 特殊日フラグ: true のみ日数としてカウント。false / null は集計対象外
- *   - 睡眠: sleep_sessions が存在する日のみ集計。勤務形態未記録日は勤務形態別集計から除外
+ *   - 睡眠: Google Health metrics が渡された場合は sleep_minutes / sleep_bed_at / sleep_wake_at を優先。
+ *           未指定時は後方互換として sleep_sessions を使う。勤務形態未記録日は勤務形態別集計から除外
+ *   - 心肺機能: null を除外し、0 補完しない
  */
 
 import type { DashboardDailyLog } from "@/lib/supabase/types";
+import type { GoogleHealthDailyMetricForDisplay } from "@/lib/googleHealth/displayMetrics";
 import {
   isValidTrainingType,
   isValidWorkMode,
@@ -28,6 +32,13 @@ import { calcMonthlySleepStats } from "./calcMonthlySleepStats";
 import type { MonthlySleepStats } from "./calcMonthlySleepStats";
 
 export type { MonthlySleepStats };
+
+export interface MonthlyCardioStats {
+  /** HRV の月平均 (ms)。有効値なしなら null */
+  avgHrvMs: number | null;
+  /** 安静時心拍数の月平均 (bpm)。有効値なしなら null */
+  avgRhrBpm: number | null;
+}
 
 type SleepSessionInput = {
   wake_date: string;
@@ -60,9 +71,14 @@ export interface MonthlyBehaviorStats {
   };
   /**
    * 睡眠リズム集計 (#581)。
-   * sleepSessions が渡されなかった場合 / 対象月にセッションがない場合は null。
+   * Google Health metrics / sleepSessions が渡されなかった場合、または対象月に有効値がない場合は null。
    */
   sleepStats: MonthlySleepStats | null;
+  /**
+   * 心肺機能集計 (#688)。
+   * Google Health metrics が渡されなかった場合 / 対象月に有効値がない場合は null。
+   */
+  cardioStats: MonthlyCardioStats | null;
 }
 
 /**
@@ -71,12 +87,14 @@ export interface MonthlyBehaviorStats {
  * @param logs          - DashboardDailyLog の配列（全期間）
  * @param months        - 最新から何ヶ月分を返すか。0 以下なら全月を返す (デフォルト: 0)
  * @param sleepSessions - sleep_sessions の配列（省略時は睡眠集計なし）
+ * @param googleHealthMetrics - Google Health 日次メトリクス（指定時は睡眠集計の参照元として優先）
  * @returns 月ごとの集計結果。新しい月から順（降順）に並ぶ
  */
 export function calcMonthlyBehaviorStats(
   logs: DashboardDailyLog[],
   months = 0,
   sleepSessions: SleepSessionInput[] = [],
+  googleHealthMetrics?: GoogleHealthDailyMetricForDisplay[],
 ): MonthlyBehaviorStats[] {
   // month → ログ配列 に振り分ける
   const map = new Map<string, DashboardDailyLog[]>();
@@ -131,15 +149,44 @@ export function calcMonthlyBehaviorStats(
     const workModeByDate = new Map<string, string | null>(
       dayLogs.map((l) => [l.log_date, l.work_mode]),
     );
-    const monthSessions = sleepSessions.filter(
-      (s) => s.wake_date.slice(0, 7) === month,
-    );
+    const monthGoogleHealthMetrics = googleHealthMetrics?.filter(
+      (metric) => metric.metric_date.slice(0, 7) === month,
+    ) ?? [];
+    const sleepInputs = googleHealthMetrics
+      ? monthGoogleHealthMetrics.map((metric) => ({
+          wake_date:      metric.metric_date,
+          bed_at:         metric.sleep_bed_at,
+          wake_at:        metric.sleep_wake_at,
+          sleep_minutes:  metric.sleep_minutes,
+        }))
+      : sleepSessions.filter((s) => s.wake_date.slice(0, 7) === month);
+    const rawSleepStats =
+      sleepInputs.length > 0
+        ? calcMonthlySleepStats(sleepInputs, workModeByDate)
+        : null;
     const sleepStats =
-      monthSessions.length > 0
-        ? calcMonthlySleepStats(monthSessions, workModeByDate)
+      rawSleepStats &&
+      (
+        rawSleepStats.avgSleepHours !== null ||
+        rawSleepStats.medianBedTime !== null ||
+        rawSleepStats.medianWakeTime !== null
+      )
+        ? rawSleepStats
         : null;
 
-    return { month, bowelDays, trainingCounts, workModeCounts, flagCounts, sleepStats };
+    const avg = (values: Array<number | null>): number | null => {
+      const valid = values.filter((value): value is number => value !== null);
+      if (valid.length === 0) return null;
+      return Math.round((valid.reduce((sum, value) => sum + value, 0) / valid.length) * 10) / 10;
+    };
+    const avgHrvMs = avg(monthGoogleHealthMetrics.map((metric) => metric.hrv_ms));
+    const avgRhrBpm = avg(monthGoogleHealthMetrics.map((metric) => metric.rhr_bpm));
+    const cardioStats =
+      avgHrvMs !== null || avgRhrBpm !== null
+        ? { avgHrvMs, avgRhrBpm }
+        : null;
+
+    return { month, bowelDays, trainingCounts, workModeCounts, flagCounts, sleepStats, cardioStats };
   });
 }
 

--- a/src/lib/utils/calcMonthlySleepStats.ts
+++ b/src/lib/utils/calcMonthlySleepStats.ts
@@ -1,10 +1,11 @@
 /**
  * calcMonthlySleepStats — 月別睡眠リズム集計
  *
- * sleep_sessions を source of truth として月別の睡眠集計を計算する純粋関数。
+ * sleep_sessions または Google Health 由来の睡眠入力から月別の睡眠集計を計算する純粋関数。
  *
  * ## 集計仕様
- *   - 睡眠時間  : wake_date 基準で月内の全セッションの平均 (小数点以下1桁)
+ *   - 睡眠時間  : wake_date 基準で月内の全睡眠入力の平均 (小数点以下1桁)
+ *                 sleep_minutes が渡された場合はそれを優先し、なければ bed_at / wake_at から算出する
  *   - 就寝・起床: 同月の中央値 ("HH:MM" JST)
  *   - 勤務形態別: work_mode が記録されているセッションのみを対象に平均を計算
  *
@@ -89,8 +90,9 @@ export function medianOf(values: number[]): number | null {
 
 type SleepSessionInput = {
   wake_date: string;
-  bed_at: string;   // TIMESTAMPTZ
-  wake_at: string;  // TIMESTAMPTZ
+  bed_at: string | null;   // TIMESTAMPTZ
+  wake_at: string | null;  // TIMESTAMPTZ
+  sleep_minutes?: number | null;
 };
 
 /**
@@ -104,21 +106,24 @@ export function calcMonthlySleepStats(
   workModeByDate: Map<string, string | null>,
 ): MonthlySleepStats {
   type SleepEntry = {
-    sleepHours: number;
-    bedTime: string;
-    wakeTime: string;
+    sleepHours: number | null;
+    bedTime: string | null;
+    wakeTime: string | null;
     workMode: string | null;
   };
 
   const entries: SleepEntry[] = [];
 
   for (const s of sessions) {
-    const bedTime  = extractJstHHMM(s.bed_at);
-    const wakeTime = extractJstHHMM(s.wake_at);
-    if (!bedTime || !wakeTime) continue;
-
-    const sleepHours = deriveSleepHours(bedTime, wakeTime);
-    if (sleepHours === null) continue;
+    const bedTime  = s.bed_at ? extractJstHHMM(s.bed_at) : null;
+    const wakeTime = s.wake_at ? extractJstHHMM(s.wake_at) : null;
+    const sleepHoursFromMinutes =
+      s.sleep_minutes !== null && s.sleep_minutes !== undefined
+        ? Math.round((s.sleep_minutes / 60) * 10) / 10
+        : null;
+    const sleepHoursFromTime = bedTime && wakeTime ? deriveSleepHours(bedTime, wakeTime) : null;
+    const sleepHours = sleepHoursFromMinutes ?? sleepHoursFromTime;
+    if (sleepHours === null && bedTime === null && wakeTime === null) continue;
 
     entries.push({
       sleepHours,
@@ -137,9 +142,15 @@ export function calcMonthlySleepStats(
     };
   }
 
+  const sleepHourValues = entries
+    .map((e) => e.sleepHours)
+    .filter((v): v is number => v !== null);
+
   // 全体平均睡眠時間
-  const sumHours = entries.reduce((acc, e) => acc + e.sleepHours, 0);
-  const avgSleepHours = Math.round((sumHours / entries.length) * 10) / 10;
+  const avgSleepHours =
+    sleepHourValues.length > 0
+      ? Math.round((sleepHourValues.reduce((acc, value) => acc + value, 0) / sleepHourValues.length) * 10) / 10
+      : null;
 
   // 勤務形態別平均睡眠時間 (office / remote / off のみ)
   const groups: Record<"office" | "remote" | "off", number[]> = {
@@ -148,6 +159,7 @@ export function calcMonthlySleepStats(
     off:    [],
   };
   for (const e of entries) {
+    if (e.sleepHours === null) continue;
     if (e.workMode === "office") groups.office.push(e.sleepHours);
     else if (e.workMode === "remote") groups.remote.push(e.sleepHours);
     else if (e.workMode === "off")    groups.off.push(e.sleepHours);
@@ -165,14 +177,14 @@ export function calcMonthlySleepStats(
 
   // 就寝時刻の中央値 (日跨ぎ補正あり)
   const bedMins = entries
-    .map((e) => bedTimeToMinutes(e.bedTime))
+    .map((e) => e.bedTime ? bedTimeToMinutes(e.bedTime) : null)
     .filter((v): v is number => v !== null);
   const medBed = medianOf(bedMins);
   const medianBedTime = medBed !== null ? minutesToHHMM(medBed) : null;
 
   // 起床時刻の中央値
   const wakeMins = entries
-    .map((e) => wakeTimeToMinutes(e.wakeTime))
+    .map((e) => e.wakeTime ? wakeTimeToMinutes(e.wakeTime) : null)
     .filter((v): v is number => v !== null);
   const medWake = medianOf(wakeMins);
   const medianWakeTime = medWake !== null ? minutesToHHMM(medWake) : null;

--- a/src/lib/utils/calendarUtils.test.ts
+++ b/src/lib/utils/calendarUtils.test.ts
@@ -6,6 +6,7 @@
 
 import { buildCalendarDayMap, buildConditionTags, getMobileTrainingLabel, toDateKey, calcFastingHours } from "./calendarUtils";
 import type { DailyLog } from "@/lib/supabase/types";
+import type { GoogleHealthDailyMetricForDisplay } from "@/lib/googleHealth/displayMetrics";
 
 // ── テストデータ工場 ─────────────────────────────────────────────────────────
 
@@ -43,6 +44,38 @@ describe("buildCalendarDayMap", () => {
   it("ログがない場合は空 Map を返す", () => {
     const result = buildCalendarDayMap([]);
     expect(result.size).toBe(0);
+  });
+
+  it("Google Health metrics が渡された場合は就寝・起床・睡眠を Google Health 由来にする", () => {
+    const logs = [
+      makeLog({ log_date: "2026-06-04", weight: 63.8, sleep_hours: 9.9 }),
+    ];
+    const sleepSessions = [
+      {
+        wake_date: "2026-06-04",
+        bed_at: "2026-06-03T13:00:00+00:00",
+        wake_at: "2026-06-03T22:00:00+00:00",
+      },
+    ];
+    const googleHealthMetrics: GoogleHealthDailyMetricForDisplay[] = [
+      {
+        metric_date: "2026-06-04",
+        step_count: 5126,
+        sleep_minutes: 336,
+        deep_sleep_minutes: 63,
+        sleep_bed_at: "2026-06-03T15:02:00Z",
+        sleep_wake_at: "2026-06-03T20:38:00Z",
+        hrv_ms: 128.8,
+        rhr_bpm: 43,
+      },
+    ];
+
+    const map = buildCalendarDayMap(logs, sleepSessions, googleHealthMetrics);
+    const data = map.get("2026-06-04")!;
+
+    expect(data.sleep_hours).toBe(5.6);
+    expect(data.bed_at).toBe("2026-06-03T15:02:00Z");
+    expect(data.wake_at).toBe("2026-06-03T20:38:00Z");
   });
 
   it("ログ日が Map のキーになる", () => {

--- a/src/lib/utils/calendarUtils.ts
+++ b/src/lib/utils/calendarUtils.ts
@@ -12,6 +12,8 @@
 
 import type { DashboardDailyLog } from "@/lib/supabase/types";
 import type { SleepSession } from "@/lib/supabase/types";
+import type { GoogleHealthDailyMetricForDisplay } from "@/lib/googleHealth/displayMetrics";
+import { metricMinutesToHours } from "@/lib/googleHealth/displayMetrics";
 import { DAY_TAGS, DAY_TAG_LABELS, DAY_TAG_BADGE_COLORS } from "./dayTags";
 import { formatConditionSummary, isValidTrainingType, isValidWorkMode, TRAINING_TYPE_LABELS, WORK_MODE_LABELS } from "./trainingType";
 import { addDaysStr } from "./date";
@@ -55,8 +57,8 @@ export interface CalendarDayData {
   fasting_hours: number | null;
   /**
    * 日次の睡眠時間（時間単位）。
-   * source of truth: daily_logs.sleep_hours
-   * (sleep_sessions の bed_at / wake_at から DB トリガー trg_sync_sleep_hours が自動同期する projection 値)
+   * Google Health metrics が渡された場合は google_health_daily_metrics.sleep_minutes 由来。
+   * 未指定時は後方互換として daily_logs.sleep_hours 由来。
    * null = 睡眠記録なし。
    */
   sleep_hours: number | null;
@@ -194,8 +196,10 @@ export function getMobileTrainingLabel(
 export function buildCalendarDayMap(
   logs: DashboardDailyLog[],
   sleepSessions: Pick<SleepSession, "wake_date" | "wake_at" | "bed_at">[] = [],
+  googleHealthMetrics?: GoogleHealthDailyMetricForDisplay[],
 ): Map<string, CalendarDayData> {
   const sorted = [...logs].sort((a, b) => a.log_date.localeCompare(b.log_date));
+  const useGoogleHealthSleep = googleHealthMetrics !== undefined;
 
   // 体重・カロリーそれぞれの「記録ありログ」リスト（差分計算用）
   const withWeight = sorted.filter((d) => d.weight !== null);
@@ -207,6 +211,9 @@ export function buildCalendarDayMap(
   // wake_date → wake_at (ISO 8601) の高速参照テーブル（断食時間算出・UI 表示共用）
   const sessionByDate = new Map(
     sleepSessions.map((s) => [s.wake_date, s])
+  );
+  const googleHealthMetricByDate = new Map(
+    (googleHealthMetrics ?? []).map((metric) => [metric.metric_date, metric])
   );
 
   const map = new Map<string, CalendarDayData>();
@@ -258,14 +265,25 @@ export function buildCalendarDayMap(
     const prevDateKey = addDaysStr(log.log_date, -1);
     const prevDayLog  = prevDateKey ? (logByDate.get(prevDateKey) ?? null) : null;
     const session     = sessionByDate.get(log.log_date) ?? null;
-    const wakeUpTime  = session ? extractJstHHMM(session.wake_at) : null;
+    const googleHealthMetric = googleHealthMetricByDate.get(log.log_date) ?? null;
+    const bedAt = useGoogleHealthSleep
+      ? googleHealthMetric?.sleep_bed_at ?? null
+      : session?.bed_at ?? null;
+    const wakeAt = useGoogleHealthSleep
+      ? googleHealthMetric?.sleep_wake_at ?? null
+      : session?.wake_at ?? null;
+    const sleepHours = useGoogleHealthSleep
+      ? metricMinutesToHours(googleHealthMetric?.sleep_minutes)
+      : log.sleep_hours;
+    const wakeAtForFasting = wakeAt ?? session?.wake_at ?? null;
+    const wakeUpTime = wakeAtForFasting ? extractJstHHMM(wakeAtForFasting) : null;
     const fasting_hours = calcFastingHours(prevDayLog?.last_meal_end_time, wakeUpTime);
 
     map.set(log.log_date, {
       log, weightDelta, calDelta, dayTags, conditionSummary, conditionTags, fasting_hours,
-      sleep_hours: log.sleep_hours,
-      bed_at:  session?.bed_at  ?? null,
-      wake_at: session?.wake_at ?? null,
+      sleep_hours: sleepHours,
+      bed_at:  bedAt,
+      wake_at: wakeAt,
     });
   }
 


### PR DESCRIPTION
## 概要
- ホーム画面の直近ログに Google Health 由来の日次メトリクス行を追加しました。
- カレンダーの就寝・起床・睡眠表示を Google Health 由来の値に差し替えました。
- 月別タブの生活リズムを Google Health 由来で集計し、心肺機能列を追加しました。

## 変更内容
- `google_health_daily_metrics` の表示用 query と formatter を追加。
- 直近ログの補足行を2行構成に変更し、1行目から既存睡眠表示を除外。
- カレンダー表示では `sleep_bed_at` / `sleep_wake_at` / `sleep_minutes` を使用。
- 月別行動・生活サマリーで `sleep_minutes`、`sleep_bed_at`、`sleep_wake_at` を使って生活リズムを算出。
- 月別行動・生活サマリーに HRV / 安静時心拍数の月平均を表示する「心肺機能」列を追加。

## 判断理由
- 既存の保存・同期処理には触れず、画面表示と集計入力の差し替えにスコープを限定しました。
- `daily_logs.sleep_hours` や `sleep_sessions` の削除は別論点として残し、#688 では表示参照元の変更に留めています。

## 検証結果
- `npm test -- --runTestsByPath src/lib/googleHealth/displayMetrics.test.ts src/lib/utils/calendarUtils.test.ts src/lib/utils/__tests__/calcMonthlyBehaviorStats.test.ts`
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- `npm test -- --runInBand`

Closes #688