### PR TITLE
食事記録を明細保存できるようにする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,7 @@ body-comp-tracker-v2/
   - `is_cheat_day` / `is_refeed_day` / `is_eating_out` / `is_travel_day` / `is_tanning_day` / `is_posing_day` は
     `BOOLEAN NOT NULL DEFAULT FALSE`。特殊日フラグ。`dayTags.ts` の `DAY_TAGS` / `DAY_TAG_LABELS` / `DAY_TAG_BADGE_COLORS` が
     canonical 定義源。新フラグ追加時はこのファイルと migration・RPC・CSV・型定義・テスト fixture を同時更新する
+  - `calories` / `protein` / `fat` / `carbs` は食事明細 (`meal_items`) から同期される projection 値。既存画面・分析処理の互換性維持のため残す
   - `work_mode` の DB CHECK 制約は `off/office/remote/active/travel/other` の 6 値を許容するが、
     フロントエンド（`src/lib/utils/trainingType.ts`）では `off/office/remote` の 3 値のみ定義している。
     `active/travel/other` はフロント UI・CSV import・表示整形で現状扱われない（将来拡張余地）
@@ -162,6 +163,10 @@ body-comp-tracker-v2/
     残っている場合があるため、最新 migration を参照すること（#442 / #526 / #529 で発生した regression）**
 - `food_master` — name(PK), protein, fat, carbs, calories, category
 - `menu_master` — name(PK), recipe(JSONB)
+- `meal_entries` — id(UUID PK), user_id, log_date, meal_type, title, note, created_at, updated_at
+  - 1行 = 1食事単位。`meal_type` は `meal_1` / `meal_2` / `meal_3` / `meal_4` / `other`
+- `meal_items` — id(UUID PK), meal_entry_id, food_name, amount_g, calories_kcal, protein_g, fat_g, carbs_g, source_type, source_name
+  - 1行 = 1食品明細。食事記録の source of truth。INSERT/UPDATE/DELETE 後に `daily_logs` のカロリー/PFC projection を再計算する
 - `settings` — key(PK), value_num, value_str
 - `predictions` — id, ds(DATE), yhat(FLOAT), model_version(TEXT), created_at
 - `analytics_cache` — metric_type(PK), payload(JSONB), updated_at
@@ -197,7 +202,7 @@ body-comp-tracker-v2/
 ### RLS ポリシーの方針
 - 全テーブルに `ENABLE ROW LEVEL SECURITY` を適用する
 - anon ロールにはアプリデータの SELECT / INSERT / UPDATE / DELETE を許可しない
-- `daily_logs` / `sleep_sessions` / `settings` / `food_master` / `menu_master` は authenticated user の `user_id = auth.uid()` 行だけを許可する
+- `daily_logs` / `sleep_sessions` / `settings` / `food_master` / `menu_master` / `meal_entries` / `meal_items` は authenticated user の `user_id = auth.uid()` 行だけを許可する
 - `predictions` / `analytics_cache` / `career_logs` / `forecast_backtest_*` は authenticated SELECT のみ。書き込みは service_role の ML / analytics バッチが担当する
 - ポリシーはすべて `supabase/migrations/` で管理し、手動 Console 操作で追加しない
 

--- a/src/app/actions/mealEntries.ts
+++ b/src/app/actions/mealEntries.ts
@@ -1,0 +1,212 @@
+"use server";
+
+import { createClient, requireCurrentUser } from "@/lib/supabase/server";
+import { authRequiredMessage } from "@/lib/auth/actionErrors";
+import { revalidateAfterDailyLogMutation } from "@/lib/cache/revalidate";
+import { isMealType } from "@/lib/domain/meals";
+import { validateMealItemInput, type SaveMealItemInput } from "@/lib/domain/mealEntryPayload";
+import { parseLocalDateStr } from "@/lib/utils/date";
+import type { Database, MealType } from "@/lib/supabase/types";
+
+type MealEntryInsert = Database["public"]["Tables"]["meal_entries"]["Insert"];
+type MealItemInsert = Database["public"]["Tables"]["meal_items"]["Insert"];
+type MealItemUpdate = Database["public"]["Tables"]["meal_items"]["Update"];
+
+export type AddMealEntryInput = {
+  log_date: string;
+  meal_type: MealType;
+  items: SaveMealItemInput[];
+};
+
+export type UpdateMealItemInput = {
+  id: string;
+  amount_g?: number | null;
+  calories_kcal?: number | null;
+  protein_g?: number | null;
+  fat_g?: number | null;
+  carbs_g?: number | null;
+};
+
+export type MealActionResult =
+  | { ok: true }
+  | { ok: false; message: string; reason?: "auth_required" };
+
+function validateUpdateNumber(value: number | null | undefined): number | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  return Number.isFinite(value) && value >= 0 ? value : Number.NaN;
+}
+
+async function requireUserForMealAction(): Promise<
+  | { ok: true; userId: string }
+  | { ok: false; message: string; reason: "auth_required" }
+> {
+  try {
+    const user = await requireCurrentUser();
+    return { ok: true, userId: user.id };
+  } catch (error) {
+    const message = authRequiredMessage(error);
+    if (message) return { ok: false, message, reason: "auth_required" };
+    throw error;
+  }
+}
+
+export async function addMealEntry(input: AddMealEntryInput): Promise<MealActionResult> {
+  if (parseLocalDateStr(input.log_date) === null) {
+    return { ok: false, message: "日付の形式が正しくありません" };
+  }
+  if (!isMealType(input.meal_type)) {
+    return { ok: false, message: "食事区分が不正です" };
+  }
+  if (input.items.length === 0) {
+    return { ok: false, message: "食事明細がありません" };
+  }
+
+  const itemRows: MealItemInsert[] = [];
+  for (const item of input.items) {
+    const validated = validateMealItemInput(item);
+    if ("error" in validated) return { ok: false, message: validated.error };
+    itemRows.push(validated);
+  }
+
+  const auth = await requireUserForMealAction();
+  if (!auth.ok) return { ok: false, message: auth.message, reason: auth.reason };
+
+  const supabase = await createClient();
+
+  const { data: existingLogs, error: dailyLogError } = await supabase
+    .from("daily_logs")
+    .select("log_date")
+    .eq("user_id", auth.userId)
+    .eq("log_date", input.log_date)
+    .limit(1);
+
+  if (dailyLogError) {
+    return { ok: false, message: "日次ログの確認に失敗しました: " + dailyLogError.message };
+  }
+  if ((existingLogs ?? []).length === 0) {
+    return { ok: false, message: "新しい日付に食事を追加するには先に体重を保存してください" };
+  }
+
+  const entryPayload: MealEntryInsert = {
+    user_id: auth.userId,
+    log_date: input.log_date,
+    meal_type: input.meal_type,
+  };
+
+  const { data: entry, error: entryError } = await supabase
+    .from("meal_entries")
+    .insert(entryPayload)
+    .select("id")
+    .single();
+
+  if (entryError || !entry) {
+    return { ok: false, message: "食事の作成に失敗しました: " + (entryError?.message ?? "unknown error") };
+  }
+
+  const rows = itemRows.map((row, index) => ({
+    ...row,
+    user_id: auth.userId,
+    meal_entry_id: entry.id,
+    item_order: index,
+  }));
+
+  const { error: itemError } = await supabase.from("meal_items").insert(rows);
+  if (itemError) {
+    await supabase
+      .from("meal_entries")
+      .delete()
+      .eq("user_id", auth.userId)
+      .eq("id", entry.id);
+    return { ok: false, message: "食事明細の保存に失敗しました: " + itemError.message };
+  }
+
+  revalidateAfterDailyLogMutation();
+  return { ok: true };
+}
+
+export async function updateMealItem(input: UpdateMealItemInput): Promise<MealActionResult> {
+  if (input.id.trim() === "") {
+    return { ok: false, message: "食事明細IDが不正です" };
+  }
+
+  const payload: MealItemUpdate = {};
+  for (const key of ["amount_g", "calories_kcal", "protein_g", "fat_g", "carbs_g"] as const) {
+    const value = validateUpdateNumber(input[key]);
+    if (Number.isNaN(value)) {
+      return { ok: false, message: "食事明細の数値は0以上で入力してください" };
+    }
+    if (value !== undefined) payload[key] = value;
+  }
+
+  if (Object.keys(payload).length === 0) {
+    return { ok: false, message: "更新するデータがありません" };
+  }
+
+  const auth = await requireUserForMealAction();
+  if (!auth.ok) return { ok: false, message: auth.message, reason: auth.reason };
+
+  const supabase = await createClient();
+  const { error } = await supabase
+    .from("meal_items")
+    .update(payload)
+    .eq("user_id", auth.userId)
+    .eq("id", input.id);
+
+  if (error) {
+    return { ok: false, message: "食事明細の更新に失敗しました: " + error.message };
+  }
+
+  revalidateAfterDailyLogMutation();
+  return { ok: true };
+}
+
+export async function deleteMealItem(id: string): Promise<MealActionResult> {
+  if (id.trim() === "") {
+    return { ok: false, message: "食事明細IDが不正です" };
+  }
+
+  const auth = await requireUserForMealAction();
+  if (!auth.ok) return { ok: false, message: auth.message, reason: auth.reason };
+
+  const supabase = await createClient();
+  const { data: deletedRows, error } = await supabase
+    .from("meal_items")
+    .delete()
+    .eq("user_id", auth.userId)
+    .eq("id", id)
+    .select("meal_entry_id");
+
+  if (error) {
+    return { ok: false, message: "食事明細の削除に失敗しました: " + error.message };
+  }
+
+  const mealEntryId = deletedRows?.[0]?.meal_entry_id;
+  if (mealEntryId) {
+    const { data: remainingItems, error: remainingError } = await supabase
+      .from("meal_items")
+      .select("id")
+      .eq("user_id", auth.userId)
+      .eq("meal_entry_id", mealEntryId)
+      .limit(1);
+
+    if (remainingError) {
+      return { ok: false, message: "食事明細の削除後確認に失敗しました: " + remainingError.message };
+    }
+
+    if ((remainingItems ?? []).length === 0) {
+      const { error: entryDeleteError } = await supabase
+        .from("meal_entries")
+        .delete()
+        .eq("user_id", auth.userId)
+        .eq("id", mealEntryId);
+
+      if (entryDeleteError) {
+        return { ok: false, message: "空の食事記録の削除に失敗しました: " + entryDeleteError.message };
+      }
+    }
+  }
+
+  revalidateAfterDailyLogMutation();
+  return { ok: true };
+}

--- a/src/app/api/client-data/route.test.ts
+++ b/src/app/api/client-data/route.test.ts
@@ -108,6 +108,53 @@ describe("GET /api/client-data", () => {
     expect(response.status).toBe(400);
   });
 
+  it("fetches meal entries with items for a date", async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: "user-id", email: "owner@example.com" });
+
+    const entriesOrder = jest.fn().mockReturnValue(queryResult([
+      { id: "entry-1", user_id: "user-id", log_date: "2024-01-01", meal_type: "meal_1" },
+    ]));
+    const entriesEqLogDate = jest.fn().mockReturnValue({ order: entriesOrder });
+    const entriesEqUser = jest.fn().mockReturnValue({ eq: entriesEqLogDate });
+    const entriesSelect = jest.fn().mockReturnValue({ eq: entriesEqUser });
+
+    const itemsOrder = jest.fn().mockReturnValue(queryResult([
+      { id: "item-1", user_id: "user-id", meal_entry_id: "entry-1", food_name: "chicken", item_order: 0 },
+    ]));
+    const itemsIn = jest.fn().mockReturnValue({ order: itemsOrder });
+    const itemsEq = jest.fn().mockReturnValue({ in: itemsIn });
+    const itemsSelect = jest.fn().mockReturnValue({ eq: itemsEq });
+
+    const from = jest.fn((table: string) => {
+      if (table === "meal_entries") return { select: entriesSelect };
+      if (table === "meal_items") return { select: itemsSelect };
+      return { select: jest.fn() };
+    });
+    mockCreateClient.mockResolvedValue({ from });
+
+    const response = await GET(makeRequest({ resource: "meal_entries", date: "2024-01-01" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(from).toHaveBeenCalledWith("meal_entries");
+    expect(from).toHaveBeenCalledWith("meal_items");
+    expect(entriesEqUser).toHaveBeenCalledWith("user_id", "user-id");
+    expect(entriesEqLogDate).toHaveBeenCalledWith("log_date", "2024-01-01");
+    expect(itemsEq).toHaveBeenCalledWith("user_id", "user-id");
+    expect(itemsIn).toHaveBeenCalledWith("meal_entry_id", ["entry-1"]);
+    expect(body.data).toEqual([
+      {
+        id: "entry-1",
+        user_id: "user-id",
+        log_date: "2024-01-01",
+        meal_type: "meal_1",
+        items: [
+          { id: "item-1", user_id: "user-id", meal_entry_id: "entry-1", food_name: "chicken", item_order: 0 },
+        ],
+      },
+    ]);
+  });
+
   it("validates date range for daily_log_dates", async () => {
     mockGetCurrentUser.mockResolvedValue({ id: "user-id", email: "owner@example.com" });
 

--- a/src/app/api/client-data/route.ts
+++ b/src/app/api/client-data/route.ts
@@ -1,9 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient, getCurrentUser } from "@/lib/supabase/server";
 import { isValidDateParam } from "@/lib/utils/date";
+import type { MealEntry, MealEntryWithItems, MealItem } from "@/lib/supabase/types";
 
 const RESOURCES = [
   "daily_logs",
+  "meal_entries",
   "food_master",
   "menu_master",
   "predictions",
@@ -51,6 +53,48 @@ export async function GET(request: NextRequest) {
       .limit(200);
     if (error) return NextResponse.json({ error: error.message }, { status: 500 });
     return NextResponse.json({ data: data ?? [] });
+  }
+
+  if (resource === "meal_entries") {
+    const date = request.nextUrl.searchParams.get("date") ?? "";
+    if (!isValidDateParam(date)) {
+      return NextResponse.json({ error: "Invalid date" }, { status: 400 });
+    }
+
+    const { data: entries, error: entriesError } = await supabase
+      .from("meal_entries")
+      .select("*")
+      .eq("user_id", user.id)
+      .eq("log_date", date)
+      .order("created_at", { ascending: true });
+    if (entriesError) return NextResponse.json({ error: entriesError.message }, { status: 500 });
+
+    const mealEntries = (entries as MealEntry[] | null) ?? [];
+    if (mealEntries.length === 0) {
+      return NextResponse.json({ data: [] });
+    }
+
+    const { data: items, error: itemsError } = await supabase
+      .from("meal_items")
+      .select("*")
+      .eq("user_id", user.id)
+      .in("meal_entry_id", mealEntries.map((entry) => entry.id))
+      .order("item_order", { ascending: true });
+    if (itemsError) return NextResponse.json({ error: itemsError.message }, { status: 500 });
+
+    const itemsByEntry = new Map<string, MealItem[]>();
+    for (const item of ((items as MealItem[] | null) ?? [])) {
+      const list = itemsByEntry.get(item.meal_entry_id) ?? [];
+      list.push(item);
+      itemsByEntry.set(item.meal_entry_id, list);
+    }
+
+    const data: MealEntryWithItems[] = mealEntries.map((entry) => ({
+      ...entry,
+      items: itemsByEntry.get(entry.id) ?? [],
+    }));
+
+    return NextResponse.json({ data });
   }
 
   if (resource === "food_master") {

--- a/src/components/meal/MealLogger.test.ts
+++ b/src/components/meal/MealLogger.test.ts
@@ -1,4 +1,5 @@
 import {
+  buildMealItemInputs,
   buildNoteSaveValue,
   computeHasContent,
   computeHasDailyLogChanges,
@@ -61,8 +62,8 @@ describe("computeHasContent", () => {
     expect(computeHasContent({ ...base, note: null, noteTouched: true })).toBe(true);
   });
 
-  it("cartEverHadItems=true（カートを追加後に空にした）のとき true", () => {
-    expect(computeHasContent({ ...base, cartEverHadItems: true })).toBe(true);
+  it("cartEverHadItems=true でもカートが空なら保存対象なしとして false", () => {
+    expect(computeHasContent({ ...base, cartEverHadItems: true })).toBe(false);
   });
 
   // ── 特殊日タグ ──
@@ -142,13 +143,13 @@ describe("computeHasDailyLogChanges", () => {
     expect(computeHasDailyLogChanges({ ...base, weight: "70.0", weightTouched: true })).toBe(true);
   });
 
-  it("cartItems に食品あり → true", () => {
+  it("cartItems に食品があっても daily_logs 変更ではないため false", () => {
     const item = { kind: "regular" as const, food: { id: "test-id", name: "chicken", calories: 165, protein: 31, fat: 3.6, carbs: 0, category: null, created_at: null }, grams: 100 };
-    expect(computeHasDailyLogChanges({ ...base, cartItems: [item] })).toBe(true);
+    expect(computeHasDailyLogChanges({ ...base, cartItems: [item] })).toBe(false);
   });
 
-  it("cartEverHadItems=true → true (カートを追加後に空にした場合も null 送信が必要)", () => {
-    expect(computeHasDailyLogChanges({ ...base, cartEverHadItems: true })).toBe(true);
+  it("cartEverHadItems=true → false (明細削除は保存済み明細側で扱う)", () => {
+    expect(computeHasDailyLogChanges({ ...base, cartEverHadItems: true })).toBe(false);
   });
 
   it("noteTouched=true → true", () => {
@@ -201,6 +202,61 @@ describe("buildNoteSaveValue", () => {
 
   it("削除予定状態の場合は null を返す", () => {
     expect(buildNoteSaveValue(null, true)).toBeNull();
+  });
+});
+
+describe("buildMealItemInputs", () => {
+  it("food_master 由来のカート食品を保存用明細へ変換する", () => {
+    const item = {
+      kind: "regular" as const,
+      food: { id: "food-id", name: "chicken", calories: 165, protein: 31, fat: 3.6, carbs: 0, category: null, created_at: null },
+      grams: 150,
+    };
+
+    expect(buildMealItemInputs([item])).toEqual([
+      {
+        source_type: "food_master",
+        source_name: "chicken",
+        food_name: "chicken",
+        amount_g: 150,
+        calories_kcal: 248,
+        protein_g: 47,
+        fat_g: 5,
+        carbs_g: 0,
+        calories_per_100g: 165,
+        protein_per_100g: 31,
+        fat_per_100g: 3.6,
+        carbs_per_100g: 0,
+      },
+    ]);
+  });
+
+  it("一時食品は入力済み栄養値をそのまま保存用明細へ変換する", () => {
+    const item = {
+      kind: "temp" as const,
+      food: {
+        tempId: "temp-1",
+        name: "外食メニュー",
+        grams: 0,
+        calories: 700,
+        protein: 35,
+        fat: 20,
+        carbs: 80,
+      },
+    };
+
+    expect(buildMealItemInputs([item])).toEqual([
+      {
+        source_type: "temp",
+        source_name: "外食メニュー",
+        food_name: "外食メニュー",
+        amount_g: 0,
+        calories_kcal: 700,
+        protein_g: 35,
+        fat_g: 20,
+        carbs_g: 80,
+      },
+    ]);
   });
 });
 

--- a/src/components/meal/MealLogger.tsx
+++ b/src/components/meal/MealLogger.tsx
@@ -4,10 +4,14 @@ import { useState, useMemo, useEffect, useRef } from "react";
 import { Loader2, PenLine, X, Undo2, ChevronDown, Plus } from "lucide-react";
 import { Toast } from "@/components/ui/Toast";
 import { saveDailyLog } from "@/app/actions/saveDailyLog";
+import { addMealEntry } from "@/app/actions/mealEntries";
 import { FoodPicker } from "./FoodPicker";
-import { Cart, calcCartTotals } from "./Cart";
+import { Cart } from "./Cart";
 import type { CartItem, TempFoodItem } from "./Cart";
-import type { FoodMaster, DailyLog } from "@/lib/supabase/types";
+import { SavedMeals } from "./SavedMeals";
+import { MEAL_TYPE_LABELS, MEAL_TYPES } from "@/lib/domain/meals";
+import type { SaveMealItemInput } from "@/lib/domain/mealEntryPayload";
+import type { FoodMaster, DailyLog, MealType } from "@/lib/supabase/types";
 import { toJstDateStr } from "@/lib/utils/date";
 import {
   type DayTag,
@@ -25,6 +29,7 @@ import {
   type WorkMode,
 } from "@/lib/utils/trainingType";
 import { useDailyLogByDate, useDailyLogs } from "@/lib/hooks/useDailyLogs";
+import { useMealEntriesByDate } from "@/lib/hooks/useMealEntries";
 import { parseStrictNumber } from "@/lib/utils/parseNumber";
 
 type SaveStatus = "idle" | "saving" | "saved" | "error";
@@ -38,7 +43,7 @@ export interface HasContentInput {
   weight: string | null;          // null = 明示的クリア予定
   weightTouched: boolean;         // ユーザーが weight を操作したか（hydrate のみでは false）
   cartItems: CartItem[];
-  cartEverHadItems: boolean;      // カートに一度でもアイテムが追加されたか
+  cartEverHadItems: boolean;      // hydrate 上書き防止用: カートに一度でもアイテムが追加されたか
   note: string | null;            // null = 明示的クリア予定
   noteTouched: boolean;           // ユーザーが note を操作したか
   touchedTags: Set<DayTag>;
@@ -54,7 +59,6 @@ export function computeHasContent(input: HasContentInput): boolean {
     // 保存ボタンが有効にならず、不要な更新も送信されない。
     input.weightTouched ||
     input.cartItems.length > 0 ||
-    input.cartEverHadItems ||       // カートを空にした場合も null 送信のため有効化
     input.noteTouched ||
     input.touchedTags.size > 0 ||
     input.hadBowelMovementTouched || // touched なら null 送信も含め有効化
@@ -69,14 +73,52 @@ export function computeHasContent(input: HasContentInput): boolean {
 export function computeHasDailyLogChanges(input: HasContentInput): boolean {
   return (
     input.weightTouched ||
-    input.cartItems.length > 0 ||
-    input.cartEverHadItems ||
     input.noteTouched ||
     input.touchedTags.size > 0 ||
     input.hadBowelMovementTouched ||
     input.trainingTypeTouched ||
     input.workModeTouched
   );
+}
+
+function calcFoodNutrient(
+  food: FoodMaster,
+  grams: number,
+  key: keyof Pick<FoodMaster, "calories" | "protein" | "fat" | "carbs">
+): number {
+  return Math.round(((food[key] ?? 0) * grams) / 100);
+}
+
+export function buildMealItemInputs(cartItems: CartItem[]): SaveMealItemInput[] {
+  return cartItems.map((item) => {
+    if (item.kind === "regular") {
+      return {
+        source_type: "food_master",
+        source_name: item.food.name,
+        food_name: item.food.name,
+        amount_g: item.grams,
+        calories_kcal: calcFoodNutrient(item.food, item.grams, "calories"),
+        protein_g: calcFoodNutrient(item.food, item.grams, "protein"),
+        fat_g: calcFoodNutrient(item.food, item.grams, "fat"),
+        carbs_g: calcFoodNutrient(item.food, item.grams, "carbs"),
+        calories_per_100g: item.food.calories,
+        protein_per_100g: item.food.protein,
+        fat_per_100g: item.food.fat,
+        carbs_per_100g: item.food.carbs,
+      };
+    }
+
+    return {
+      source_type: "temp",
+      source_name: item.food.name,
+      food_name: item.food.name,
+      amount_g: item.food.grams,
+      calories_kcal: item.food.calories,
+      protein_g: item.food.protein,
+      fat_g: item.food.fat,
+      carbs_g: item.food.carbs,
+    };
+  });
 }
 
 export function hasDailyLogForDate(
@@ -94,7 +136,7 @@ export function hasDailyLogForDate(
 }
 
 function formIsPristine(input: HasContentInput): boolean {
-  return !computeHasContent(input);
+  return !computeHasContent(input) && !input.cartEverHadItems;
 }
 
 /**
@@ -142,7 +184,7 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
   const [note, setNote] = useState<string | null>("");
   const [noteTouched, setNoteTouched] = useState(false);
   const [cartItems, setCartItems] = useState<CartItem[]>([]);
-  // カートに一度でもアイテムが追加されたか（空カートでも null 送信させるためのフラグ）
+  // カートに一度でもアイテムが追加されたか（SWR hydrate で入力中状態を上書きしないためのフラグ）
   const [cartEverHadItems, setCartEverHadItems] = useState(false);
   const [tags, setTags] = useState<ReturnType<typeof emptyTagState>>(emptyTagState);
   // 明示的にトグルされたタグのみ追跡する（未操作タグは undefined として送り既存値を保持）
@@ -164,6 +206,7 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
 
   // 食品を追加セクションの開閉状態（初期: 非表示）
   const [foodPickerOpen, setFoodPickerOpen] = useState(false);
+  const [mealType, setMealType] = useState<MealType>("meal_1");
 
   const cachedDailyLog = useMemo(
     () => logs?.find((l) => l.log_date === date) ?? null,
@@ -174,6 +217,11 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
     data: fetchedDailyLog,
     isLoading: isDailyLogByDateLoading,
   } = useDailyLogByDate(date, shouldFetchDailyLogByDate);
+  const {
+    data: mealEntries,
+    isLoading: isMealEntriesLoading,
+    mutate: mutateMealEntries,
+  } = useMealEntriesByDate(date, date !== "");
 
   /**
    * 日付変更時にフォームを hydrate または空リセットする。
@@ -192,9 +240,10 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
     setWorkModeTouched(false);
     setTouchedTags(new Set());
 
-    // カートはマクロ値から復元不可のためリセット
+    // カートは「これから追加する食事」なので日付変更時にリセット
     setCartItems([]);
     setCartEverHadItems(false);
+    setMealType("meal_1");
 
     if (existingLog) {
       // 既存値をフォームへ表示（touched は立てない）
@@ -359,10 +408,9 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
         note, noteTouched, touchedTags,
         hadBowelMovementTouched, trainingTypeTouched, workModeTouched,
       });
+      const mealItemsToSave = buildMealItemInputs(cartItems);
 
       if (hasDailyLogChanges) {
-        const totals = calcCartTotals(cartItems);
-
         // 明示的にトグルされたタグのみペイロードに含める
         const tagPayload: Partial<Record<DayTag, boolean>> = {};
         for (const tag of touchedTags) {
@@ -376,11 +424,6 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
           weight:   weightTouched
             ? (weight === null   ? null   : parseStrictNumber(weight)   ?? undefined)
             : undefined,
-          // カートに一度でも追加後に空にした → null 送信（マクロをクリア）
-          calories: cartItems.length > 0 ? totals.calories : (cartEverHadItems ? null : undefined),
-          protein:  cartItems.length > 0 ? totals.protein  : (cartEverHadItems ? null : undefined),
-          fat:      cartItems.length > 0 ? totals.fat      : (cartEverHadItems ? null : undefined),
-          carbs:    cartItems.length > 0 ? totals.carbs    : (cartEverHadItems ? null : undefined),
           note:     buildNoteSaveValue(note, noteTouched),
           ...tagPayload,
           // ルール: touched=true → hadBowelMovement の値をそのまま送信
@@ -395,6 +438,22 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
 
         if (!result.ok) {
           console.error("[MealLogger] save error:", result.message);
+          setErrorMessage(result.message);
+          setStatus("error");
+          setTimeout(() => { setStatus("idle"); setErrorMessage(""); }, 5000);
+          return;
+        }
+      }
+
+      if (mealItemsToSave.length > 0) {
+        const result = await addMealEntry({
+          log_date: date,
+          meal_type: mealType,
+          items: mealItemsToSave,
+        });
+
+        if (!result.ok) {
+          console.error("[MealLogger] meal save error:", result.message);
           setErrorMessage(result.message);
           setStatus("error");
           setTimeout(() => { setStatus("idle"); setErrorMessage(""); }, 5000);
@@ -420,8 +479,10 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
       setTrainingTypeTouched(false);
       setWorkMode(null);
       setWorkModeTouched(false);
+      setMealType("meal_1");
       // SWR キャッシュを更新して次回 hydrate に最新ログを反映させる
       void mutateLogs();
+      void mutateMealEntries();
       setTimeout(() => setStatus("idle"), 2000);
       // 保存成功コールバック: Toast が少し見えてから modal / sheet を閉じる
       if (onSaveSuccess) setTimeout(onSaveSuccess, 800);
@@ -568,19 +629,25 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
         </div>
       </div>
 
-      {/* 既存ログのマクロ表示（カートで復元不可なため参照用に表示） */}
-      {hydratedLog && (hydratedLog.calories !== null || hydratedLog.protein !== null) && (
-        <div className="rounded-xl border border-amber-100 bg-amber-50 px-3 py-2 text-xs text-amber-700 dark:border-amber-700/40 dark:bg-amber-900/20 dark:text-amber-400">
-          <span className="font-semibold">記録済みマクロ:</span>{" "}
-          <div>
-            {hydratedLog.calories !== null && <span>{hydratedLog.calories} kcal</span>}
-            {hydratedLog.protein  !== null && <span> / P {hydratedLog.protein}g</span>}
-            {hydratedLog.fat      !== null && <span> / F {hydratedLog.fat}g</span>}
-            {hydratedLog.carbs    !== null && <span> / C {hydratedLog.carbs}g</span>}
+      {/* 保存済み食事明細 */}
+      <div className="min-w-0">
+        <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">保存済み食事</p>
+        <SavedMeals
+          entries={mealEntries}
+          isLoading={isMealEntriesLoading}
+          onChanged={() => {
+            void mutateMealEntries();
+            void mutateLogs();
+          }}
+        />
+        {!isMealEntriesLoading && mealEntries?.length === 0 && hydratedLog && (hydratedLog.calories !== null || hydratedLog.protein !== null) && (
+          <div className="mt-2 rounded-xl border border-amber-100 bg-amber-50 px-3 py-2 text-xs text-amber-700 dark:border-amber-700/40 dark:bg-amber-900/20 dark:text-amber-400">
+            <span className="font-semibold">記録済みマクロ:</span>{" "}
+            <span>{hydratedLog.calories ?? 0} kcal / P {hydratedLog.protein ?? 0}g F {hydratedLog.fat ?? 0}g C {hydratedLog.carbs ?? 0}g</span>
+            <div className="mt-0.5 text-amber-600">明細はまだ作成されていません。</div>
           </div>
-          <div className="mt-0.5 text-amber-600">（更新する場合はカートから追加）</div>
-        </div>
-      )}
+        )}
+      </div>
 
       {/* 特殊日タグ (is_cheat_day / is_refeed_day / is_eating_out / is_travel_day) */}
       <div className="min-w-0">
@@ -699,6 +766,26 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
 
         {foodPickerOpen && (
           <div className="flex flex-col gap-3">
+            <div>
+              <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-slate-400">追加先</p>
+              <div className="grid grid-cols-5 gap-1.5">
+                {MEAL_TYPES.map((type) => (
+                  <button
+                    key={type}
+                    type="button"
+                    aria-pressed={mealType === type}
+                    onClick={() => setMealType(type)}
+                    className={`rounded-lg border px-2 py-2 text-xs font-semibold transition-colors ${
+                      mealType === type
+                        ? "border-blue-500 bg-blue-600 text-white"
+                        : "border-slate-200 bg-white text-slate-500 hover:border-slate-300 hover:bg-slate-100 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
+                    }`}
+                  >
+                    {MEAL_TYPE_LABELS[type]}
+                  </button>
+                ))}
+              </div>
+            </div>
             <FoodPicker onAdd={addFood} onAddSet={addFromMenu} onAddTemp={addTempFood} />
             {cartItems.length > 0 && (
               <div>

--- a/src/components/meal/SavedMeals.tsx
+++ b/src/components/meal/SavedMeals.tsx
@@ -1,0 +1,287 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Save, Trash2 } from "lucide-react";
+import { deleteMealItem, updateMealItem } from "@/app/actions/mealEntries";
+import { MEAL_TYPE_LABELS } from "@/lib/domain/meals";
+import type { MealEntryWithItems, MealItem, MealType } from "@/lib/supabase/types";
+
+type EditState = {
+  amount_g: string;
+  calories_kcal: string;
+  protein_g: string;
+  fat_g: string;
+  carbs_g: string;
+};
+
+interface SavedMealsProps {
+  entries: MealEntryWithItems[] | undefined;
+  isLoading: boolean;
+  onChanged: () => void;
+}
+
+function formatValue(value: number | null): string {
+  return value === null ? "" : String(value);
+}
+
+function toEditState(item: MealItem): EditState {
+  return {
+    amount_g: formatValue(item.amount_g),
+    calories_kcal: formatValue(item.calories_kcal),
+    protein_g: formatValue(item.protein_g),
+    fat_g: formatValue(item.fat_g),
+    carbs_g: formatValue(item.carbs_g),
+  };
+}
+
+function parseNullableNonNegative(raw: string): number | null | typeof Number.NaN {
+  if (raw.trim() === "") return null;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) return Number.NaN;
+  return parsed;
+}
+
+function calcEntryTotals(entry: MealEntryWithItems) {
+  return entry.items.reduce(
+    (acc, item) => ({
+      calories: acc.calories + (item.calories_kcal ?? 0),
+      protein: acc.protein + (item.protein_g ?? 0),
+      fat: acc.fat + (item.fat_g ?? 0),
+      carbs: acc.carbs + (item.carbs_g ?? 0),
+    }),
+    { calories: 0, protein: 0, fat: 0, carbs: 0 }
+  );
+}
+
+export function SavedMeals({ entries, isLoading, onChanged }: SavedMealsProps) {
+  const [edits, setEdits] = useState<Record<string, EditState>>({});
+  const [busyItemId, setBusyItemId] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string>("");
+
+  const visibleEntries = useMemo(
+    () => (entries ?? []).filter((entry) => entry.items.length > 0),
+    [entries]
+  );
+
+  function getEdit(item: MealItem): EditState {
+    return edits[item.id] ?? toEditState(item);
+  }
+
+  function setEditField(item: MealItem, field: keyof EditState, value: string) {
+    const current = edits[item.id] ?? toEditState(item);
+    const next: EditState = { ...current, [field]: value };
+
+    if (
+      field === "amount_g"
+      && item.calories_per_100g !== null
+      && item.protein_per_100g !== null
+      && item.fat_per_100g !== null
+      && item.carbs_per_100g !== null
+    ) {
+      const grams = Number(value);
+      if (Number.isFinite(grams) && grams >= 0) {
+        next.calories_kcal = String(Math.round((item.calories_per_100g * grams) / 100));
+        next.protein_g = String(Math.round((item.protein_per_100g * grams) / 100));
+        next.fat_g = String(Math.round((item.fat_per_100g * grams) / 100));
+        next.carbs_g = String(Math.round((item.carbs_per_100g * grams) / 100));
+      }
+    }
+
+    setEdits((prev) => ({
+      ...prev,
+      [item.id]: next,
+    }));
+  }
+
+  async function handleUpdate(item: MealItem) {
+    const edit = getEdit(item);
+    const parsed = {
+      amount_g: parseNullableNonNegative(edit.amount_g),
+      calories_kcal: parseNullableNonNegative(edit.calories_kcal),
+      protein_g: parseNullableNonNegative(edit.protein_g),
+      fat_g: parseNullableNonNegative(edit.fat_g),
+      carbs_g: parseNullableNonNegative(edit.carbs_g),
+    };
+
+    if (Object.values(parsed).some((value) => Number.isNaN(value))) {
+      setErrorMessage("食事明細の数値は0以上で入力してください");
+      return;
+    }
+
+    setBusyItemId(item.id);
+    setErrorMessage("");
+    const result = await updateMealItem({ id: item.id, ...parsed });
+    setBusyItemId(null);
+
+    if (!result.ok) {
+      setErrorMessage(result.message);
+      return;
+    }
+
+    setEdits((prev) => {
+      const next = { ...prev };
+      delete next[item.id];
+      return next;
+    });
+    onChanged();
+  }
+
+  async function handleDelete(item: MealItem) {
+    setBusyItemId(item.id);
+    setErrorMessage("");
+    const result = await deleteMealItem(item.id);
+    setBusyItemId(null);
+
+    if (!result.ok) {
+      setErrorMessage(result.message);
+      return;
+    }
+
+    setEdits((prev) => {
+      const next = { ...prev };
+      delete next[item.id];
+      return next;
+    });
+    onChanged();
+  }
+
+  const inputCls =
+    "w-full min-w-0 rounded border border-slate-200 bg-white px-2 py-1.5 text-right text-xs text-slate-700 outline-none focus:border-blue-400 focus:ring-1 focus:ring-blue-100 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100";
+
+  if (isLoading && entries === undefined) {
+    return <p className="py-2 text-sm text-slate-400">保存済みの食事を読み込み中...</p>;
+  }
+
+  if (visibleEntries.length === 0) {
+    return <p className="py-2 text-sm text-slate-400">保存済みの食事明細はありません</p>;
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {errorMessage && (
+        <p className="rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-xs text-rose-600 dark:border-rose-700/50 dark:bg-rose-900/20 dark:text-rose-300">
+          {errorMessage}
+        </p>
+      )}
+
+      {visibleEntries.map((entry) => {
+        const totals = calcEntryTotals(entry);
+        const mealType = entry.meal_type as MealType;
+        return (
+          <section key={entry.id} className="rounded-xl border border-slate-200 bg-slate-50 p-3 dark:border-slate-700 dark:bg-slate-900/40">
+            <div className="mb-2 flex items-center justify-between gap-2">
+              <div className="min-w-0">
+                <p className="text-sm font-semibold text-slate-700 dark:text-slate-100">
+                  {MEAL_TYPE_LABELS[mealType] ?? entry.meal_type}
+                  {entry.title && <span className="ml-2 text-xs font-normal text-slate-400">{entry.title}</span>}
+                </p>
+                <p className="text-xs text-slate-400">
+                  {Math.round(totals.calories)} kcal / P {Math.round(totals.protein)}g F {Math.round(totals.fat)}g C {Math.round(totals.carbs)}g
+                </p>
+              </div>
+            </div>
+
+            <ul className="flex flex-col gap-2">
+              {entry.items.map((item) => {
+                const edit = getEdit(item);
+                const busy = busyItemId === item.id;
+                return (
+                  <li key={item.id} className="rounded-lg border border-slate-100 bg-white p-2 dark:border-slate-700 dark:bg-slate-900">
+                    <div className="mb-2 flex items-center justify-between gap-2">
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-medium text-slate-800 dark:text-slate-100">{item.food_name}</p>
+                        <p className="text-xs text-slate-400">
+                          {item.source_type === "legacy_total" ? "既存記録" : item.source_name ?? item.source_type}
+                        </p>
+                      </div>
+                      <div className="flex shrink-0 items-center gap-1">
+                        <button
+                          type="button"
+                          onClick={() => handleUpdate(item)}
+                          disabled={busy}
+                          aria-label={`${item.food_name}を更新`}
+                          title="明細を更新"
+                          className="rounded-md p-2 text-slate-400 transition-colors hover:bg-blue-50 hover:text-blue-600 disabled:opacity-50 dark:hover:bg-blue-900/30 dark:hover:text-blue-300"
+                        >
+                          <Save size={15} />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleDelete(item)}
+                          disabled={busy}
+                          aria-label={`${item.food_name}を削除`}
+                          title="明細を削除"
+                          className="rounded-md p-2 text-slate-400 transition-colors hover:bg-rose-50 hover:text-rose-600 disabled:opacity-50 dark:hover:bg-rose-900/30 dark:hover:text-rose-300"
+                        >
+                          <Trash2 size={15} />
+                        </button>
+                      </div>
+                    </div>
+
+                    <div className="grid grid-cols-5 gap-1.5">
+                      <label className="min-w-0">
+                        <span className="mb-1 block text-[10px] text-slate-400">g</span>
+                        <input
+                          type="number"
+                          inputMode="decimal"
+                          min={0}
+                          value={edit.amount_g}
+                          onChange={(e) => setEditField(item, "amount_g", e.target.value)}
+                          className={inputCls}
+                        />
+                      </label>
+                      <label className="min-w-0">
+                        <span className="mb-1 block text-[10px] text-slate-400">kcal</span>
+                        <input
+                          type="number"
+                          inputMode="decimal"
+                          min={0}
+                          value={edit.calories_kcal}
+                          onChange={(e) => setEditField(item, "calories_kcal", e.target.value)}
+                          className={inputCls}
+                        />
+                      </label>
+                      <label className="min-w-0">
+                        <span className="mb-1 block text-[10px] text-slate-400">P</span>
+                        <input
+                          type="number"
+                          inputMode="decimal"
+                          min={0}
+                          value={edit.protein_g}
+                          onChange={(e) => setEditField(item, "protein_g", e.target.value)}
+                          className={inputCls}
+                        />
+                      </label>
+                      <label className="min-w-0">
+                        <span className="mb-1 block text-[10px] text-slate-400">F</span>
+                        <input
+                          type="number"
+                          inputMode="decimal"
+                          min={0}
+                          value={edit.fat_g}
+                          onChange={(e) => setEditField(item, "fat_g", e.target.value)}
+                          className={inputCls}
+                        />
+                      </label>
+                      <label className="min-w-0">
+                        <span className="mb-1 block text-[10px] text-slate-400">C</span>
+                        <input
+                          type="number"
+                          inputMode="decimal"
+                          min={0}
+                          value={edit.carbs_g}
+                          onChange={(e) => setEditField(item, "carbs_g", e.target.value)}
+                          className={inputCls}
+                        />
+                      </label>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/lib/cache/revalidate.ts
+++ b/src/lib/cache/revalidate.ts
@@ -14,7 +14,7 @@
  *
  * ## ページ依存マップ (更新種別 → 影響ページ)
  *
- * daily_logs 更新:
+ * daily_logs / meal_entries / meal_items 更新:
  *   /             fetchDashboardDailyLogs / fetchEnrichedLogs
  *   /history      fetchWeightLogs
  *   /macro        fetchMacroDailyLogs

--- a/src/lib/domain/mealEntryPayload.test.ts
+++ b/src/lib/domain/mealEntryPayload.test.ts
@@ -1,0 +1,51 @@
+import { validateMealItemInput } from "./mealEntryPayload";
+
+describe("validateMealItemInput", () => {
+  it("有効な food_master 明細をDB insert形に正規化する", () => {
+    expect(validateMealItemInput({
+      source_type: "food_master",
+      source_name: " chicken ",
+      food_name: " chicken ",
+      amount_g: 120,
+      calories_kcal: 198,
+      protein_g: 37,
+      fat_g: 4,
+      carbs_g: 0,
+      calories_per_100g: 165,
+      protein_per_100g: 31,
+      fat_per_100g: 3.6,
+      carbs_per_100g: 0,
+    })).toEqual({
+      user_id: "",
+      meal_entry_id: "",
+      source_type: "food_master",
+      source_name: "chicken",
+      food_name: "chicken",
+      amount_g: 120,
+      calories_kcal: 198,
+      protein_g: 37,
+      fat_g: 4,
+      carbs_g: 0,
+      calories_per_100g: 165,
+      protein_per_100g: 31,
+      fat_per_100g: 3.6,
+      carbs_per_100g: 0,
+    });
+  });
+
+  it("空の食品名はエラーにする", () => {
+    expect(validateMealItemInput({
+      source_type: "temp",
+      food_name: " ",
+      calories_kcal: 100,
+    })).toEqual({ error: "食品名は1〜100文字で入力してください" });
+  });
+
+  it("負数の栄養値はエラーにする", () => {
+    expect(validateMealItemInput({
+      source_type: "temp",
+      food_name: "test",
+      calories_kcal: -1,
+    })).toEqual({ error: "食事明細の数値は0以上で入力してください" });
+  });
+});

--- a/src/lib/domain/mealEntryPayload.ts
+++ b/src/lib/domain/mealEntryPayload.ts
@@ -1,0 +1,76 @@
+import type { Database, MealItemSourceType } from "@/lib/supabase/types";
+
+type MealItemInsert = Database["public"]["Tables"]["meal_items"]["Insert"];
+
+const MEAL_ITEM_SOURCE_TYPES = ["food_master", "menu_master", "temp", "manual", "legacy_total"] as const satisfies readonly MealItemSourceType[];
+
+export type SaveMealItemInput = {
+  source_type: MealItemSourceType;
+  source_name?: string | null;
+  food_name: string;
+  amount_g?: number | null;
+  calories_kcal?: number | null;
+  protein_g?: number | null;
+  fat_g?: number | null;
+  carbs_g?: number | null;
+  calories_per_100g?: number | null;
+  protein_per_100g?: number | null;
+  fat_per_100g?: number | null;
+  carbs_per_100g?: number | null;
+};
+
+function isMealItemSourceType(value: string): value is MealItemSourceType {
+  return (MEAL_ITEM_SOURCE_TYPES as readonly string[]).includes(value);
+}
+
+function normalizeText(value: string | null | undefined): string | null {
+  const trimmed = value?.trim() ?? "";
+  return trimmed === "" ? null : trimmed;
+}
+
+function normalizeFoodName(value: string): string | null {
+  const trimmed = value.trim();
+  if (trimmed === "" || trimmed.length > 100) return null;
+  return trimmed;
+}
+
+function normalizeNullableNonNegative(value: number | null | undefined): number | null {
+  if (value === undefined || value === null) return null;
+  return Number.isFinite(value) && value >= 0 ? value : Number.NaN;
+}
+
+export function validateMealItemInput(item: SaveMealItemInput): MealItemInsert | { error: string } {
+  if (!isMealItemSourceType(item.source_type)) {
+    return { error: "食事明細の入力元が不正です" };
+  }
+
+  const foodName = normalizeFoodName(item.food_name);
+  if (foodName === null) {
+    return { error: "食品名は1〜100文字で入力してください" };
+  }
+
+  const normalized = {
+    amount_g: normalizeNullableNonNegative(item.amount_g),
+    calories_kcal: normalizeNullableNonNegative(item.calories_kcal),
+    protein_g: normalizeNullableNonNegative(item.protein_g),
+    fat_g: normalizeNullableNonNegative(item.fat_g),
+    carbs_g: normalizeNullableNonNegative(item.carbs_g),
+    calories_per_100g: normalizeNullableNonNegative(item.calories_per_100g),
+    protein_per_100g: normalizeNullableNonNegative(item.protein_per_100g),
+    fat_per_100g: normalizeNullableNonNegative(item.fat_per_100g),
+    carbs_per_100g: normalizeNullableNonNegative(item.carbs_per_100g),
+  };
+
+  if (Object.values(normalized).some((value) => Number.isNaN(value))) {
+    return { error: "食事明細の数値は0以上で入力してください" };
+  }
+
+  return {
+    user_id: "",
+    meal_entry_id: "",
+    source_type: item.source_type,
+    source_name: normalizeText(item.source_name),
+    food_name: foodName,
+    ...normalized,
+  };
+}

--- a/src/lib/domain/meals.ts
+++ b/src/lib/domain/meals.ts
@@ -1,0 +1,15 @@
+import type { MealType } from "@/lib/supabase/types";
+
+export const MEAL_TYPES = ["meal_1", "meal_2", "meal_3", "meal_4", "other"] as const satisfies readonly MealType[];
+
+export const MEAL_TYPE_LABELS: Record<MealType, string> = {
+  meal_1: "食事1",
+  meal_2: "食事2",
+  meal_3: "食事3",
+  meal_4: "食事4",
+  other: "その他",
+};
+
+export function isMealType(value: string): value is MealType {
+  return (MEAL_TYPES as readonly string[]).includes(value);
+}

--- a/src/lib/hooks/useMealEntries.ts
+++ b/src/lib/hooks/useMealEntries.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import useSWR from "swr";
+import { fetchClientData } from "@/lib/clientData/fetchJson";
+import type { MealEntryWithItems } from "@/lib/supabase/types";
+
+async function fetchMealEntriesByDate(date: string): Promise<MealEntryWithItems[]> {
+  return fetchClientData<MealEntryWithItems[]>(
+    `/api/client-data?resource=meal_entries&date=${encodeURIComponent(date)}`
+  );
+}
+
+export function useMealEntriesByDate(date: string, enabled: boolean) {
+  return useSWR<MealEntryWithItems[]>(
+    enabled ? ["meal_entries_by_date", date] : null,
+    () => fetchMealEntriesByDate(date),
+    {
+      revalidateOnFocus: false,
+    }
+  );
+}

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -449,6 +449,118 @@ export type Database = {
           },
         ]
       }
+      meal_entries: {
+        Row: {
+          created_at: string
+          id: string
+          log_date: string
+          meal_type: string
+          note: string | null
+          title: string | null
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          log_date: string
+          meal_type: string
+          note?: string | null
+          title?: string | null
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          log_date?: string
+          meal_type?: string
+          note?: string | null
+          title?: string | null
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "fk_meal_entries_daily_logs"
+            columns: ["user_id", "log_date"]
+            isOneToOne: false
+            referencedRelation: "daily_logs"
+            referencedColumns: ["user_id", "log_date"]
+          },
+        ]
+      }
+      meal_items: {
+        Row: {
+          amount_g: number | null
+          calories_kcal: number | null
+          calories_per_100g: number | null
+          carbs_g: number | null
+          carbs_per_100g: number | null
+          created_at: string
+          fat_g: number | null
+          fat_per_100g: number | null
+          food_name: string
+          id: string
+          item_order: number
+          meal_entry_id: string
+          protein_g: number | null
+          protein_per_100g: number | null
+          source_name: string | null
+          source_type: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          amount_g?: number | null
+          calories_kcal?: number | null
+          calories_per_100g?: number | null
+          carbs_g?: number | null
+          carbs_per_100g?: number | null
+          created_at?: string
+          fat_g?: number | null
+          fat_per_100g?: number | null
+          food_name: string
+          id?: string
+          item_order?: number
+          meal_entry_id: string
+          protein_g?: number | null
+          protein_per_100g?: number | null
+          source_name?: string | null
+          source_type: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          amount_g?: number | null
+          calories_kcal?: number | null
+          calories_per_100g?: number | null
+          carbs_g?: number | null
+          carbs_per_100g?: number | null
+          created_at?: string
+          fat_g?: number | null
+          fat_per_100g?: number | null
+          food_name?: string
+          id?: string
+          item_order?: number
+          meal_entry_id?: string
+          protein_g?: number | null
+          protein_per_100g?: number | null
+          source_name?: string | null
+          source_type?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "fk_meal_items_meal_entries"
+            columns: ["meal_entry_id", "user_id"]
+            isOneToOne: false
+            referencedRelation: "meal_entries"
+            referencedColumns: ["id", "user_id"]
+          },
+        ]
+      }
       menu_master: {
         Row: {
           created_at: string | null
@@ -717,10 +829,19 @@ export type GoogleHealthConnectionStatus = Database["private"]["Enums"]["google_
 
 export type FoodMaster  = OptionalUserId<Database["public"]["Tables"]["food_master"]["Row"]>;
 export type MenuMaster  = OptionalUserId<Database["public"]["Tables"]["menu_master"]["Row"]>;
+export type MealEntry   = Database["public"]["Tables"]["meal_entries"]["Row"];
+export type MealItem    = Database["public"]["Tables"]["meal_items"]["Row"];
 export type Setting     = OptionalUserId<Database["public"]["Tables"]["settings"]["Row"]>;
 export type Prediction  = Database["public"]["Tables"]["predictions"]["Row"];
 export type AnalyticsCache = Database["public"]["Tables"]["analytics_cache"]["Row"];
 export type CareerLog   = Database["public"]["Tables"]["career_logs"]["Row"];
+
+export type MealType = "meal_1" | "meal_2" | "meal_3" | "meal_4" | "other";
+export type MealItemSourceType = "food_master" | "menu_master" | "temp" | "manual" | "legacy_total";
+
+export type MealEntryWithItems = MealEntry & {
+  items: MealItem[];
+};
 
 /** menu_master.recipe JSONB の要素型 (旧版: {name, amount}) */
 export interface RecipeItem {

--- a/supabase/migrations/20260614000000_create_meal_detail_logs.sql
+++ b/supabase/migrations/20260614000000_create_meal_detail_logs.sql
@@ -1,0 +1,333 @@
+-- Create meal detail logs (#728)
+--
+-- meal_items becomes the source of truth for nutrition detail.
+-- daily_logs.calories/protein/fat/carbs are kept as projection values for
+-- existing Dashboard / Macro / TDEE / ML consumers.
+
+-- ── daily_logs FK prerequisite ──────────────────────────────────────────────
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+      FROM pg_constraint
+     WHERE conname = 'uq_daily_logs_user_id_log_date'
+       AND conrelid = 'daily_logs'::regclass
+  ) THEN
+    ALTER TABLE daily_logs
+      ADD CONSTRAINT uq_daily_logs_user_id_log_date UNIQUE (user_id, log_date);
+  END IF;
+END $$;
+
+-- ── meal_entries: one row per meal event ────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS meal_entries (
+  id         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id    UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  log_date   DATE        NOT NULL,
+  meal_type  TEXT        NOT NULL,
+  title      TEXT,
+  note       TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT uq_meal_entries_id_user_id UNIQUE (id, user_id),
+  CONSTRAINT fk_meal_entries_daily_logs
+    FOREIGN KEY (user_id, log_date)
+    REFERENCES daily_logs(user_id, log_date)
+    ON DELETE CASCADE,
+  CONSTRAINT chk_meal_entries_meal_type
+    CHECK (meal_type IN ('meal_1', 'meal_2', 'meal_3', 'meal_4', 'other'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_meal_entries_user_date
+  ON meal_entries(user_id, log_date);
+
+COMMENT ON TABLE meal_entries IS
+  '食事ログの食事単位。1行 = 1食事。daily_logs の日付に紐づく。';
+COMMENT ON COLUMN meal_entries.user_id IS 'Owner Supabase auth.users.id。';
+COMMENT ON COLUMN meal_entries.log_date IS '記録日 (JST)。daily_logs.log_date と同じ日付軸。';
+COMMENT ON COLUMN meal_entries.meal_type IS
+  '食事区分: meal_1 / meal_2 / meal_3 / meal_4 / other。';
+COMMENT ON COLUMN meal_entries.title IS '任意の食事名。';
+COMMENT ON COLUMN meal_entries.note IS '食事単位メモ。';
+
+-- ── meal_items: one row per food item ───────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS meal_items (
+  id                 UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id            UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  meal_entry_id      UUID        NOT NULL,
+  item_order         INTEGER     NOT NULL DEFAULT 0,
+  source_type        TEXT        NOT NULL,
+  source_name        TEXT,
+  food_name          TEXT        NOT NULL,
+  amount_g           NUMERIC,
+  calories_kcal      NUMERIC,
+  protein_g          NUMERIC,
+  fat_g              NUMERIC,
+  carbs_g            NUMERIC,
+  calories_per_100g  NUMERIC,
+  protein_per_100g   NUMERIC,
+  fat_per_100g       NUMERIC,
+  carbs_per_100g     NUMERIC,
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT fk_meal_items_meal_entries
+    FOREIGN KEY (meal_entry_id, user_id)
+    REFERENCES meal_entries(id, user_id)
+    ON DELETE CASCADE,
+  CONSTRAINT chk_meal_items_source_type
+    CHECK (source_type IN ('food_master', 'menu_master', 'temp', 'manual', 'legacy_total')),
+  CONSTRAINT chk_meal_items_item_order
+    CHECK (item_order >= 0),
+  CONSTRAINT chk_meal_items_amount_g
+    CHECK (amount_g IS NULL OR amount_g >= 0),
+  CONSTRAINT chk_meal_items_calories_kcal
+    CHECK (calories_kcal IS NULL OR calories_kcal >= 0),
+  CONSTRAINT chk_meal_items_protein_g
+    CHECK (protein_g IS NULL OR protein_g >= 0),
+  CONSTRAINT chk_meal_items_fat_g
+    CHECK (fat_g IS NULL OR fat_g >= 0),
+  CONSTRAINT chk_meal_items_carbs_g
+    CHECK (carbs_g IS NULL OR carbs_g >= 0),
+  CONSTRAINT chk_meal_items_calories_per_100g
+    CHECK (calories_per_100g IS NULL OR calories_per_100g >= 0),
+  CONSTRAINT chk_meal_items_protein_per_100g
+    CHECK (protein_per_100g IS NULL OR protein_per_100g >= 0),
+  CONSTRAINT chk_meal_items_fat_per_100g
+    CHECK (fat_per_100g IS NULL OR fat_per_100g >= 0),
+  CONSTRAINT chk_meal_items_carbs_per_100g
+    CHECK (carbs_per_100g IS NULL OR carbs_per_100g >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_meal_items_user_entry
+  ON meal_items(user_id, meal_entry_id);
+
+COMMENT ON TABLE meal_items IS
+  '食事ログの食品明細。daily_logs のカロリー/PFC集計の source of truth。';
+COMMENT ON COLUMN meal_items.source_type IS
+  '入力元: food_master / menu_master / temp / manual / legacy_total。';
+COMMENT ON COLUMN meal_items.source_name IS '元食品名・メニュー名。';
+COMMENT ON COLUMN meal_items.food_name IS '表示用食品名。';
+COMMENT ON COLUMN meal_items.amount_g IS '摂取量 (g)。詳細不明・手入力では NULL 可。';
+COMMENT ON COLUMN meal_items.calories_kcal IS 'この明細のカロリー (kcal)。';
+COMMENT ON COLUMN meal_items.protein_g IS 'この明細のタンパク質 (g)。';
+COMMENT ON COLUMN meal_items.fat_g IS 'この明細の脂質 (g)。';
+COMMENT ON COLUMN meal_items.carbs_g IS 'この明細の炭水化物 (g)。';
+COMMENT ON COLUMN meal_items.calories_per_100g IS '保存時点の100gあたりカロリー。';
+COMMENT ON COLUMN meal_items.protein_per_100g IS '保存時点の100gあたりタンパク質。';
+COMMENT ON COLUMN meal_items.fat_per_100g IS '保存時点の100gあたり脂質。';
+COMMENT ON COLUMN meal_items.carbs_per_100g IS '保存時点の100gあたり炭水化物。';
+
+-- ── updated_at triggers ─────────────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION set_updated_at_meal_entries()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at := NOW();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_set_updated_at_meal_entries ON meal_entries;
+CREATE TRIGGER trg_set_updated_at_meal_entries
+BEFORE UPDATE ON meal_entries
+FOR EACH ROW EXECUTE FUNCTION set_updated_at_meal_entries();
+
+CREATE OR REPLACE FUNCTION set_updated_at_meal_items()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at := NOW();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_set_updated_at_meal_items ON meal_items;
+CREATE TRIGGER trg_set_updated_at_meal_items
+BEFORE UPDATE ON meal_items
+FOR EACH ROW EXECUTE FUNCTION set_updated_at_meal_items();
+
+-- ── Projection sync to daily_logs ───────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION recalc_daily_log_nutrition(
+  p_user_id UUID,
+  p_log_date DATE
+) RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_item_count INTEGER;
+  v_calories   NUMERIC;
+  v_protein    NUMERIC;
+  v_fat        NUMERIC;
+  v_carbs      NUMERIC;
+BEGIN
+  SELECT
+    COUNT(mi.id)::INTEGER,
+    SUM(mi.calories_kcal),
+    SUM(mi.protein_g),
+    SUM(mi.fat_g),
+    SUM(mi.carbs_g)
+  INTO
+    v_item_count,
+    v_calories,
+    v_protein,
+    v_fat,
+    v_carbs
+  FROM meal_entries me
+  JOIN meal_items mi
+    ON mi.meal_entry_id = me.id
+   AND mi.user_id = me.user_id
+  WHERE me.user_id = p_user_id
+    AND me.log_date = p_log_date;
+
+  UPDATE daily_logs
+  SET
+    calories = CASE WHEN v_item_count = 0 THEN NULL ELSE COALESCE(v_calories, 0) END,
+    protein  = CASE WHEN v_item_count = 0 THEN NULL ELSE COALESCE(v_protein,  0) END,
+    fat      = CASE WHEN v_item_count = 0 THEN NULL ELSE COALESCE(v_fat,      0) END,
+    carbs    = CASE WHEN v_item_count = 0 THEN NULL ELSE COALESCE(v_carbs,    0) END
+  WHERE user_id = p_user_id
+    AND log_date = p_log_date;
+END;
+$$;
+
+COMMENT ON FUNCTION recalc_daily_log_nutrition(UUID, DATE) IS
+  'meal_items から対象日のカロリー/PFCを再計算し、daily_logs の projection 列へ同期する。';
+
+CREATE OR REPLACE FUNCTION sync_daily_log_nutrition_from_meal_item()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_old_log_date DATE;
+  v_new_log_date DATE;
+BEGIN
+  IF TG_OP IN ('UPDATE', 'DELETE') THEN
+    SELECT log_date INTO v_old_log_date
+      FROM meal_entries
+     WHERE id = OLD.meal_entry_id
+       AND user_id = OLD.user_id;
+
+    IF v_old_log_date IS NOT NULL THEN
+      PERFORM recalc_daily_log_nutrition(OLD.user_id, v_old_log_date);
+    END IF;
+  END IF;
+
+  IF TG_OP IN ('INSERT', 'UPDATE') THEN
+    SELECT log_date INTO v_new_log_date
+      FROM meal_entries
+     WHERE id = NEW.meal_entry_id
+       AND user_id = NEW.user_id;
+
+    IF v_new_log_date IS NOT NULL THEN
+      PERFORM recalc_daily_log_nutrition(NEW.user_id, v_new_log_date);
+    END IF;
+  END IF;
+
+  RETURN COALESCE(NEW, OLD);
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_sync_daily_log_nutrition_from_meal_item ON meal_items;
+CREATE TRIGGER trg_sync_daily_log_nutrition_from_meal_item
+AFTER INSERT OR UPDATE OR DELETE ON meal_items
+FOR EACH ROW EXECUTE FUNCTION sync_daily_log_nutrition_from_meal_item();
+
+-- ── RLS ─────────────────────────────────────────────────────────────────────
+
+ALTER TABLE meal_entries ENABLE ROW LEVEL SECURITY;
+ALTER TABLE meal_items ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "authenticated owner can select meal_entries" ON meal_entries;
+DROP POLICY IF EXISTS "authenticated owner can insert meal_entries" ON meal_entries;
+DROP POLICY IF EXISTS "authenticated owner can update meal_entries" ON meal_entries;
+DROP POLICY IF EXISTS "authenticated owner can delete meal_entries" ON meal_entries;
+
+CREATE POLICY "authenticated owner can select meal_entries"
+  ON meal_entries FOR SELECT TO authenticated USING (user_id = auth.uid());
+CREATE POLICY "authenticated owner can insert meal_entries"
+  ON meal_entries FOR INSERT TO authenticated WITH CHECK (user_id = auth.uid());
+CREATE POLICY "authenticated owner can update meal_entries"
+  ON meal_entries FOR UPDATE TO authenticated USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+CREATE POLICY "authenticated owner can delete meal_entries"
+  ON meal_entries FOR DELETE TO authenticated USING (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "authenticated owner can select meal_items" ON meal_items;
+DROP POLICY IF EXISTS "authenticated owner can insert meal_items" ON meal_items;
+DROP POLICY IF EXISTS "authenticated owner can update meal_items" ON meal_items;
+DROP POLICY IF EXISTS "authenticated owner can delete meal_items" ON meal_items;
+
+CREATE POLICY "authenticated owner can select meal_items"
+  ON meal_items FOR SELECT TO authenticated USING (user_id = auth.uid());
+CREATE POLICY "authenticated owner can insert meal_items"
+  ON meal_items FOR INSERT TO authenticated WITH CHECK (user_id = auth.uid());
+CREATE POLICY "authenticated owner can update meal_items"
+  ON meal_items FOR UPDATE TO authenticated USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+CREATE POLICY "authenticated owner can delete meal_items"
+  ON meal_items FOR DELETE TO authenticated USING (user_id = auth.uid());
+
+-- ── Backfill existing nutrition totals as legacy detail ─────────────────────
+
+INSERT INTO meal_entries (user_id, log_date, meal_type, title)
+SELECT dl.user_id, dl.log_date, 'other', '既存記録'
+  FROM daily_logs dl
+ WHERE dl.user_id IS NOT NULL
+   AND (
+     dl.calories IS NOT NULL
+     OR dl.protein IS NOT NULL
+     OR dl.fat IS NOT NULL
+     OR dl.carbs IS NOT NULL
+   )
+   AND NOT EXISTS (
+     SELECT 1
+       FROM meal_entries me
+      WHERE me.user_id = dl.user_id
+        AND me.log_date = dl.log_date
+        AND me.meal_type = 'other'
+        AND me.title = '既存記録'
+   );
+
+INSERT INTO meal_items (
+  user_id,
+  meal_entry_id,
+  item_order,
+  source_type,
+  food_name,
+  calories_kcal,
+  protein_g,
+  fat_g,
+  carbs_g
+)
+SELECT
+  dl.user_id,
+  me.id,
+  0,
+  'legacy_total',
+  '既存食事記録（詳細不明）',
+  dl.calories,
+  dl.protein,
+  dl.fat,
+  dl.carbs
+FROM daily_logs dl
+JOIN meal_entries me
+  ON me.user_id = dl.user_id
+ AND me.log_date = dl.log_date
+ AND me.meal_type = 'other'
+ AND me.title = '既存記録'
+WHERE dl.user_id IS NOT NULL
+  AND (
+    dl.calories IS NOT NULL
+    OR dl.protein IS NOT NULL
+    OR dl.fat IS NOT NULL
+    OR dl.carbs IS NOT NULL
+  )
+  AND NOT EXISTS (
+    SELECT 1
+      FROM meal_items mi
+     WHERE mi.user_id = me.user_id
+       AND mi.meal_entry_id = me.id
+       AND mi.source_type = 'legacy_total'
+  );


### PR DESCRIPTION
## 概要

食事記録を合計値だけではなく、食事単位・食材単位の明細として保存できるようにしました。
`meal_type` は `meal_1` / `meal_2` / `meal_3` / `meal_4` / `other` を使用します。

Closes #728

## 変更内容

- `meal_entries` / `meal_items` テーブルを追加
- `meal_items` の insert/update/delete から `daily_logs.calories` / `protein` / `fat` / `carbs` を再計算するDB関数・トリガーを追加
- 既存の合計値だけの食事ログを `legacy_total` 明細としてバックフィル
- MealLoggerで保存済み食事明細の表示・編集・削除に対応
- カート保存を `daily_logs` への合計値直接保存から、食事明細保存へ変更
- 日付別の食事明細取得API、SWR hook、型定義、テストを追加
- Supabase migration をリモートDBへ適用済み

## 判断理由

既存のDashboard / Macro / TDEE / ML処理が `daily_logs` の集計列を参照しているため、`daily_logs` のカロリー/PFC列は削除せず、食事明細から同期されるprojectionとして維持しました。
食品DBの変更で過去ログが変わらないよう、保存時点の栄養値スナップショットも `meal_items` に保持します。

## 検証結果

- `npm test -- --runTestsByPath src/components/meal/MealLogger.test.ts src/lib/domain/mealEntryPayload.test.ts src/app/api/client-data/route.test.ts`
- `npm run lint`
- `npm run build`
- `npx supabase db push`
- `npx supabase migration list` で `20260614000000` の Local / Remote 一致を確認

## 補足

CSVへの食事明細export/import、食事テンプレート、昨日と同じ食事コピーは今回のスコープ外です。
