### PR TITLE
#707 週間レビューをGoogle Health指標に対応する

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -206,7 +206,7 @@ export default async function DashboardPage() {
   const weeklyReview = calcWeeklyReview(logs, readinessMetrics, qualityReport, {
     avgTdee14d,
     phase,
-    sleepSessions,
+    googleHealthMetrics,
   });
 
   // 今月目標進捗の比較値: 最新体重優先 (単日ノイズ込みの実測値で進捗を把握する)

--- a/src/components/dashboard/WeeklyReviewCard.integration.test.tsx
+++ b/src/components/dashboard/WeeklyReviewCard.integration.test.tsx
@@ -24,6 +24,7 @@ jest.mock("lucide-react", () => ({
   Flame: () => <span data-testid="icon-flame" />,
   Beef: () => <span data-testid="icon-beef" />,
   Moon: () => <span data-testid="icon-moon" />,
+  HeartPulse: () => <span data-testid="icon-heart-pulse" />,
 }));
 
 function makeData(overrides: Partial<WeeklyReviewData> = {}): WeeklyReviewData {
@@ -58,6 +59,22 @@ function makeData(overrides: Partial<WeeklyReviewData> = {}): WeeklyReviewData {
       avgBedTimeDeltaMins: null,
       avgWakeTimeDeltaMins: null,
       timeDaysLogged: 0,
+    },
+    cardio: {
+      hrv: {
+        avg7d: null,
+        daysLogged7d: 0,
+        baselineAvg14d: null,
+        baselineStdDev14d: null,
+        deviationPct: null,
+      },
+      rhr: {
+        avg7d: null,
+        daysLogged7d: 0,
+        baselineAvg14d: null,
+        baselineStdDev14d: null,
+        deviationPct: null,
+      },
     },
     quality: {
       score: 90,
@@ -220,6 +237,42 @@ describe("WeeklyReviewCard", () => {
       />
     );
     expect(screen.getByText("睡眠 (6 日分)")).toBeInTheDocument();
+  });
+
+  it("心肺機能セクションにHRVと安静時心拍数を表示する", () => {
+    render(
+      <WeeklyReviewCard
+        data={makeData({
+          cardio: {
+            hrv: {
+              avg7d: 127,
+              daysLogged7d: 5,
+              baselineAvg14d: 124.5,
+              baselineStdDev14d: 8.2,
+              deviationPct: 2,
+            },
+            rhr: {
+              avg7d: 43.4,
+              daysLogged7d: 6,
+              baselineAvg14d: 44.1,
+              baselineStdDev14d: 1.7,
+              deviationPct: -1.6,
+            },
+          },
+        })}
+        phase="Cut"
+      />
+    );
+
+    expect(screen.getByText("心肺機能 (6 日分)")).toBeInTheDocument();
+    expect(screen.getByText("HRV")).toBeInTheDocument();
+    expect(screen.getByText("127.0")).toBeInTheDocument();
+    expect(screen.getByText("ms")).toBeInTheDocument();
+    expect(screen.getByText("(2週 124.5±8.2ms)")).toBeInTheDocument();
+    expect(screen.getByText("安静時")).toBeInTheDocument();
+    expect(screen.getByText("43.4")).toBeInTheDocument();
+    expect(screen.getByText("bpm")).toBeInTheDocument();
+    expect(screen.getByText("(2週 44.1±1.7bpm)")).toBeInTheDocument();
   });
 
   it("必要値が欠けるときは — 表示にフォールバックし、該当所見カードを出さない", () => {

--- a/src/components/dashboard/WeeklyReviewCard.tsx
+++ b/src/components/dashboard/WeeklyReviewCard.tsx
@@ -32,6 +32,7 @@ import {
   Flame,
   Beef,
   Moon,
+  HeartPulse,
 } from "lucide-react";
 import type { WeeklyReviewData, StagnationLevel } from "@/lib/utils/calcWeeklyReview";
 import { DAY_TAG_LABELS, DAY_TAG_BADGE_COLORS } from "@/lib/utils/dayTags";
@@ -177,6 +178,12 @@ function fmtSignedKcal(v: number | null): string {
   const s = v > 0 ? "+" : "";
   return `${s}${Math.round(v).toLocaleString()}`;
 }
+function fmtBaseline(avg: number | null, stdDev: number | null, unit: string): string | undefined {
+  if (avg === null) return undefined;
+  return stdDev !== null
+    ? `(2週 ${avg.toFixed(1)}±${stdDev.toFixed(1)}${unit})`
+    : `(2週 ${avg.toFixed(1)}${unit})`;
+}
 
 function qualityScoreColor(score: number): string {
   if (score >= 90) return "text-emerald-600";
@@ -220,6 +227,8 @@ export function WeeklyReviewCard({ data, phase, enrichedAvailability }: Props) {
   const StIcon = stCfg.icon;
 
   const { weight, nutrition, tdee, sleep, quality } = data;
+  const cardio = data.cardio;
+  const showCardio = cardio.hrv.avg7d !== null || cardio.rhr.avg7d !== null;
 
   // 所見カード用データを導出 (既存 findings string[] とは別に生成)
   const insightItems = deriveWeeklyInsightItems(data, phase);
@@ -441,6 +450,33 @@ export function WeeklyReviewCard({ data, phase, enrichedAvailability }: Props) {
                         ? `(${sleep.avgWakeTimeDeltaMins >= 0 ? "+" : ""}${sleep.avgWakeTimeDeltaMins}分)`
                         : undefined
                     }
+                  />
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* 心肺機能 */}
+          {showCardio && (
+            <div>
+              <SectionLabel icon={<HeartPulse size={12} className="text-rose-400" />}>
+                心肺機能 ({Math.max(cardio.hrv.daysLogged7d, cardio.rhr.daysLogged7d)} 日分)
+              </SectionLabel>
+              <div className="space-y-0.5">
+                {cardio.hrv.avg7d !== null && (
+                  <StatRow
+                    label="HRV"
+                    value={cardio.hrv.avg7d.toFixed(1)}
+                    unit="ms"
+                    sub={fmtBaseline(cardio.hrv.baselineAvg14d, cardio.hrv.baselineStdDev14d, "ms")}
+                  />
+                )}
+                {cardio.rhr.avg7d !== null && (
+                  <StatRow
+                    label="安静時"
+                    value={cardio.rhr.avg7d.toFixed(1)}
+                    unit="bpm"
+                    sub={fmtBaseline(cardio.rhr.baselineAvg14d, cardio.rhr.baselineStdDev14d, "bpm")}
                   />
                 )}
               </div>

--- a/src/lib/utils/calcWeeklyReview.test.ts
+++ b/src/lib/utils/calcWeeklyReview.test.ts
@@ -1,5 +1,6 @@
 import { calcWeeklyReview } from "./calcWeeklyReview";
-import type { DashboardDailyLog, SleepSession } from "@/lib/supabase/types";
+import type { DashboardDailyLog } from "@/lib/supabase/types";
+import type { GoogleHealthDailyMetricForDisplay } from "@/lib/googleHealth/displayMetrics";
 import type { ReadinessMetrics } from "./calcReadiness";
 import type { DataQualityReport } from "./calcDataQuality";
 
@@ -82,6 +83,23 @@ function makeQualityReport(overrides: Partial<DataQualityReport> = {}): DataQual
   } as DataQualityReport;
 }
 
+function makeGoogleHealthMetric(
+  metricDate: string,
+  overrides: Partial<GoogleHealthDailyMetricForDisplay> = {},
+): GoogleHealthDailyMetricForDisplay {
+  return {
+    metric_date: metricDate,
+    step_count: null,
+    sleep_minutes: null,
+    deep_sleep_minutes: null,
+    sleep_bed_at: null,
+    sleep_wake_at: null,
+    hrv_ms: null,
+    rhr_bpm: null,
+    ...overrides,
+  };
+}
+
 describe("calcWeeklyReview", () => {
   it("タンパク質 g/kg BW と脂質カロリー比を算出する", () => {
     const logs = [
@@ -108,20 +126,29 @@ describe("calcWeeklyReview", () => {
 
   it("直近 7 暦日の平均睡眠時間を算出する", () => {
     const logs = [
-      makeLog("2026-03-27", { sleep_hours: 7.0 }),
-      makeLog("2026-03-28", { sleep_hours: 8.0 }),
-      makeLog("2026-03-29", { sleep_hours: 7.5 }),
-      makeLog("2026-03-30", { sleep_hours: null }), // 欠損は除外
-      makeLog("2026-03-31", { sleep_hours: 6.5 }),
-      makeLog("2026-04-01", { sleep_hours: 8.0 }),
-      makeLog("2026-04-02", { sleep_hours: 7.0 }),
+      makeLog("2026-03-27"),
+      makeLog("2026-03-28"),
+      makeLog("2026-03-29"),
+      makeLog("2026-03-30"),
+      makeLog("2026-03-31"),
+      makeLog("2026-04-01"),
+      makeLog("2026-04-02"),
+    ];
+    const metrics = [
+      makeGoogleHealthMetric("2026-03-27", { sleep_minutes: 420 }),
+      makeGoogleHealthMetric("2026-03-28", { sleep_minutes: 480 }),
+      makeGoogleHealthMetric("2026-03-29", { sleep_minutes: 450 }),
+      makeGoogleHealthMetric("2026-03-30", { sleep_minutes: null }),
+      makeGoogleHealthMetric("2026-03-31", { sleep_minutes: 390 }),
+      makeGoogleHealthMetric("2026-04-01", { sleep_minutes: 480 }),
+      makeGoogleHealthMetric("2026-04-02", { sleep_minutes: 420 }),
     ];
 
     const result = calcWeeklyReview(
       logs,
       makeMetrics(),
       makeQualityReport(),
-      { today: "2026-04-02", phase: "Cut" }
+      { today: "2026-04-02", phase: "Cut", googleHealthMetrics: metrics }
     );
 
     // (7.0 + 8.0 + 7.5 + 6.5 + 8.0 + 7.0) / 6 = 44 / 6 ≈ 7.333
@@ -129,10 +156,10 @@ describe("calcWeeklyReview", () => {
     expect(result.sleep.sleepDaysLogged).toBe(6);
   });
 
-  it("sleep_hours が全て null のときは avgSleepHours が null になる", () => {
+  it("睡眠データが全て欠損しているときは avgSleepHours が null になる", () => {
     const logs = [
-      makeLog("2026-03-27", { sleep_hours: null }),
-      makeLog("2026-03-28", { sleep_hours: null }),
+      makeLog("2026-03-27"),
+      makeLog("2026-03-28"),
     ];
 
     const result = calcWeeklyReview(
@@ -146,7 +173,7 @@ describe("calcWeeklyReview", () => {
     expect(result.sleep.sleepDaysLogged).toBe(0);
   });
 
-  it("新フィールドのデフォルト: sleepSessions 未指定のとき全て null / 0", () => {
+  it("新フィールドのデフォルトは null / 0", () => {
     const result = calcWeeklyReview(
       [makeLog("2026-04-02")],
       makeMetrics(),
@@ -158,28 +185,24 @@ describe("calcWeeklyReview", () => {
     expect(result.sleep.avgBedTimeDeltaMins).toBeNull();
     expect(result.sleep.avgWakeTimeDeltaMins).toBeNull();
     expect(result.sleep.timeDaysLogged).toBe(0);
+    expect(result.cardio.hrv.avg7d).toBeNull();
+    expect(result.cardio.rhr.avg7d).toBeNull();
   });
 
   // ─── 就寝・起床平均時刻 ───────────────────────────────────────────────────────
 
-  function makeSleepSession(
-    wakeDate: string,
+  function makeSleepMetric(
+    metricDate: string,
     bedAtUtc: string,
     wakeAtUtc: string
-  ): SleepSession {
-    return {
-      id: `session-${wakeDate}`,
-      wake_date: wakeDate,
-      bed_at: bedAtUtc,
-      wake_at: wakeAtUtc,
-      source: "manual",
-      note: null,
-      created_at: "2026-01-01T00:00:00Z",
-      updated_at: "2026-01-01T00:00:00Z",
-    };
+  ): GoogleHealthDailyMetricForDisplay {
+    return makeGoogleHealthMetric(metricDate, {
+      sleep_bed_at: bedAtUtc,
+      sleep_wake_at: wakeAtUtc,
+    });
   }
 
-  it("sleepSessions から就寝・起床平均時刻を算出する", () => {
+  it("就寝・起床平均時刻を算出する", () => {
     // today = 2026-04-02, 当週: 2026-03-27〜2026-04-02
     // セッション 1 (wake_date=2026-04-01): bed 23:00 JST, wake 7:00 JST
     //   bed_at UTC: JST23:00=UTC14:00 → "2026-03-31T14:00:00Z"
@@ -187,15 +210,15 @@ describe("calcWeeklyReview", () => {
     // セッション 2 (wake_date=2026-04-02): bed 23:30 JST, wake 7:00 JST
     //   bed_at UTC: JST23:30=UTC14:30 → "2026-04-01T14:30:00Z"
     //   wake_at UTC: JST07:00=UTC22:00 → "2026-04-01T22:00:00Z"
-    const sessions = [
-      makeSleepSession("2026-04-01", "2026-03-31T14:00:00Z", "2026-03-31T22:00:00Z"),
-      makeSleepSession("2026-04-02", "2026-04-01T14:30:00Z", "2026-04-01T22:00:00Z"),
+    const metrics = [
+      makeSleepMetric("2026-04-01", "2026-03-31T14:00:00Z", "2026-03-31T22:00:00Z"),
+      makeSleepMetric("2026-04-02", "2026-04-01T14:30:00Z", "2026-04-01T22:00:00Z"),
     ];
     const result = calcWeeklyReview(
       [makeLog("2026-04-01"), makeLog("2026-04-02")],
       makeMetrics(),
       makeQualityReport(),
-      { today: "2026-04-02", sleepSessions: sessions }
+      { today: "2026-04-02", googleHealthMetrics: metrics }
     );
     // avg bed: (23:00=1380 + 23:30=1410) / 2 = 1395 → 23:15
     expect(result.sleep.avgBedTime).toBe("23:15");
@@ -208,15 +231,15 @@ describe("calcWeeklyReview", () => {
     // 0:30 JST = UTC 15:30 前日 → timestampToJstMinutes → 30 → +1440 = 1470
     // 23:30 JST = UTC 14:30 → 1410 → 補正なし
     // avg = (1470 + 1410) / 2 = 1440 → minutesToHHMM(1440) = 1440%1440=0 → "00:00"
-    const sessions = [
-      makeSleepSession("2026-04-01", "2026-03-31T15:30:00Z", "2026-04-01T22:00:00Z"),
-      makeSleepSession("2026-04-02", "2026-04-01T14:30:00Z", "2026-04-01T22:00:00Z"),
+    const metrics = [
+      makeSleepMetric("2026-04-01", "2026-03-31T15:30:00Z", "2026-04-01T22:00:00Z"),
+      makeSleepMetric("2026-04-02", "2026-04-01T14:30:00Z", "2026-04-01T22:00:00Z"),
     ];
     const result = calcWeeklyReview(
       [makeLog("2026-04-01"), makeLog("2026-04-02")],
       makeMetrics(),
       makeQualityReport(),
-      { today: "2026-04-02", sleepSessions: sessions }
+      { today: "2026-04-02", googleHealthMetrics: metrics }
     );
     expect(result.sleep.avgBedTime).toBe("00:00");
   });
@@ -229,15 +252,15 @@ describe("calcWeeklyReview", () => {
     //   bed_at UTC: "2026-04-06T14:00:00Z", wake_at UTC: "2026-04-06T22:00:00Z"
     // 当週 (wake_date=2026-04-14): bed 23:30(1410), wake 07:30(450)
     //   bed_at UTC: "2026-04-13T14:30:00Z", wake_at UTC: "2026-04-13T22:30:00Z"
-    const sessions = [
-      makeSleepSession("2026-04-07", "2026-04-06T14:00:00Z", "2026-04-06T22:00:00Z"),
-      makeSleepSession("2026-04-14", "2026-04-13T14:30:00Z", "2026-04-13T22:30:00Z"),
+    const metrics = [
+      makeSleepMetric("2026-04-07", "2026-04-06T14:00:00Z", "2026-04-06T22:00:00Z"),
+      makeSleepMetric("2026-04-14", "2026-04-13T14:30:00Z", "2026-04-13T22:30:00Z"),
     ];
     const result = calcWeeklyReview(
       [makeLog("2026-04-07"), makeLog("2026-04-14")],
       makeMetrics(),
       makeQualityReport(),
-      { today: "2026-04-14", sleepSessions: sessions }
+      { today: "2026-04-14", googleHealthMetrics: metrics }
     );
     // bed delta: 1410 - 1380 = 30 分 (30分遅くなった)
     expect(result.sleep.avgBedTimeDeltaMins).toBe(30);
@@ -247,18 +270,43 @@ describe("calcWeeklyReview", () => {
 
   it("前週データがない場合は delta が null", () => {
     // 当週のみのセッション (前週は空)
-    const sessions = [
-      makeSleepSession("2026-04-02", "2026-04-01T14:30:00Z", "2026-04-01T22:00:00Z"),
+    const metrics = [
+      makeSleepMetric("2026-04-02", "2026-04-01T14:30:00Z", "2026-04-01T22:00:00Z"),
     ];
     const result = calcWeeklyReview(
       [makeLog("2026-04-02")],
       makeMetrics(),
       makeQualityReport(),
-      { today: "2026-04-02", sleepSessions: sessions }
+      { today: "2026-04-02", googleHealthMetrics: metrics }
     );
     expect(result.sleep.avgBedTime).toBe("23:30");
     expect(result.sleep.avgBedTimeDeltaMins).toBeNull();
     expect(result.sleep.avgWakeTimeDeltaMins).toBeNull();
+  });
+
+  it("心肺機能の直近7日平均と14日ベースラインを算出する", () => {
+    const metrics = [
+      makeGoogleHealthMetric("2026-03-20", { hrv_ms: 100, rhr_bpm: 40 }),
+      makeGoogleHealthMetric("2026-03-21", { hrv_ms: 120, rhr_bpm: 44 }),
+      makeGoogleHealthMetric("2026-03-27", { hrv_ms: 130, rhr_bpm: 42 }),
+      makeGoogleHealthMetric("2026-03-28", { hrv_ms: null, rhr_bpm: null }),
+      makeGoogleHealthMetric("2026-04-02", { hrv_ms: 150, rhr_bpm: 46 }),
+    ];
+
+    const result = calcWeeklyReview(
+      [makeLog("2026-04-02")],
+      makeMetrics(),
+      makeQualityReport(),
+      { today: "2026-04-02", googleHealthMetrics: metrics }
+    );
+
+    expect(result.cardio.hrv.avg7d).toBe(140);
+    expect(result.cardio.hrv.daysLogged7d).toBe(2);
+    expect(result.cardio.hrv.baselineAvg14d).toBe(125);
+    expect(result.cardio.hrv.baselineStdDev14d).toBeCloseTo(Math.sqrt(325), 5);
+    expect(result.cardio.hrv.deviationPct).toBeCloseTo(12, 5);
+    expect(result.cardio.rhr.avg7d).toBe(44);
+    expect(result.cardio.rhr.baselineAvg14d).toBe(43);
   });
 
   it("基準体重や脂質/カロリーが欠けるときは null にフォールバックする", () => {

--- a/src/lib/utils/calcWeeklyReview.ts
+++ b/src/lib/utils/calcWeeklyReview.ts
@@ -15,7 +15,8 @@
  *   - generateFindings で「チートデイ後の水分増加の可能性」を注記
  */
 
-import type { DashboardDailyLog, SleepSession } from "@/lib/supabase/types";
+import type { DashboardDailyLog } from "@/lib/supabase/types";
+import type { GoogleHealthDailyMetricForDisplay } from "@/lib/googleHealth/displayMetrics";
 import type { ReadinessMetrics } from "./calcReadiness";
 import type { DataQualityReport } from "./calcDataQuality";
 import { addDaysStr, dateRangeStr, toJstDateStr } from "./date";
@@ -101,21 +102,19 @@ export interface WeeklyTdee {
 
 export interface WeeklySleep {
   /**
-   * 直近 7 暦日のうち sleep_hours が記録されている日の平均 (h)。
-   * source of truth: daily_logs.sleep_hours
-   * (sleep_sessions の bed_at / wake_at から DB トリガーが自動同期する projection 値)
+   * 直近 7 暦日のうち Google Health sleep_minutes が記録されている日の平均 (h)。
    */
   avgSleepHours: number | null;
-  /** sleep_hours が非 null の日数 */
+  /** sleep_minutes が非 null の日数 */
   sleepDaysLogged: number;
   /**
    * 直近 7 暦日の平均就寝時刻 "HH:MM" (JST)。
-   * sleepSessions が渡されない場合、または当週のデータがない場合は null。
+   * Google Health sleep_bed_at がない場合は null。
    */
   avgBedTime: string | null;
   /**
    * 直近 7 暦日の平均起床時刻 "HH:MM" (JST)。
-   * sleepSessions が渡されない場合、または当週のデータがない場合は null。
+   * Google Health sleep_wake_at がない場合は null。
    */
   avgWakeTime: string | null;
   /**
@@ -130,6 +129,24 @@ export interface WeeklySleep {
   avgWakeTimeDeltaMins: number | null;
   /** 直近 7 日のうち bed_at / wake_at がある日数 */
   timeDaysLogged: number;
+}
+
+export interface WeeklyCardioMetric {
+  /** 直近 7 暦日の平均 */
+  avg7d: number | null;
+  /** 直近 7 暦日の記録日数 */
+  daysLogged7d: number;
+  /** 直近 14 暦日の平均 */
+  baselineAvg14d: number | null;
+  /** 直近 14 暦日の標準偏差。記録が 2 件未満なら null */
+  baselineStdDev14d: number | null;
+  /** 直近 7 日平均の 14 日平均との差分 (%) */
+  deviationPct: number | null;
+}
+
+export interface WeeklyCardio {
+  hrv: WeeklyCardioMetric;
+  rhr: WeeklyCardioMetric;
 }
 
 /** 直近 7 日の特殊日集計 */
@@ -149,6 +166,7 @@ export interface WeeklyReviewData {
   nutrition: WeeklyNutrition;
   tdee: WeeklyTdee;
   sleep: WeeklySleep;
+  cardio: WeeklyCardio;
   quality: {
     score: number;
     weightMissingDays: number;
@@ -466,18 +484,19 @@ function applyBedTimeCrossing(mins: number): number {
 
 type AvgTimeResult = { avgMins: number; count: number };
 
-/**
- * 指定した wake_date セットに対応する睡眠セッションの平均就寝時刻を計算する。
- * 日付越え補正済みの生の avgMins を返す（minutesToHHMM で変換する前の値）。
- */
+type GoogleHealthMetricDateKey = Pick<
+  GoogleHealthDailyMetricForDisplay,
+  "metric_date" | "sleep_bed_at" | "sleep_wake_at"
+>;
+
 function computeAvgBedTime(
-  sessions: SleepSession[],
+  metrics: GoogleHealthMetricDateKey[],
   dateSet: Set<string>
 ): AvgTimeResult | null {
   const vals: number[] = [];
-  for (const s of sessions) {
-    if (!dateSet.has(s.wake_date)) continue;
-    const mins = timestampToJstMinutes(s.bed_at);
+  for (const metric of metrics) {
+    if (!dateSet.has(metric.metric_date) || metric.sleep_bed_at === null) continue;
+    const mins = timestampToJstMinutes(metric.sleep_bed_at);
     if (mins === null) continue;
     vals.push(applyBedTimeCrossing(mins));
   }
@@ -485,22 +504,61 @@ function computeAvgBedTime(
   return { avgMins: vals.reduce((a, b) => a + b, 0) / vals.length, count: vals.length };
 }
 
-/**
- * 指定した wake_date セットに対応する睡眠セッションの平均起床時刻を計算する。
- */
 function computeAvgWakeTime(
-  sessions: SleepSession[],
+  metrics: GoogleHealthMetricDateKey[],
   dateSet: Set<string>
 ): AvgTimeResult | null {
   const vals: number[] = [];
-  for (const s of sessions) {
-    if (!dateSet.has(s.wake_date)) continue;
-    const mins = timestampToJstMinutes(s.wake_at);
+  for (const metric of metrics) {
+    if (!dateSet.has(metric.metric_date) || metric.sleep_wake_at === null) continue;
+    const mins = timestampToJstMinutes(metric.sleep_wake_at);
     if (mins === null) continue;
     vals.push(mins);
   }
   if (vals.length === 0) return null;
   return { avgMins: vals.reduce((a, b) => a + b, 0) / vals.length, count: vals.length };
+}
+
+function average(values: number[]): number | null {
+  return values.length > 0 ? values.reduce((a, b) => a + b, 0) / values.length : null;
+}
+
+function stdDev(values: number[]): number | null {
+  if (values.length < 2) return null;
+  const avg = average(values);
+  if (avg === null) return null;
+  const variance = values.reduce((sum, value) => sum + (value - avg) ** 2, 0) / values.length;
+  return Math.sqrt(variance);
+}
+
+function buildCardioMetric(args: {
+  metrics: GoogleHealthDailyMetricForDisplay[];
+  currentDateSet: Set<string>;
+  baselineDateSet: Set<string>;
+  field: "hrv_ms" | "rhr_bpm";
+}): WeeklyCardioMetric {
+  const currentValues = args.metrics
+    .filter((metric) => args.currentDateSet.has(metric.metric_date))
+    .map((metric) => metric[args.field])
+    .filter((value): value is number => value !== null);
+  const baselineValues = args.metrics
+    .filter((metric) => args.baselineDateSet.has(metric.metric_date))
+    .map((metric) => metric[args.field])
+    .filter((value): value is number => value !== null);
+
+  const avg7d = average(currentValues);
+  const baselineAvg14d = average(baselineValues);
+
+  return {
+    avg7d,
+    daysLogged7d: currentValues.length,
+    baselineAvg14d,
+    baselineStdDev14d: stdDev(baselineValues),
+    deviationPct:
+      avg7d !== null && baselineAvg14d !== null && baselineAvg14d > 0
+        ? ((avg7d - baselineAvg14d) / baselineAvg14d) * 100
+        : null,
+  };
 }
 
 // ─── メイン関数 ──────────────────────────────────────────────────────────────
@@ -515,8 +573,7 @@ function computeAvgWakeTime(
  *                            未指定のときは WeeklyTdee.avgEstimated / balancePerDay が null になる。
  * @param options.phase  "Cut" | "Bulk" (デフォルト "Cut")
  * @param options.today  基準日 YYYY-MM-DD (省略時 JST 今日)
- * @param options.sleepSessions  sleep_sessions テーブルの行。就寝・起床平均時刻の算出に使う。
- *                               渡されない場合は avgBedTime / avgWakeTime が null になる。
+ * @param options.googleHealthMetrics  google_health_daily_metrics の行。睡眠・心肺機能の算出に使う。
  */
 export function calcWeeklyReview(
   logs: DashboardDailyLog[],
@@ -526,10 +583,10 @@ export function calcWeeklyReview(
     avgTdee14d?: number | null;
     phase?: string;
     today?: string;
-    sleepSessions?: SleepSession[];
+    googleHealthMetrics?: GoogleHealthDailyMetricForDisplay[];
   } = {}
 ): WeeklyReviewData {
-  const { avgTdee14d, phase = "Cut", today, sleepSessions } = options;
+  const { avgTdee14d, phase = "Cut", today, googleHealthMetrics = [] } = options;
   const todayStr = today ?? toJstDateStr(new Date());
 
   // ── 7 暦日リスト ──
@@ -611,17 +668,18 @@ export function calcWeeklyReview(
 
   // ── Sleep ──
 
-  // 平均睡眠時間: daily_logs.sleep_hours (sleep_sessions からの DB トリガー projection 値)
-  const sleepVals = windowLogs
-    .filter((l) => l.sleep_hours !== null)
-    .map((l) => l.sleep_hours as number);
-
-  // 就寝・起床平均時刻: sleep_sessions.bed_at / wake_at から算出
   // 前週比のため、前の 7 暦日 (today-13 〜 today-7) も集計する
   const d7DateSet = new Set(last7Dates);
   const prevD14Start = addDaysStr(todayStr, -13) ?? todayStr;
   const prevD7End    = addDaysStr(todayStr, -7)  ?? todayStr;
   const prev7DateSet = new Set(dateRangeStr(prevD14Start, prevD7End));
+  const d14DateSet = new Set(dateRangeStr(prevD14Start, todayStr));
+
+  const sleepVals = googleHealthMetrics
+    .filter((metric) => d7DateSet.has(metric.metric_date))
+    .map((metric) => metric.sleep_minutes)
+    .filter((value): value is number => value !== null)
+    .map((minutes) => minutes / 60);
 
   let avgBedTime: string | null = null;
   let avgWakeTime: string | null = null;
@@ -629,11 +687,11 @@ export function calcWeeklyReview(
   let avgWakeTimeDeltaMins: number | null = null;
   let timeDaysLogged = 0;
 
-  if (sleepSessions && sleepSessions.length > 0) {
-    const currBed  = computeAvgBedTime(sleepSessions, d7DateSet);
-    const currWake = computeAvgWakeTime(sleepSessions, d7DateSet);
-    const prevBed  = computeAvgBedTime(sleepSessions, prev7DateSet);
-    const prevWake = computeAvgWakeTime(sleepSessions, prev7DateSet);
+  if (googleHealthMetrics.length > 0) {
+    const currBed  = computeAvgBedTime(googleHealthMetrics, d7DateSet);
+    const currWake = computeAvgWakeTime(googleHealthMetrics, d7DateSet);
+    const prevBed  = computeAvgBedTime(googleHealthMetrics, prev7DateSet);
+    const prevWake = computeAvgWakeTime(googleHealthMetrics, prev7DateSet);
 
     avgBedTime  = currBed  ? minutesToHHMM(currBed.avgMins)  : null;
     avgWakeTime = currWake ? minutesToHHMM(currWake.avgMins) : null;
@@ -649,16 +707,28 @@ export function calcWeeklyReview(
   }
 
   const sleep: WeeklySleep = {
-    avgSleepHours:
-      sleepVals.length > 0
-        ? sleepVals.reduce((a, b) => a + b, 0) / sleepVals.length
-        : null,
+    avgSleepHours: average(sleepVals),
     sleepDaysLogged: sleepVals.length,
     avgBedTime,
     avgWakeTime,
     avgBedTimeDeltaMins,
     avgWakeTimeDeltaMins,
     timeDaysLogged,
+  };
+
+  const cardio: WeeklyCardio = {
+    hrv: buildCardioMetric({
+      metrics: googleHealthMetrics,
+      currentDateSet: d7DateSet,
+      baselineDateSet: d14DateSet,
+      field: "hrv_ms",
+    }),
+    rhr: buildCardioMetric({
+      metrics: googleHealthMetrics,
+      currentDateSet: d7DateSet,
+      baselineDateSet: d14DateSet,
+      field: "rhr_bpm",
+    }),
   };
 
   // ── TDEE (14日平均 TDEE を基準線として参照) ──
@@ -722,6 +792,7 @@ export function calcWeeklyReview(
     nutrition,
     tdee,
     sleep,
+    cardio,
     quality,
     stagnation,
     specialDays,

--- a/src/lib/utils/weeklyInsights.test.ts
+++ b/src/lib/utils/weeklyInsights.test.ts
@@ -53,6 +53,22 @@ function makeData(overrides: Partial<WeeklyReviewData> = {}): WeeklyReviewData {
       avgWakeTimeDeltaMins: null,
       timeDaysLogged: 0,
     },
+    cardio: {
+      hrv: {
+        avg7d: null,
+        daysLogged7d: 0,
+        baselineAvg14d: null,
+        baselineStdDev14d: null,
+        deviationPct: null,
+      },
+      rhr: {
+        avg7d: null,
+        daysLogged7d: 0,
+        baselineAvg14d: null,
+        baselineStdDev14d: null,
+        deviationPct: null,
+      },
+    },
     quality: {
       score: 90,
       weightMissingDays: 0,
@@ -85,6 +101,25 @@ function makeStagnation(
     trendKgPerWeek: -0.35,
     qualityNote: null,
     ...overrides,
+  };
+}
+
+function makeHrvData(deviationPct: number | null): WeeklyReviewData["cardio"] {
+  return {
+    hrv: {
+      avg7d: deviationPct === null ? null : 120,
+      daysLogged7d: deviationPct === null ? 0 : 7,
+      baselineAvg14d: deviationPct === null ? null : 125,
+      baselineStdDev14d: deviationPct === null ? null : 8.5,
+      deviationPct,
+    },
+    rhr: {
+      avg7d: null,
+      daysLogged7d: 0,
+      baselineAvg14d: null,
+      baselineStdDev14d: null,
+      deviationPct: null,
+    },
   };
 }
 
@@ -479,7 +514,76 @@ describe("deriveWeeklyInsightItems", () => {
     });
   });
 
+  // ── HRV ベースライン ── //
+
+  describe("HRV ベースライン InsightItem", () => {
+    it("+10%以上 → 過回復・適応良好として status ok", () => {
+      const items = deriveWeeklyInsightItems(
+        makeData({ cardio: makeHrvData(10) }),
+        "Cut",
+      );
+      const hrvItem = items.find((i) => i.title.startsWith("HRV "));
+      expect(hrvItem).toBeDefined();
+      expect(hrvItem!.status).toBe("ok");
+      expect(hrvItem!.title).toContain("過回復・適応良好");
+      expect(hrvItem!.detail).toContain("7日平均 120.0ms / 2週平均 125.0ms");
+    });
+
+    it("±10%以内 → 通常として status ok", () => {
+      const items = deriveWeeklyInsightItems(
+        makeData({ cardio: makeHrvData(-10) }),
+        "Cut",
+      );
+      const hrvItem = items.find((i) => i.title.startsWith("HRV "));
+      expect(hrvItem).toBeDefined();
+      expect(hrvItem!.status).toBe("ok");
+      expect(hrvItem!.title).toContain("通常");
+    });
+
+    it("-10〜-15% → 軽度の蓄積疲労として status caution", () => {
+      const items = deriveWeeklyInsightItems(
+        makeData({ cardio: makeHrvData(-12) }),
+        "Cut",
+      );
+      const hrvItem = items.find((i) => i.title.startsWith("HRV "));
+      expect(hrvItem).toBeDefined();
+      expect(hrvItem!.status).toBe("caution");
+      expect(hrvItem!.title).toContain("軽度の蓄積疲労");
+    });
+
+    it("-15〜-25% → 中度の疲労として status caution", () => {
+      const items = deriveWeeklyInsightItems(
+        makeData({ cardio: makeHrvData(-20) }),
+        "Cut",
+      );
+      const hrvItem = items.find((i) => i.title.startsWith("HRV "));
+      expect(hrvItem).toBeDefined();
+      expect(hrvItem!.status).toBe("caution");
+      expect(hrvItem!.title).toContain("中度の疲労");
+    });
+
+    it("-25%以上低下 → 重度の疲労として status alert", () => {
+      const items = deriveWeeklyInsightItems(
+        makeData({ cardio: makeHrvData(-25) }),
+        "Cut",
+      );
+      const hrvItem = items.find((i) => i.title.startsWith("HRV "));
+      expect(hrvItem).toBeDefined();
+      expect(hrvItem!.status).toBe("alert");
+      expect(hrvItem!.title).toContain("重度の疲労");
+    });
+
+    it("HRV の偏差が算出できないときは InsightItem を生成しない", () => {
+      const items = deriveWeeklyInsightItems(
+        makeData({ cardio: makeHrvData(null) }),
+        "Cut",
+      );
+      expect(items.every((i) => !i.title.startsWith("HRV "))).toBe(true);
+    });
+  });
+
   // ── データ品質警告 ── //
+
 
   describe("データ品質警告 InsightItem", () => {
     it("weightMissingDays > 0 → caution item が生成される", () => {

--- a/src/lib/utils/weeklyInsights.ts
+++ b/src/lib/utils/weeklyInsights.ts
@@ -47,6 +47,25 @@ function fmtSigned(v: number, decimals: number): string {
   return `${v > 0 ? "+" : ""}${v.toFixed(decimals)}`;
 }
 
+function hrvDeviationInsight(deviationPct: number): {
+  status: InsightStatus;
+  label: string;
+} {
+  if (deviationPct >= 10) {
+    return { status: "ok", label: "過回復・適応良好" };
+  }
+  if (deviationPct >= -10) {
+    return { status: "ok", label: "通常" };
+  }
+  if (deviationPct >= -15) {
+    return { status: "caution", label: "軽度の蓄積疲労" };
+  }
+  if (deviationPct > -25) {
+    return { status: "caution", label: "中度の疲労" };
+  }
+  return { status: "alert", label: "重度の疲労" };
+}
+
 // ── メイン関数 ────────────────────────────────────────────────────────────────
 
 /**
@@ -70,7 +89,7 @@ export function deriveWeeklyInsightItems(
 ): InsightItem[] {
   const items: InsightItem[] = [];
   const isCut = phase !== "Bulk";
-  const { weight, nutrition, tdee, quality, stagnation, specialDays } = data;
+  const { weight, nutrition, tdee, quality, stagnation, specialDays, cardio } = data;
 
   // ── 1. 体重トレンド ──────────────────────────────────────────────────────
   {
@@ -226,6 +245,16 @@ export function deriveWeeklyInsightItems(
     }
 
     items.push({ status, title: label, detail });
+  }
+
+  // ── 6. HRV ベースライン ─────────────────────────────────────────────────
+  if (cardio.hrv.deviationPct !== null && cardio.hrv.avg7d !== null && cardio.hrv.baselineAvg14d !== null) {
+    const hrv = hrvDeviationInsight(cardio.hrv.deviationPct);
+    items.push({
+      status: hrv.status,
+      title: `HRV ${fmtSigned(cardio.hrv.deviationPct, 1)}% — ${hrv.label}`,
+      detail: `7日平均 ${cardio.hrv.avg7d.toFixed(1)}ms / 2週平均 ${cardio.hrv.baselineAvg14d.toFixed(1)}ms`,
+    });
   }
 
   // ── 7. データ品質警告 ────────────────────────────────────────────────────


### PR DESCRIPTION
## 概要
- 週間レビューの睡眠集計を `google_health_daily_metrics` ベースに変更しました。
- 睡眠セクション下に `心肺機能` セクションを追加し、HRV / 安静時心拍数の直近7暦日平均と直近14暦日の平均±標準偏差を表示します。
- 所見カードに HRV のベースライン逸脱 KPI を追加しました。

## 変更内容
- `calcWeeklyReview` に `googleHealthMetrics` を渡し、睡眠時間・就寝/起床時刻・心肺機能を算出。
- `WeeklyReviewCard` に `心肺機能` セクションを追加。
- `weeklyInsights` に HRV 逸脱率の所見カードを追加。
- 関連ユニットテスト / UI 結合テストを更新。

## 判断理由
- #688 で画面表示を Google Health 由来に寄せたため、週間レビューも同じ source of truth に揃えるため。
- `睡眠 (5 日分)` のような表示は、直近7暦日のうち有効な睡眠/時刻データがある日数を表す仕様として維持しています。

## 検証結果
- `npm test -- --runTestsByPath src/lib/utils/calcWeeklyReview.test.ts src/lib/utils/weeklyInsights.test.ts src/components/dashboard/WeeklyReviewCard.integration.test.tsx`
- `npx tsc --noEmit`
- `npm run lint`

Closes #707