### PR TITLE
目標達成ナビの月次計画警告表示を改善する

### DIFF
--- a/src/components/dashboard/GoalNavigator.tsx
+++ b/src/components/dashboard/GoalNavigator.tsx
@@ -564,9 +564,11 @@ export function GoalNavigator({
               </span>
             )}
 
-            {/* 警告あり補足 */}
-            {monthlyGoalProgress.hasWarnings && (
-              <span className="text-[10px] text-amber-600">⚠ 計画に警告あり</span>
+            {/* 月次計画の注意補足 */}
+            {monthlyGoalProgress.dashboardWarningLabel && (
+              <span className="text-[10px] text-amber-600">
+                {monthlyGoalProgress.dashboardWarningLabel}
+              </span>
             )}
           </div>
         </div>

--- a/src/lib/utils/calcMonthlyGoalProgress.test.ts
+++ b/src/lib/utils/calcMonthlyGoalProgress.test.ts
@@ -14,6 +14,7 @@ import {
   calcMonthlyGoalProgress,
   getMonthEndDate,
   calcDaysToMonthEnd,
+  getDashboardMonthlyGoalWarningLabel,
   MONTHLY_ON_TRACK_PACE_KG_WEEK,
   MONTHLY_REPLAN_PACE_KG_WEEK,
 } from "./calcMonthlyGoalProgress";
@@ -338,10 +339,112 @@ describe("calcMonthlyGoalProgress — 月末当日 (daysToMonthEnd = 0)", () => 
   });
 });
 
-// ─── calcMonthlyGoalProgress — hasWarnings ───────────────────────────────────
+// ─── getDashboardMonthlyGoalWarningLabel ─────────────────────────────────────
 
-describe("calcMonthlyGoalProgress — hasWarnings", () => {
-  it("contestDate が今月末 → DEADLINE_TOO_CLOSE 警告あり → hasWarnings: true", () => {
+describe("getDashboardMonthlyGoalWarningLabel", () => {
+  const today = "2026-07-15";
+
+  it("表示対象 warning がなければ null", () => {
+    expect(getDashboardMonthlyGoalWarningLabel([], today)).toBeNull();
+  });
+
+  it("ALREADY_AT_GOAL のみでは表示しない", () => {
+    expect(
+      getDashboardMonthlyGoalWarningLabel([{ code: "ALREADY_AT_GOAL" }], today)
+    ).toBeNull();
+  });
+
+  it("MANUAL_GOAL_MISMATCH のみでは表示しない", () => {
+    expect(
+      getDashboardMonthlyGoalWarningLabel(
+        [{ code: "MANUAL_GOAL_MISMATCH" }],
+        today
+      )
+    ).toBeNull();
+  });
+
+  it("DEADLINE_TOO_CLOSE は表示する", () => {
+    expect(
+      getDashboardMonthlyGoalWarningLabel(
+        [{ code: "DEADLINE_TOO_CLOSE" }],
+        today
+      )
+    ).toBe("⚠ 期限まで残り1ヶ月以下");
+  });
+
+  it("過去月の HIGH_MONTHLY_DELTA は表示しない", () => {
+    expect(
+      getDashboardMonthlyGoalWarningLabel(
+        [
+          {
+            code: "HIGH_MONTHLY_DELTA",
+            month: "2026-06",
+            value: 2.5,
+            threshold: 2.0,
+          },
+        ],
+        today
+      )
+    ).toBeNull();
+  });
+
+  it("当月以降の HIGH_MONTHLY_DELTA は表示する", () => {
+    expect(
+      getDashboardMonthlyGoalWarningLabel(
+        [
+          {
+            code: "HIGH_MONTHLY_DELTA",
+            month: "2026-07",
+            value: 2.5,
+            threshold: 2.0,
+          },
+        ],
+        today
+      )
+    ).toBe("⚠ 月間目標変化量が大きい");
+  });
+
+  it("過去月の WRONG_DIRECTION は表示しない", () => {
+    expect(
+      getDashboardMonthlyGoalWarningLabel(
+        [{ code: "WRONG_DIRECTION", month: "2026-06" }],
+        today
+      )
+    ).toBeNull();
+  });
+
+  it("当月以降の WRONG_DIRECTION は表示する", () => {
+    expect(
+      getDashboardMonthlyGoalWarningLabel(
+        [{ code: "WRONG_DIRECTION", month: "2026-08" }],
+        today
+      )
+    ).toBe("⚠ 月次目標の方向を確認");
+  });
+
+  it("複数 warning では WRONG_DIRECTION を最優先する", () => {
+    expect(
+      getDashboardMonthlyGoalWarningLabel(
+        [
+          { code: "DEADLINE_TOO_CLOSE" },
+          {
+            code: "HIGH_MONTHLY_DELTA",
+            month: "2026-07",
+            value: 2.5,
+            threshold: 2.0,
+          },
+          { code: "WRONG_DIRECTION", month: "2026-07" },
+        ],
+        today
+      )
+    ).toBe("⚠ 月次目標の方向を確認");
+  });
+});
+
+// ─── calcMonthlyGoalProgress — dashboard warning ─────────────────────────────
+
+describe("calcMonthlyGoalProgress — dashboard warning", () => {
+  it("contestDate が今月末 → DEADLINE_TOO_CLOSE → dashboard warning 表示", () => {
     const result = calcMonthlyGoalProgress({
       contestDate: "2026-07-31",
       targetWeight: 73.8,
@@ -353,9 +456,26 @@ describe("calcMonthlyGoalProgress — hasWarnings", () => {
       phase: "Cut",
     });
     expect(result.hasWarnings).toBe(true);
+    expect(result.dashboardWarningLabel).toBe("⚠ 期限まで残り1ヶ月以下");
   });
 
-  it("余裕のある計画 → hasWarnings: false", () => {
+  it("ALREADY_AT_GOAL のみなら dashboard warning は表示しない", () => {
+    const result = calcMonthlyGoalProgress({
+      contestDate: "2026-12-31",
+      targetWeight: 75.0,
+      monthlyPlanStartMonth: null,
+      monthlyPlanStartWeight: null,
+      monthlyPlanOverrides: null,
+      comparisonWeight: 75.0,
+      today: "2026-07-15",
+      phase: "Cut",
+    });
+    expect(result.state).toBe("achieved");
+    expect(result.hasWarnings).toBe(false);
+    expect(result.dashboardWarningLabel).toBeNull();
+  });
+
+  it("余裕のある計画 → dashboard warning なし", () => {
     // 6ヶ月, 月間変化 ≈ -0.33 kg → 警告なし
     const result = calcMonthlyGoalProgress({
       contestDate: "2026-12-31",
@@ -368,6 +488,7 @@ describe("calcMonthlyGoalProgress — hasWarnings", () => {
       phase: "Cut",
     });
     expect(result.hasWarnings).toBe(false);
+    expect(result.dashboardWarningLabel).toBeNull();
   });
 });
 

--- a/src/lib/utils/calcMonthlyGoalProgress.ts
+++ b/src/lib/utils/calcMonthlyGoalProgress.ts
@@ -13,7 +13,7 @@ import {
   buildMonthlyGoalPlan,
   MAX_SAFE_MONTHLY_DELTA_KG,
 } from "@/lib/utils/monthlyGoalPlan";
-import type { MonthlyGoalOverride } from "@/lib/utils/monthlyGoalPlan";
+import type { MonthlyGoalOverride, MonthlyGoalWarning } from "@/lib/utils/monthlyGoalPlan";
 import { calcDaysLeft } from "@/lib/utils/date";
 import { resolveMonthlyPlanHistoryAnchor } from "@/lib/utils/monthlyPlanHistory";
 
@@ -80,8 +80,10 @@ export interface MonthlyGoalProgress {
   requiredPaceKgPerWeek: number | null;
   /** 状態判定 */
   state: MonthlyProgressState;
-  /** 今月の計画に warning が 1 件以上あるか */
+  /** Dashboard に表示すべき月次計画 warning があるか */
   hasWarnings: boolean;
+  /** Dashboard に表示する月次計画 warning 文言。表示対象がなければ null */
+  dashboardWarningLabel: string | null;
 }
 
 // ─── プライベートヘルパー ─────────────────────────────────────────────────────
@@ -144,6 +146,43 @@ function calcMonthlyProgressState(
   return "replan_recommended";
 }
 
+/**
+ * Dashboard の「今月目標進捗」に出す warning 文言を返す。
+ *
+ * 設定画面は詳細確認用として全 warning を表示するが、Dashboard では
+ * 当月以降の再計画・確認につながるものだけを 1 件に絞って表示する。
+ */
+export function getDashboardMonthlyGoalWarningLabel(
+  warnings: MonthlyGoalWarning[],
+  today: string
+): string | null {
+  const todayMonth = today.slice(0, 7);
+  const appliesToCurrentOrFutureMonth = (w: MonthlyGoalWarning): boolean =>
+    typeof w.month === "string" && w.month >= todayMonth;
+
+  if (
+    warnings.some(
+      (w) => w.code === "WRONG_DIRECTION" && appliesToCurrentOrFutureMonth(w)
+    )
+  ) {
+    return "⚠ 月次目標の方向を確認";
+  }
+
+  if (
+    warnings.some(
+      (w) => w.code === "HIGH_MONTHLY_DELTA" && appliesToCurrentOrFutureMonth(w)
+    )
+  ) {
+    return "⚠ 月間目標変化量が大きい";
+  }
+
+  if (warnings.some((w) => w.code === "DEADLINE_TOO_CLOSE")) {
+    return "⚠ 期限まで残り1ヶ月以下";
+  }
+
+  return null;
+}
+
 // ─── メイン計算関数 ──────────────────────────────────────────────────────────
 
 /**
@@ -192,6 +231,7 @@ export function calcMonthlyGoalProgress(input: {
     requiredPaceKgPerWeek: null,
     state: "unavailable",
     hasWarnings: false,
+    dashboardWarningLabel: null,
   };
 
   // 前提条件チェック (いずれか欠損 → 計算不能)
@@ -254,6 +294,10 @@ export function calcMonthlyGoalProgress(input: {
 
   const isCut = phase !== "Bulk";
   const state = calcMonthlyProgressState(deltaKg, requiredPaceKgPerWeek, isCut);
+  const dashboardWarningLabel = getDashboardMonthlyGoalWarningLabel(
+    plan.warnings,
+    today
+  );
 
   return {
     hasData: true,
@@ -264,6 +308,7 @@ export function calcMonthlyGoalProgress(input: {
     weeksToMonthEnd,
     requiredPaceKgPerWeek,
     state,
-    hasWarnings: plan.warnings.length > 0,
+    hasWarnings: dashboardWarningLabel !== null,
+    dashboardWarningLabel,
   };
 }


### PR DESCRIPTION
## 概要

目標達成ナビの「今月目標進捗」に表示される月次計画 warning を、ダッシュボードで注意喚起すべき内容に絞りました。

Closes #716

## 変更内容

- `calcMonthlyGoalProgress` に dashboard 表示用 warning label の判定を追加
- `GoalNavigator` を固定文言の `⚠ 計画に警告あり` から、具体的な warning label 表示へ変更
- `ALREADY_AT_GOAL` / `MANUAL_GOAL_MISMATCH` を dashboard 警告表示対象外に変更
- `HIGH_MONTHLY_DELTA` / `WRONG_DIRECTION` は当月以降の warning のみ dashboard 表示対象に変更
- warning 優先順位と表示対象外ケースの unit test を追加

## 判断理由

現在の `plan.warnings.length > 0` では、目標達成済みのような悪い状態ではない warning でも `⚠ 計画に警告あり` と表示され、ユーザーに誤解を与えやすいためです。

設定画面は詳細 warning を確認する場所として全 warning 表示を維持し、ダッシュボードでは今月以降の再計画・確認につながる warning だけを表示する方針にしました。

## 検証結果

- `npm test -- --runInBand src/lib/utils/calcMonthlyGoalProgress.test.ts`
- `npx tsc --noEmit`
- `npm run lint`

すべて成功しています。

## 補足

月次計画の生成ロジック、設定画面の warning 表示、月別サマリーの判定ロジックは変更していません。