### PR TITLE
Google Health 同期ボタンの背景を記録ボタンと揃える

### DIFF
--- a/src/components/googleHealth/GoogleHealthSyncButton.integration.test.tsx
+++ b/src/components/googleHealth/GoogleHealthSyncButton.integration.test.tsx
@@ -110,7 +110,11 @@ describe("GoogleHealthSyncButton", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Google Health 同期" }));
+    const syncButton = screen.getByRole("button", { name: "Google Health 同期" });
+    expect(syncButton).toHaveClass("bg-white", "border-slate-100", "text-slate-700");
+    expect(syncButton).not.toHaveClass("bg-blue-600");
+
+    fireEvent.click(syncButton);
 
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/google-health/daily-metrics?start=2026-06-01&end=2026-06-07",

--- a/src/components/googleHealth/GoogleHealthSyncButton.tsx
+++ b/src/components/googleHealth/GoogleHealthSyncButton.tsx
@@ -206,9 +206,9 @@ export function GoogleHealthSyncButton({ initialStatus }: GoogleHealthSyncButton
           type="button"
           onClick={syncNow}
           disabled={syncing}
-          className={`${buttonClassName} border-blue-500 bg-blue-600 text-white hover:bg-blue-700 hover:shadow-md dark:border-blue-500 dark:bg-blue-500 dark:hover:bg-blue-400`}
+          className={`${buttonClassName} border-slate-100 bg-white text-slate-700 hover:bg-slate-50 hover:shadow-md dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:shadow-none dark:hover:bg-slate-800/60`}
         >
-          <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-white/15">
+          <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-blue-50 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400">
             {syncing ? (
               <Loader2 size={15} className="animate-spin" aria-hidden="true" />
             ) : (


### PR DESCRIPTION
## 概要
ダッシュボードの Google Health 同期ボタンの通常時背景を、「食事・体重を記録する」ボタンと同じ白背景のスタイルに揃えました。

## 変更内容
- 連携済み状態の Google Health 同期ボタンを青背景から白背景へ変更
- border、text、hover、dark mode の背景を記録ボタンと同系統に調整
- アイコンは青アクセントを残し、同期ボタンであることは判別できるように維持
- connected 状態が青背景に戻らないよう integration test に class assertion を追加

## 判断理由
- ダッシュボード上部の主要アクション内で同期ボタンだけが常時青く強調されすぎていたため
- 同期処理や接続状態の仕様は変えず、見た目の一貫性だけを調整するため

## 検証結果
- `npm test -- --runTestsByPath src/components/googleHealth/GoogleHealthSyncButton.integration.test.tsx src/components/dashboard/DashboardQuickActions.integration.test.tsx`
- `npx tsc --noEmit`
- `npm run lint`
- `git diff --check`

Closes #726