### PR TITLE
日次ログ export に Google Health 日次メトリクスを結合する

### DIFF
--- a/src/app/api/export/route.test.ts
+++ b/src/app/api/export/route.test.ts
@@ -4,7 +4,7 @@
  * テスト構成:
  *   1. isValidDateParam — 純粋関数のユニットテスト
  *   2. GET handler — table / start / end の不正入力で 400 を返すことを検証
- *   3. GET handler — daily_logs CSV 出力
+ *   3. GET handler — daily_logs + Google Health CSV 出力
  *
  * 注: バリデーション 400 ケースは DB 呼び出し前に return するため、
  * supabase モックが実際に呼ばれることはない。
@@ -132,19 +132,24 @@ describe("GET /api/export — バリデーション", () => {
   });
 });
 
-// ── GET handler — daily_logs CSV 出力 ─────────────────────────────────────────
+// ── GET handler — daily_logs + Google Health CSV 出力 ─────────────────────────
 
 /**
  * supabase の chained query builder をモックする。
  * select / order / gte / lte が連鎖可能で、await した際に result を返す。
  */
 type QueryResult = { data: unknown[] | null; error: { message: string } | null };
+type ChainableQuery = Promise<QueryResult> & {
+  select: jest.Mock;
+  order: jest.Mock;
+  gte: jest.Mock;
+  lte: jest.Mock;
+};
 
-function makeChainableQuery(result: QueryResult): unknown {
+function makeChainableQuery(result: QueryResult): ChainableQuery {
   // Promise を継承しつつメソッドチェーンも可能にする
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const p = Promise.resolve(result) as any;
-  for (const m of ["select", "order", "gte", "lte"]) {
+  const p = Promise.resolve(result) as ChainableQuery;
+  for (const m of ["select", "order", "gte", "lte"] as const) {
     p[m] = jest.fn().mockReturnValue(p);
   }
   return p;
@@ -170,14 +175,51 @@ const SAMPLE_LOG = {
   leg_flag: null,
 };
 
-describe("GET /api/export — daily_logs CSV", () => {
+const SAMPLE_GOOGLE_HEALTH_METRIC = {
+  metric_date: "2026-04-01",
+  step_count: 12345,
+  sleep_minutes: 450,
+  deep_sleep_minutes: 63,
+  sleep_bed_at: "2026-03-31T15:00:00Z",
+  sleep_wake_at: "2026-03-31T22:30:00Z",
+  hrv_ms: 128.8,
+  rhr_bpm: 43,
+  google_health_steps_source: "reconcile",
+  synced_at: "2026-04-02T00:00:00Z",
+};
+
+function parseCsv(csv: string): Array<Record<string, string>> {
+  const lines = csv.split("\n");
+  const headers = lines[0]!.split(",");
+  return lines.slice(1).filter(Boolean).map((line) => {
+    const values = line.split(",");
+    return Object.fromEntries(headers.map((header, i) => [header, values[i] ?? ""]));
+  });
+}
+
+describe("GET /api/export — daily_logs + Google Health CSV", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it("旧歩数・睡眠・断食列を含まず daily_logs CSV を返す", async () => {
-    const dailyLogsQuery = makeChainableQuery({ data: [SAMPLE_LOG], error: null });
-    const from = jest.fn(() => dailyLogsQuery);
+  it("日次ログと Google Health metrics を日付でマージして CSV を返す", async () => {
+    const dailyLogsQuery = makeChainableQuery({
+      data: [
+        SAMPLE_LOG,
+        { ...SAMPLE_LOG, log_date: "2026-04-02", weight: 70.2 },
+      ],
+      error: null,
+    });
+    const googleHealthQuery = makeChainableQuery({
+      data: [
+        SAMPLE_GOOGLE_HEALTH_METRIC,
+        { ...SAMPLE_GOOGLE_HEALTH_METRIC, metric_date: "2026-04-03", step_count: 9876 },
+      ],
+      error: null,
+    });
+    const from = jest.fn((table: string) =>
+      table === "daily_logs" ? dailyLogsQuery : googleHealthQuery
+    );
 
     mockCreateClient.mockReturnValue({
       from,
@@ -189,17 +231,62 @@ describe("GET /api/export — daily_logs CSV", () => {
     const lines = csv.split("\n");
 
     expect(from).toHaveBeenCalledWith("daily_logs");
+    expect(from).toHaveBeenCalledWith("google_health_daily_metrics");
     expect(lines[0]).toBe(
       "log_date,weight,calories,protein,fat,carbs,note," +
       "is_cheat_day,is_refeed_day,is_eating_out,is_travel_day," +
       "is_tanning_day,is_posing_day," +
-      "had_bowel_movement,training_type,work_mode,leg_flag",
+      "had_bowel_movement,training_type,work_mode,leg_flag," +
+      "google_health_step_count,google_health_sleep_minutes,google_health_deep_sleep_minutes," +
+      "google_health_sleep_bed_at,google_health_sleep_wake_at,google_health_hrv_ms," +
+      "google_health_rhr_bpm,google_health_steps_source,google_health_synced_at",
     );
     expect(lines[0]).not.toContain("sleep_hours");
     expect(lines[0]).not.toContain("sleep_bed_time");
     expect(lines[0]).not.toContain("sleep_wake_time");
     expect(lines[0]).not.toContain("last_meal_end_time");
-    expect(lines[0]).not.toContain("step_count");
-    expect(lines[1]).toContain("2026-04-01");
+    expect(lines[0]!.split(",")).not.toContain("step_count");
+
+    const rows = parseCsv(csv);
+    expect(rows.map((row) => row.log_date)).toEqual([
+      "2026-04-01",
+      "2026-04-02",
+      "2026-04-03",
+    ]);
+
+    expect(rows[0]!.weight).toBe("70");
+    expect(rows[0]!.google_health_step_count).toBe("12345");
+    expect(rows[0]!.google_health_sleep_minutes).toBe("450");
+    expect(rows[0]!.google_health_hrv_ms).toBe("128.8");
+    expect(rows[0]!.google_health_rhr_bpm).toBe("43");
+    expect(rows[0]!.google_health_steps_source).toBe("reconcile");
+
+    expect(rows[1]!.weight).toBe("70.2");
+    expect(rows[1]!.google_health_step_count).toBe("");
+
+    expect(rows[2]!.weight).toBe("");
+    expect(rows[2]!.google_health_step_count).toBe("9876");
+  });
+
+  it("start / end は daily_logs と Google Health metrics の両方に適用される", async () => {
+    const dailyLogsQuery = makeChainableQuery({ data: [], error: null });
+    const googleHealthQuery = makeChainableQuery({ data: [], error: null });
+    const from = jest.fn((table: string) =>
+      table === "daily_logs" ? dailyLogsQuery : googleHealthQuery
+    );
+
+    mockCreateClient.mockReturnValue({ from });
+
+    const res = await GET(makeRequest({
+      table: "daily_logs",
+      start: "2026-04-01",
+      end: "2026-04-30",
+    }));
+
+    expect(res.status).toBe(200);
+    expect(dailyLogsQuery.gte).toHaveBeenCalledWith("log_date", "2026-04-01");
+    expect(dailyLogsQuery.lte).toHaveBeenCalledWith("log_date", "2026-04-30");
+    expect(googleHealthQuery.gte).toHaveBeenCalledWith("metric_date", "2026-04-01");
+    expect(googleHealthQuery.lte).toHaveBeenCalledWith("metric_date", "2026-04-30");
   });
 });

--- a/src/app/api/export/route.ts
+++ b/src/app/api/export/route.ts
@@ -14,6 +14,51 @@ import { isValidDateParam } from "@/lib/utils/date";
 
 const ALLOWED_TABLES = ["daily_logs", "food_master", "predictions"] as const;
 
+const DAILY_LOG_EXPORT_COLUMNS = [
+  "log_date", "weight", "calories", "protein", "fat", "carbs", "note",
+  "is_cheat_day", "is_refeed_day", "is_eating_out", "is_travel_day",
+  "is_tanning_day", "is_posing_day",
+  "had_bowel_movement", "training_type", "work_mode", "leg_flag",
+];
+
+const GOOGLE_HEALTH_EXPORT_COLUMNS = [
+  "google_health_step_count",
+  "google_health_sleep_minutes",
+  "google_health_deep_sleep_minutes",
+  "google_health_sleep_bed_at",
+  "google_health_sleep_wake_at",
+  "google_health_hrv_ms",
+  "google_health_rhr_bpm",
+  "google_health_steps_source",
+  "google_health_synced_at",
+];
+
+const GOOGLE_HEALTH_SELECT_COLUMNS = [
+  "metric_date",
+  "step_count",
+  "sleep_minutes",
+  "deep_sleep_minutes",
+  "sleep_bed_at",
+  "sleep_wake_at",
+  "hrv_ms",
+  "rhr_bpm",
+  "google_health_steps_source",
+  "synced_at",
+];
+
+type GoogleHealthExportRow = {
+  metric_date: string;
+  step_count: number | null;
+  sleep_minutes: number | null;
+  deep_sleep_minutes: number | null;
+  sleep_bed_at: string | null;
+  sleep_wake_at: string | null;
+  hrv_ms: number | null;
+  rhr_bpm: number | null;
+  google_health_steps_source: string | null;
+  synced_at: string | null;
+};
+
 function toCSV(rows: Record<string, unknown>[], columns: string[]): string {
   const header = columns.join(",");
   const body = rows.map((row) =>
@@ -56,21 +101,57 @@ export async function GET(req: NextRequest) {
   const supabase = await createClient();
 
   if (table === "daily_logs") {
-    // CSV エクスポートのため全列 select("*") が必要。
+    // CSV エクスポート専用に daily_logs と Google Health 日次メトリクスを日付でマージする。
     // front SSR 用 projection query (src/lib/queries/dailyLogs.ts) とは異なる経路。
-    let query = supabase.from("daily_logs").select("*").order("log_date", { ascending: true });
-    if (start) query = query.gte("log_date", start);
-    if (end) query = query.lte("log_date", end);
-    const { data, error } = await query;
-    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    let dailyLogsQuery = supabase
+      .from("daily_logs")
+      .select(DAILY_LOG_EXPORT_COLUMNS.join(","))
+      .order("log_date", { ascending: true });
+    if (start) dailyLogsQuery = dailyLogsQuery.gte("log_date", start);
+    if (end) dailyLogsQuery = dailyLogsQuery.lte("log_date", end);
 
-    const columns = [
-      "log_date", "weight", "calories", "protein", "fat", "carbs", "note",
-      "is_cheat_day", "is_refeed_day", "is_eating_out", "is_travel_day",
-      "is_tanning_day", "is_posing_day",
-      "had_bowel_movement", "training_type", "work_mode", "leg_flag",
-    ];
-    const csv = toCSV((data ?? []) as Record<string, unknown>[], columns);
+    let googleHealthQuery = supabase
+      .from("google_health_daily_metrics")
+      .select(GOOGLE_HEALTH_SELECT_COLUMNS.join(","))
+      .order("metric_date", { ascending: true });
+    if (start) googleHealthQuery = googleHealthQuery.gte("metric_date", start);
+    if (end) googleHealthQuery = googleHealthQuery.lte("metric_date", end);
+
+    const [
+      { data: dailyLogsData, error: dailyLogsError },
+      { data: googleHealthData, error: googleHealthError },
+    ] = await Promise.all([dailyLogsQuery, googleHealthQuery]);
+    if (dailyLogsError) return NextResponse.json({ error: dailyLogsError.message }, { status: 500 });
+    if (googleHealthError) return NextResponse.json({ error: googleHealthError.message }, { status: 500 });
+
+    const rowsByDate = new Map<string, Record<string, unknown>>();
+    for (const rawLog of ((dailyLogsData ?? []) as unknown as Record<string, unknown>[])) {
+      const logDate = rawLog.log_date;
+      if (typeof logDate !== "string") continue;
+      rowsByDate.set(logDate, { ...rawLog, log_date: logDate });
+    }
+
+    for (const metric of ((googleHealthData ?? []) as unknown as GoogleHealthExportRow[])) {
+      const metricDate = metric.metric_date;
+      if (typeof metricDate !== "string") continue;
+      const row = rowsByDate.get(metricDate) ?? { log_date: metricDate };
+      row.google_health_step_count = metric.step_count;
+      row.google_health_sleep_minutes = metric.sleep_minutes;
+      row.google_health_deep_sleep_minutes = metric.deep_sleep_minutes;
+      row.google_health_sleep_bed_at = metric.sleep_bed_at;
+      row.google_health_sleep_wake_at = metric.sleep_wake_at;
+      row.google_health_hrv_ms = metric.hrv_ms;
+      row.google_health_rhr_bpm = metric.rhr_bpm;
+      row.google_health_steps_source = metric.google_health_steps_source;
+      row.google_health_synced_at = metric.synced_at;
+      rowsByDate.set(metricDate, row);
+    }
+
+    const columns = [...DAILY_LOG_EXPORT_COLUMNS, ...GOOGLE_HEALTH_EXPORT_COLUMNS];
+    const rows = Array.from(rowsByDate.values()).sort((a, b) =>
+      String(a.log_date).localeCompare(String(b.log_date))
+    );
+    const csv = toCSV(rows, columns);
     const filename = `bodymake_log_${start || "all"}_${end || "all"}.csv`;
 
     return new NextResponse(csv, {

--- a/src/components/settings/ExportSection.tsx
+++ b/src/components/settings/ExportSection.tsx
@@ -33,7 +33,7 @@ export function ExportSection() {
 
       {/* 日次ログ */}
       <div className="space-y-3">
-        <p className="text-sm font-medium text-gray-600 dark:text-slate-300">日次ログ（daily_logs）</p>
+        <p className="text-sm font-medium text-gray-600 dark:text-slate-300">日次ログ + Google Health</p>
         <div className="flex flex-wrap items-end gap-3">
           <div>
             <label className="mb-1 block text-xs font-medium text-gray-500 dark:text-slate-400">開始日</label>
@@ -62,6 +62,7 @@ export function ExportSection() {
           </button>
         </div>
         <p className="text-xs text-gray-400 dark:text-slate-500">
+          体重・食事・行動ログに Google Health の歩数・睡眠・HRV・安静時心拍数を結合して出力します。
           ファイル名: bodymake_log_{start}_{end}.csv
         </p>
       </div>


### PR DESCRIPTION
## 概要
#711 の対応として、日次ログ CSV export に Google Health 日次メトリクスを日付で結合して出力するようにしました。

## 変更内容
- `/api/export?table=daily_logs` で `daily_logs.log_date` と `google_health_daily_metrics.metric_date` をキーにマージ
- daily_logs のみ、Google Health のみ、両方ありの日をすべて 1 日 1 行で出力
- Google Health カラムを `google_health_*` prefix で CSV 後方に追加
- `start` / `end` を daily_logs と Google Health metrics の両方に適用
- 設定画面の export 文言を「日次ログ + Google Health」に更新
- export route test をマージ仕様に合わせて更新

## 出力追加カラム
- `google_health_step_count`
- `google_health_sleep_minutes`
- `google_health_deep_sleep_minutes`
- `google_health_sleep_bed_at`
- `google_health_sleep_wake_at`
- `google_health_hrv_ms`
- `google_health_rhr_bpm`
- `google_health_steps_source`
- `google_health_synced_at`

## 判断理由
- Google Health のみ存在する日も export から落とさないため、daily_logs と Google Health metrics の union 日付で行を作成しています。
- 表示用変換は行わず、DB 値をそのまま CSV に出すことで import / 分析用途で扱いやすくしています。

## 検証結果
- `npx tsc --noEmit`
- `npm test -- --runInBand src/app/api/export/route.test.ts`
- `npm run lint`
- `npm run build`

Closes #711