### PR TITLE
Google Health同期のエラー処理と運用ログを整理する

### DIFF
--- a/src/app/api/google-health/daily-metrics/route.test.ts
+++ b/src/app/api/google-health/daily-metrics/route.test.ts
@@ -9,6 +9,7 @@ jest.mock("@/lib/googleHealth/dailyMetrics", () => ({
 }));
 
 jest.mock("@/lib/googleHealth/connections", () => ({
+  markGoogleHealthConnectionError: jest.fn(),
   markGoogleHealthConnectionSynced: jest.fn(),
   resolveGoogleHealthStoredAccessToken: jest.fn(),
 }));
@@ -24,6 +25,7 @@ jest.mock("@/lib/cache/revalidate", () => ({
 import { NextRequest } from "next/server";
 import { revalidateAfterDailyLogMutation } from "@/lib/cache/revalidate";
 import {
+  markGoogleHealthConnectionError,
   markGoogleHealthConnectionSynced,
   resolveGoogleHealthStoredAccessToken,
 } from "@/lib/googleHealth/connections";
@@ -35,6 +37,7 @@ import { POST } from "./route";
 const mockCreateClient = createClient as jest.Mock;
 const mockGetCurrentUser = getCurrentUser as jest.Mock;
 const mockResolveStoredAccessToken = resolveGoogleHealthStoredAccessToken as jest.Mock;
+const mockMarkConnectionError = markGoogleHealthConnectionError as jest.Mock;
 const mockMarkConnectionSynced = markGoogleHealthConnectionSynced as jest.Mock;
 const mockFetchGoogleHealthDailyMetrics = fetchGoogleHealthDailyMetrics as jest.Mock;
 const mockSaveGoogleHealthDailyMetrics = saveGoogleHealthDailyMetrics as jest.Mock;
@@ -61,14 +64,28 @@ function makeRequest(args?: {
 }
 
 describe("POST /api/google-health/daily-metrics", () => {
+  let consoleInfoSpy: jest.SpyInstance;
+  let consoleWarnSpy: jest.SpyInstance;
+  let consoleErrorSpy: jest.SpyInstance;
+
   beforeEach(() => {
     mockCreateClient.mockReset();
     mockGetCurrentUser.mockReset();
     mockResolveStoredAccessToken.mockReset();
+    mockMarkConnectionError.mockReset();
     mockMarkConnectionSynced.mockReset();
     mockFetchGoogleHealthDailyMetrics.mockReset();
     mockSaveGoogleHealthDailyMetrics.mockReset();
     mockRevalidate.mockReset();
+    consoleInfoSpy = jest.spyOn(console, "info").mockImplementation(() => {});
+    consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleInfoSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
   });
 
   it("未認証の場合は 401 を返す", async () => {
@@ -157,7 +174,11 @@ describe("POST /api/google-health/daily-metrics", () => {
         { ok: true, key: "heartRateVariability", dataPoints: [] },
         { ok: true, key: "restingHeartRate", dataPoints: [] },
       ],
-      stepsResult: { ok: true, source: "reconcile" },
+      stepsResult: {
+        ok: true,
+        source: "reconcile",
+        attempts: [{ source: "reconcile", ok: true, status: 200 }],
+      },
       dailyMetrics,
     });
     mockSaveGoogleHealthDailyMetrics.mockResolvedValue({
@@ -199,11 +220,93 @@ describe("POST /api/google-health/daily-metrics", () => {
         endExclusiveDate: "2026-06-03",
       },
       stepsSource: "reconcile",
+      stepsFallbackUsed: false,
+      stepsAttempts: [{ source: "reconcile", ok: true, status: 200 }],
+      emptyMetricCount: 0,
       savedCount: 1,
       skippedCount: 0,
       savedDates: ["2026-06-02"],
       skippedDates: [],
     });
+  });
+
+  it("歩数取得がfallbackされた場合は採用sourceと試行履歴を返す", async () => {
+    const supabase = { from: jest.fn() };
+    const dailyMetrics = [
+      {
+        date: "2026-06-02",
+        stepCount: null,
+        sleepMinutes: null,
+        deepSleepMinutes: null,
+        sleepBedAt: null,
+        sleepWakeAt: null,
+        hrvMs: null,
+        rhrBpm: null,
+      },
+    ];
+    const stepsAttempts = [
+      {
+        source: "reconcile",
+        ok: false,
+        status: 500,
+        message: "reconcile is temporarily unavailable",
+      },
+      {
+        source: "dailyRollUp",
+        ok: true,
+        status: 200,
+      },
+    ];
+
+    mockGetCurrentUser.mockResolvedValue({ id: "user-id" });
+    mockResolveStoredAccessToken.mockResolvedValue({
+      ok: true,
+      accessToken: "stored-google-token",
+      refreshed: false,
+      status: "connected",
+    });
+    mockCreateClient.mockResolvedValue(supabase);
+    mockFetchGoogleHealthDailyMetrics.mockResolvedValue({
+      sourceResults: [
+        { ok: true, key: "sleep", dataPoints: [] },
+        { ok: true, key: "heartRateVariability", dataPoints: [] },
+        { ok: true, key: "restingHeartRate", dataPoints: [] },
+      ],
+      stepsResult: {
+        ok: true,
+        source: "dailyRollUp",
+        attempts: stepsAttempts,
+      },
+      dailyMetrics,
+    });
+    mockSaveGoogleHealthDailyMetrics.mockResolvedValue({
+      ok: true,
+      savedCount: 1,
+      skippedCount: 0,
+      savedDates: ["2026-06-02"],
+      skippedDates: [],
+    });
+    mockMarkConnectionSynced.mockResolvedValue(undefined);
+
+    const response = await POST(makeRequest({
+      start: "2026-06-02",
+      end: "2026-06-02",
+    }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(consoleInfoSpy).toHaveBeenCalledWith("[google-health-sync]", expect.objectContaining({
+      event: "steps_fallback_used",
+      stepsSource: "dailyRollUp",
+      stepsAttempts,
+    }));
+    expect(body).toEqual(expect.objectContaining({
+      ok: true,
+      stepsSource: "dailyRollUp",
+      stepsFallbackUsed: true,
+      stepsAttempts,
+      emptyMetricCount: 1,
+    }));
   });
 
   it("歩数取得が失敗した場合は保存しない", async () => {
@@ -222,6 +325,14 @@ describe("POST /api/google-health/daily-metrics", () => {
         source: "reconcile",
         status: 403,
         message: "Required OAuth scope(s) are missing for this operation.",
+        attempts: [
+          {
+            source: "reconcile",
+            ok: false,
+            status: 403,
+            message: "Required OAuth scope(s) are missing for this operation.",
+          },
+        ],
       },
       dailyMetrics: [],
     });
@@ -233,15 +344,132 @@ describe("POST /api/google-health/daily-metrics", () => {
     const body = await response.json();
 
     expect(response.status).toBe(403);
+    expect(mockMarkConnectionError).toHaveBeenCalledWith({
+      userId: "user-id",
+      code: "google_health_steps_api_forbidden",
+      message: "Required OAuth scope(s) are missing for this operation.",
+    });
+    expect(body.code).toBe("google_health_steps_api_forbidden");
     expect(body.stepsResult).toEqual({
       dataType: "steps",
       source: "reconcile",
       status: 403,
       message: "Required OAuth scope(s) are missing for this operation.",
+      attempts: [
+        {
+          source: "reconcile",
+          ok: false,
+          status: 403,
+          message: "Required OAuth scope(s) are missing for this operation.",
+        },
+      ],
     });
     expect(JSON.stringify(body)).not.toContain("details");
     expect(mockCreateClient).not.toHaveBeenCalled();
     expect(mockSaveGoogleHealthDailyMetrics).not.toHaveBeenCalled();
+    expect(mockRevalidate).not.toHaveBeenCalled();
+  });
+
+  it("必須sourceの取得に失敗した場合はconnection errorを更新して保存しない", async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: "user-id" });
+    mockResolveStoredAccessToken.mockResolvedValue({
+      ok: true,
+      accessToken: "stored-google-token",
+      refreshed: false,
+      status: "connected",
+    });
+    mockFetchGoogleHealthDailyMetrics.mockResolvedValue({
+      sourceResults: [
+        {
+          ok: false,
+          key: "sleep",
+          status: 403,
+          message: "Required OAuth scope(s) are missing for this operation.",
+        },
+      ],
+      stepsResult: {
+        ok: true,
+        source: "reconcile",
+        attempts: [{ source: "reconcile", ok: true, status: 200 }],
+      },
+      dailyMetrics: [],
+    });
+
+    const response = await POST(makeRequest({
+      start: "2026-06-02",
+      end: "2026-06-02",
+    }));
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(mockMarkConnectionError).toHaveBeenCalledWith({
+      userId: "user-id",
+      code: "google_health_required_sources_api_forbidden",
+      message: "sleep:403",
+    });
+    expect(body).toEqual({
+      error: "Google Health 日次メトリクスの取得に失敗しました。",
+      status: "google_health_api_error",
+      code: "google_health_required_sources_api_forbidden",
+      results: [
+        {
+          key: "sleep",
+          status: 403,
+          message: "Required OAuth scope(s) are missing for this operation.",
+        },
+      ],
+    });
+    expect(mockCreateClient).not.toHaveBeenCalled();
+    expect(mockSaveGoogleHealthDailyMetrics).not.toHaveBeenCalled();
+  });
+
+  it("保存に失敗した場合はconnection errorを更新してsanitized 500を返す", async () => {
+    const supabase = { from: jest.fn() };
+
+    mockGetCurrentUser.mockResolvedValue({ id: "user-id" });
+    mockResolveStoredAccessToken.mockResolvedValue({
+      ok: true,
+      accessToken: "stored-google-token",
+      refreshed: false,
+      status: "connected",
+    });
+    mockCreateClient.mockResolvedValue(supabase);
+    mockFetchGoogleHealthDailyMetrics.mockResolvedValue({
+      sourceResults: [
+        { ok: true, key: "sleep", dataPoints: [] },
+        { ok: true, key: "heartRateVariability", dataPoints: [] },
+        { ok: true, key: "restingHeartRate", dataPoints: [] },
+      ],
+      stepsResult: {
+        ok: true,
+        source: "reconcile",
+        attempts: [{ source: "reconcile", ok: true, status: 200 }],
+      },
+      dailyMetrics: [],
+    });
+    mockSaveGoogleHealthDailyMetrics.mockResolvedValue({
+      ok: false,
+      message: "Google Health 日次メトリクスの保存に失敗しました: duplicate key",
+    });
+
+    const response = await POST(makeRequest({
+      start: "2026-06-02",
+      end: "2026-06-02",
+    }));
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(mockMarkConnectionError).toHaveBeenCalledWith({
+      userId: "user-id",
+      code: "google_health_daily_metrics_save_failed",
+      message: "Google Health 日次メトリクスの保存に失敗しました: duplicate key",
+    });
+    expect(body).toEqual({
+      error: "Google Health 日次メトリクスの保存に失敗しました: duplicate key",
+      status: "error",
+      code: "google_health_daily_metrics_save_failed",
+    });
+    expect(mockMarkConnectionSynced).not.toHaveBeenCalled();
     expect(mockRevalidate).not.toHaveBeenCalled();
   });
 
@@ -262,7 +490,11 @@ describe("POST /api/google-health/daily-metrics", () => {
         { ok: true, key: "heartRateVariability", dataPoints: [] },
         { ok: true, key: "restingHeartRate", dataPoints: [] },
       ],
-      stepsResult: { ok: true, source: "reconcile" },
+      stepsResult: {
+        ok: true,
+        source: "reconcile",
+        attempts: [{ source: "reconcile", ok: true, status: 200 }],
+      },
       dailyMetrics: [],
     });
     mockSaveGoogleHealthDailyMetrics.mockResolvedValue({
@@ -281,9 +513,15 @@ describe("POST /api/google-health/daily-metrics", () => {
     const body = await response.json();
 
     expect(response.status).toBe(500);
+    expect(mockMarkConnectionError).toHaveBeenCalledWith({
+      userId: "user-id",
+      code: "google_health_sync_timestamp_update_failed",
+      message: "Google Health sync timestamp update failed.",
+    });
     expect(body).toEqual({
       error: "Google Health sync timestamp update failed.",
       status: "error",
+      code: "google_health_sync_timestamp_update_failed",
     });
     expect(JSON.stringify(body)).not.toContain("supabase_service_role_env_missing");
     expect(mockRevalidate).not.toHaveBeenCalled();

--- a/src/app/api/google-health/daily-metrics/route.ts
+++ b/src/app/api/google-health/daily-metrics/route.ts
@@ -1,7 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { revalidateAfterDailyLogMutation } from "@/lib/cache/revalidate";
-import { fetchGoogleHealthDailyMetrics } from "@/lib/googleHealth/dailyMetrics";
 import {
+  fetchGoogleHealthDailyMetrics,
+  type GoogleHealthDailyMetric,
+  type GoogleHealthStepsAttempt,
+  type GoogleHealthStepsResult,
+} from "@/lib/googleHealth/dailyMetrics";
+import {
+  markGoogleHealthConnectionError,
   markGoogleHealthConnectionSynced,
   resolveGoogleHealthStoredAccessToken,
 } from "@/lib/googleHealth/connections";
@@ -13,6 +19,8 @@ import { createClient, getCurrentUser } from "@/lib/supabase/server";
 export const dynamic = "force-dynamic";
 
 const REQUIRED_SOURCE_KEYS = new Set(["sleep", "heartRateVariability", "restingHeartRate"]);
+
+type GoogleHealthSyncLogPayload = Record<string, unknown>;
 
 function isSameOriginRequest(request: NextRequest): boolean {
   const origin = request.headers.get("Origin");
@@ -48,6 +56,63 @@ function sanitizeSourceError(result: Extract<GoogleHealthPocTargetResult, { ok: 
     status: result.status,
     message: result.message,
   };
+}
+
+function sanitizeStepsAttempts(attempts: GoogleHealthStepsAttempt[]) {
+  return attempts.map((attempt) => ({
+    source: attempt.source,
+    ok: attempt.ok,
+    status: attempt.status,
+    ...(attempt.message ? { message: attempt.message } : {}),
+  }));
+}
+
+function buildStepsApiErrorCode(result: Extract<GoogleHealthStepsResult, { ok: false }>): string {
+  return result.status === 403
+    ? "google_health_steps_api_forbidden"
+    : "google_health_steps_api_error";
+}
+
+function buildRequiredSourceApiErrorCode(results: Extract<GoogleHealthPocTargetResult, { ok: false }>[]): string {
+  return results.some((result) => result.status === 403)
+    ? "google_health_required_sources_api_forbidden"
+    : "google_health_required_sources_api_error";
+}
+
+function apiErrorHttpStatus(status: number): number {
+  return status === 403 ? 403 : 502;
+}
+
+function countEmptyMetrics(metrics: GoogleHealthDailyMetric[]): number {
+  return metrics.filter((metric) =>
+    metric.stepCount === null &&
+    metric.sleepMinutes === null &&
+    metric.deepSleepMinutes === null &&
+    metric.sleepBedAt === null &&
+    metric.sleepWakeAt === null &&
+    metric.hrvMs === null &&
+    metric.rhrBpm === null
+  ).length;
+}
+
+function logGoogleHealthSync(
+  level: "info" | "warn" | "error",
+  event: string,
+  payload: GoogleHealthSyncLogPayload,
+): void {
+  console[level]("[google-health-sync]", { event, ...payload });
+}
+
+async function markConnectionErrorSafely(args: {
+  userId: string;
+  code: string;
+  message?: string | null;
+}): Promise<void> {
+  try {
+    await markGoogleHealthConnectionError(args);
+  } catch {
+    logGoogleHealthSync("error", "connection_error_update_failed", { code: args.code });
+  }
 }
 
 export async function POST(req: NextRequest) {
@@ -96,28 +161,74 @@ export async function POST(req: NextRequest) {
   });
 
   if (!dailyResult.stepsResult.ok) {
+    const code = buildStepsApiErrorCode(dailyResult.stepsResult);
+    const stepsAttempts = sanitizeStepsAttempts(dailyResult.stepsResult.attempts);
+
+    await markConnectionErrorSafely({
+      userId: user.id,
+      code,
+      message: dailyResult.stepsResult.message,
+    });
+    logGoogleHealthSync("warn", "steps_fetch_failed", {
+      code,
+      range: rangeResult.range,
+      stepsAttempts,
+    });
+
     return NextResponse.json(
       {
         error: "Google Health 歩数の取得に失敗しました。",
         status: "google_health_api_error",
+        code,
         stepsResult: {
           dataType: dailyResult.stepsResult.dataType,
           source: dailyResult.stepsResult.source,
           status: dailyResult.stepsResult.status,
           message: dailyResult.stepsResult.message,
+          attempts: stepsAttempts,
         },
       },
-      { status: dailyResult.stepsResult.status === 403 ? 403 : 502 },
+      { status: apiErrorHttpStatus(dailyResult.stepsResult.status) },
     );
+  }
+
+  const stepsAttempts = sanitizeStepsAttempts(dailyResult.stepsResult.attempts);
+  const stepsFallbackUsed = dailyResult.stepsResult.source !== "reconcile";
+  if (stepsFallbackUsed) {
+    logGoogleHealthSync("info", "steps_fallback_used", {
+      range: rangeResult.range,
+      stepsSource: dailyResult.stepsResult.source,
+      stepsAttempts,
+    });
   }
 
   const sourceErrors = dailyResult.sourceResults.filter(isRequiredSourceError);
   if (sourceErrors.length > 0) {
+    const code = buildRequiredSourceApiErrorCode(sourceErrors);
+    const sanitizedSourceErrors = sourceErrors.map(sanitizeSourceError);
+
+    await markConnectionErrorSafely({
+      userId: user.id,
+      code,
+      message: sanitizedSourceErrors
+        .map((result) => `${result.key}:${result.status}`)
+        .join(", "),
+    });
+    logGoogleHealthSync("warn", "required_sources_fetch_failed", {
+      code,
+      range: rangeResult.range,
+      results: sanitizedSourceErrors.map((result) => ({
+        key: result.key,
+        status: result.status,
+      })),
+    });
+
     return NextResponse.json(
       {
         error: "Google Health 日次メトリクスの取得に失敗しました。",
         status: "google_health_api_error",
-        results: sourceErrors.map(sanitizeSourceError),
+        code,
+        results: sanitizedSourceErrors,
       },
       { status: sourceErrors.some((result) => result.status === 403) ? 403 : 502 },
     );
@@ -131,16 +242,45 @@ export async function POST(req: NextRequest) {
   });
 
   if (!saveResult.ok) {
-    return NextResponse.json({ error: saveResult.message }, { status: 500 });
+    const code = "google_health_daily_metrics_save_failed";
+
+    await markConnectionErrorSafely({
+      userId: user.id,
+      code,
+      message: saveResult.message,
+    });
+    logGoogleHealthSync("error", "daily_metrics_save_failed", {
+      code,
+      range: rangeResult.range,
+    });
+
+    return NextResponse.json({
+      error: saveResult.message,
+      status: "error",
+      code,
+    }, { status: 500 });
   }
 
   try {
     await markGoogleHealthConnectionSynced({ userId: user.id });
   } catch {
+    const code = "google_health_sync_timestamp_update_failed";
+
+    await markConnectionErrorSafely({
+      userId: user.id,
+      code,
+      message: "Google Health sync timestamp update failed.",
+    });
+    logGoogleHealthSync("error", "sync_timestamp_update_failed", {
+      code,
+      range: rangeResult.range,
+    });
+
     return NextResponse.json(
       {
         error: "Google Health sync timestamp update failed.",
         status: "error",
+        code,
       },
       { status: 500 },
     );
@@ -154,6 +294,9 @@ export async function POST(req: NextRequest) {
     ok: true,
     range: rangeResult.range,
     stepsSource: dailyResult.stepsResult.source,
+    stepsFallbackUsed,
+    stepsAttempts,
+    emptyMetricCount: countEmptyMetrics(dailyResult.dailyMetrics),
     savedCount: saveResult.savedCount,
     skippedCount: saveResult.skippedCount,
     savedDates: saveResult.savedDates,

--- a/src/lib/googleHealth/dailyMetrics.test.ts
+++ b/src/lib/googleHealth/dailyMetrics.test.ts
@@ -224,6 +224,25 @@ describe("Google Health daily metrics", () => {
         message: "Invalid argument in request.",
         details,
       });
+      expect(result.attempts).toEqual([
+        {
+          source: "reconcile",
+          ok: false,
+          status: 500,
+          message: "reconcile is temporarily unavailable",
+        },
+        {
+          source: "dailyRollUp",
+          ok: false,
+          status: 400,
+          message: "Invalid argument in request.",
+        },
+        {
+          source: "listFallback",
+          ok: true,
+          status: 200,
+        },
+      ]);
       expect(result.dataPoints).toEqual([
         {
           steps: {
@@ -280,6 +299,20 @@ describe("Google Health daily metrics", () => {
       source: "dailyRollUp",
       status: 403,
       message: "Required OAuth scope(s) are missing for this operation.",
+      attempts: [
+        {
+          source: "reconcile",
+          ok: false,
+          status: 500,
+          message: "reconcile is temporarily unavailable",
+        },
+        {
+          source: "dailyRollUp",
+          ok: false,
+          status: 403,
+          message: "Required OAuth scope(s) are missing for this operation.",
+        },
+      ],
     });
   });
 
@@ -305,6 +338,14 @@ describe("Google Health daily metrics", () => {
       source: "reconcile",
       status: 403,
       message: "Required OAuth scope(s) are missing for this operation.",
+      attempts: [
+        {
+          source: "reconcile",
+          ok: false,
+          status: 403,
+          message: "Required OAuth scope(s) are missing for this operation.",
+        },
+      ],
     });
   });
 

--- a/src/lib/googleHealth/dailyMetrics.ts
+++ b/src/lib/googleHealth/dailyMetrics.ts
@@ -33,6 +33,13 @@ export type GoogleHealthStepsError = {
   details?: unknown;
 };
 
+export type GoogleHealthStepsAttempt = {
+  source: GoogleHealthStepsError["source"];
+  ok: boolean;
+  status: number;
+  message?: string;
+};
+
 export type GoogleHealthStepsResult =
   | {
       ok: true;
@@ -41,6 +48,7 @@ export type GoogleHealthStepsResult =
       pageCount: number;
       dataPoints: unknown[];
       nextPageToken: string | null;
+      attempts: GoogleHealthStepsAttempt[];
     }
   | {
       ok: true;
@@ -49,6 +57,7 @@ export type GoogleHealthStepsResult =
       pageCount: number;
       rollupDataPoints: unknown[];
       nextPageToken: string | null;
+      attempts: GoogleHealthStepsAttempt[];
     }
   | {
       ok: true;
@@ -58,6 +67,7 @@ export type GoogleHealthStepsResult =
       dataPoints: unknown[];
       nextPageToken: string | null;
       fallbackFrom: GoogleHealthStepsError;
+      attempts: GoogleHealthStepsAttempt[];
     }
   | {
       ok: false;
@@ -67,6 +77,7 @@ export type GoogleHealthStepsResult =
       message: string;
       details?: unknown;
       fallbackFrom?: GoogleHealthStepsError;
+      attempts: GoogleHealthStepsAttempt[];
     };
 
 export type GoogleHealthDailyMetricsResult = {
@@ -404,6 +415,28 @@ async function parseGoogleHealthError(response: Response): Promise<Omit<GoogleHe
   }
 }
 
+function buildSuccessfulStepsAttempt(source: GoogleHealthStepsError["source"], status: number): GoogleHealthStepsAttempt {
+  return { source, ok: true, status };
+}
+
+function buildFailedStepsAttempt(error: GoogleHealthStepsError): GoogleHealthStepsAttempt {
+  return {
+    source: error.source,
+    ok: false,
+    status: error.status,
+    message: error.message,
+  };
+}
+
+function stepsErrorFromResult(result: Extract<GoogleHealthStepsResult, { ok: false }>): GoogleHealthStepsError {
+  return {
+    source: result.source,
+    status: result.status,
+    message: result.message,
+    ...(result.details !== undefined ? { details: result.details } : {}),
+  };
+}
+
 export async function fetchGoogleHealthStepsReconcile(args: {
   range: GoogleHealthPocRange;
   accessToken: string;
@@ -427,12 +460,16 @@ export async function fetchGoogleHealthStepsReconcile(args: {
 
     if (!response.ok) {
       const error = await parseGoogleHealthError(response);
+      const stepsError = {
+        source: "reconcile" as const,
+        status: response.status,
+        ...error,
+      };
       return {
         ok: false,
         dataType: "steps",
-        source: "reconcile",
-        status: response.status,
-        ...error,
+        ...stepsError,
+        attempts: [buildFailedStepsAttempt(stepsError)],
       };
     }
 
@@ -448,6 +485,7 @@ export async function fetchGoogleHealthStepsReconcile(args: {
     pageCount,
     dataPoints,
     nextPageToken,
+    attempts: [buildSuccessfulStepsAttempt("reconcile", 200)],
   };
 }
 
@@ -469,12 +507,16 @@ export async function fetchGoogleHealthStepsDailyRollup(args: {
 
   if (!response.ok) {
     const error = await parseGoogleHealthError(response);
+    const stepsError = {
+      source: "dailyRollUp" as const,
+      status: response.status,
+      ...error,
+    };
     return {
       ok: false,
       dataType: "steps",
-      source: "dailyRollUp",
-      status: response.status,
-      ...error,
+      ...stepsError,
+      attempts: [buildFailedStepsAttempt(stepsError)],
     };
   }
 
@@ -486,6 +528,7 @@ export async function fetchGoogleHealthStepsDailyRollup(args: {
     pageCount: 1,
     rollupDataPoints: Array.isArray(body.rollupDataPoints) ? body.rollupDataPoints : [],
     nextPageToken: body.nextPageToken && body.nextPageToken.length > 0 ? body.nextPageToken : null,
+    attempts: [buildSuccessfulStepsAttempt("dailyRollUp", response.status)],
   };
 }
 
@@ -495,11 +538,14 @@ export async function fetchGoogleHealthStepsListFallback(args: {
   fetchImpl?: FetchLike;
   maxPages?: number;
   fallbackFrom: GoogleHealthStepsError;
+  previousAttempts?: GoogleHealthStepsAttempt[];
 }): Promise<GoogleHealthStepsResult> {
   const { range, accessToken, fetchImpl = fetch, maxPages = 5, fallbackFrom } = args;
+  const previousAttempts = args.previousAttempts ?? [buildFailedStepsAttempt(fallbackFrom)];
   const dataPoints: unknown[] = [];
   let nextPageToken: string | null = null;
   let pageCount = 0;
+  let successStatus = 200;
 
   do {
     const response = await fetchImpl(buildGoogleHealthStepsListUrl(range, nextPageToken ?? undefined), {
@@ -513,16 +559,21 @@ export async function fetchGoogleHealthStepsListFallback(args: {
 
     if (!response.ok) {
       const error = await parseGoogleHealthError(response);
+      const stepsError = {
+        source: "listFallback" as const,
+        status: response.status,
+        ...error,
+      };
       return {
         ok: false,
         dataType: "steps",
-        source: "listFallback",
-        status: response.status,
-        ...error,
+        ...stepsError,
         fallbackFrom,
+        attempts: [...previousAttempts, buildFailedStepsAttempt(stepsError)],
       };
     }
 
+    successStatus = response.status;
     const body = await response.json() as ListResponse;
     dataPoints.push(...(Array.isArray(body.dataPoints) ? body.dataPoints : []));
     nextPageToken = body.nextPageToken && body.nextPageToken.length > 0 ? body.nextPageToken : null;
@@ -536,6 +587,7 @@ export async function fetchGoogleHealthStepsListFallback(args: {
     dataPoints,
     nextPageToken,
     fallbackFrom,
+    attempts: [...previousAttempts, buildSuccessfulStepsAttempt("listFallback", successStatus)],
   };
 }
 
@@ -548,17 +600,24 @@ export async function fetchGoogleHealthSteps(args: {
   if (reconcileResult.ok || reconcileResult.status === 403) return reconcileResult;
 
   const rollupResult = await fetchGoogleHealthStepsDailyRollup(args);
-  if (rollupResult.ok) return rollupResult;
-  if (rollupResult.status !== 400) return rollupResult;
+  const rollupAttempts = [...reconcileResult.attempts, ...rollupResult.attempts];
+  if (rollupResult.ok) {
+    return {
+      ...rollupResult,
+      attempts: rollupAttempts,
+    };
+  }
+  if (rollupResult.status !== 400) {
+    return {
+      ...rollupResult,
+      attempts: rollupAttempts,
+    };
+  }
 
   return fetchGoogleHealthStepsListFallback({
     ...args,
-    fallbackFrom: {
-      source: rollupResult.source,
-      status: rollupResult.status,
-      message: rollupResult.message,
-      ...(rollupResult.details !== undefined ? { details: rollupResult.details } : {}),
-    },
+    fallbackFrom: stepsErrorFromResult(rollupResult),
+    previousAttempts: rollupAttempts,
   });
 }
 


### PR DESCRIPTION
## 概要
Google Health 同期 API のエラー分類と運用確認用のログを整理しました。

## 変更内容
- 歩数取得結果に `stepsAttempts` を追加し、`reconcile` / `dailyRollUp` / `listFallback` の試行履歴を raw data なしで確認できるようにしました。
- 同期 API の失敗レスポンスに `code` を追加し、Google Health API 失敗、必須 source 失敗、保存失敗、最終同期 timestamp 更新失敗を分類しました。
- Google Health API 失敗・保存失敗・timestamp 更新失敗時に `google_health_connections.last_error_*` を更新するようにしました。
- fallback 採用や失敗時に、token や raw health data を含まない安全な runtime log を出すようにしました。
- 成功レスポンスに `stepsFallbackUsed`、`stepsAttempts`、`emptyMetricCount` を追加しました。

## 判断理由
- 新しい監視基盤やログテーブルは追加せず、既存の connection 状態管理と API レスポンスで #689 の目的に絞りました。
- token、Authorization header、Google Health raw response、dataPoints 全量はレスポンス・ログに含めない方針にしています。

## 検証結果
- `npm test -- --runTestsByPath src/lib/googleHealth/dailyMetrics.test.ts src/app/api/google-health/daily-metrics/route.test.ts`
- `npx tsc --noEmit`
- `npm run lint`
- `npm test`

Closes #689