### PR TITLE
ML Actions の依存インストールを CPU PyTorch 前提にする

### DIFF
--- a/.github/workflows/ml-backtest.yml
+++ b/.github/workflows/ml-backtest.yml
@@ -55,10 +55,12 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.11"
-          cache: pip
+
+      - name: Install PyTorch CPU
+        run: python -m pip install --no-cache-dir torch==2.6.0 --index-url https://download.pytorch.org/whl/cpu
 
       - name: Install dependencies
-        run: pip install -r ml-pipeline/requirements.txt
+        run: python -m pip install --no-cache-dir -r ml-pipeline/requirements-actions.txt
 
       # workflow_dispatch 時のみ追加 CLI 引数を組み立てる。
       # schedule 実行時は github.event_name == "schedule" のため EXTRA_ARGS は空になり、

--- a/.github/workflows/ml-daily.yml
+++ b/.github/workflows/ml-daily.yml
@@ -25,10 +25,12 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.11"
-          cache: pip
+
+      - name: Install PyTorch CPU
+        run: python -m pip install --no-cache-dir torch==2.6.0 --index-url https://download.pytorch.org/whl/cpu
 
       - name: Install dependencies
-        run: pip install -r ml-pipeline/requirements.txt
+        run: python -m pip install --no-cache-dir -r ml-pipeline/requirements-actions.txt
 
       - name: Run enrich
         run: python ml-pipeline/enrich.py

--- a/ml-pipeline/requirements-actions.txt
+++ b/ml-pipeline/requirements-actions.txt
@@ -1,0 +1,9 @@
+# Runtime dependencies for GitHub Actions ML workflows.
+# PyTorch is installed separately from the official CPU wheel index.
+neuralprophet==0.9.*
+xgboost==2.*
+scikit-learn>=1.3
+pandas==2.*
+numpy==1.*
+supabase==2.*
+python-dotenv==1.*


### PR DESCRIPTION
## 概要
ML Daily Batch が依存インストール中に runner のディスク容量を使い切る問題に対応します。

## 変更内容
- ML Actions 専用の `ml-pipeline/requirements-actions.txt` を追加
- `ml-daily.yml` / `ml-backtest.yml` で pip cache を使わないように変更
- PyTorch を公式 CPU wheel index から `torch==2.6.0` として先にインストール
- その後、Actions 専用 requirements を `--no-cache-dir` でインストール

## 判断理由
今回の失敗は ML スクリプト実行前の `pip install -r ml-pipeline/requirements.txt` で発生しており、`torch>=2.6` が CUDA / NVIDIA 系の巨大依存へ解決されたことと pip cache 復元が重なって、標準 runner の空き容量を使い切ったことが原因です。

汎用の `requirements.txt` は残し、GitHub Actions の Ubuntu runner だけを CPU PyTorch 前提にすることで、既存のローカル利用や ML 実行仕様への影響を最小化します。

なお、当初候補にした `xgboost-cpu` は現在 3.x 系のみで、既存の `xgboost==2.*` から major version が変わるため採用していません。

## 検証結果
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ml-daily.yml'); YAML.load_file('.github/workflows/ml-backtest.yml'); puts 'ok'"` 成功
- `/private/tmp/bct-actions-deps-venv/bin/python -m pip install --dry-run --no-cache-dir torch==2.6.0 --index-url https://download.pytorch.org/whl/cpu` 成功
- `/private/tmp/bct-actions-deps-venv/bin/python -m pip install --dry-run --no-cache-dir -r ml-pipeline/requirements-actions.txt` 成功
- `python3 -m pytest ml-pipeline/test_predict.py ml-pipeline/test_analyze.py ml-pipeline/test_enrich.py ml-pipeline/test_feature_registry.py ml-pipeline/test_backtest.py -q` 成功: 238 passed

## 補足
Actions 上の最終確認として、PR マージ後または workflow_dispatch で `ML Daily Batch` の `Install dependencies` が通ることを確認してください。

Closes #718