### PR TITLE
食事ログをMEAL別アコーディオンUIに改善する

### DIFF
--- a/src/components/meal/MealLogger.test.ts
+++ b/src/components/meal/MealLogger.test.ts
@@ -1,6 +1,7 @@
 import {
   buildMealItemInputs,
   buildNoteSaveValue,
+  calcMealEntriesTotals,
   computeHasContent,
   computeHasDailyLogChanges,
   hasDailyLogForDate,
@@ -257,6 +258,83 @@ describe("buildMealItemInputs", () => {
         carbs_g: 80,
       },
     ]);
+  });
+});
+
+describe("calcMealEntriesTotals", () => {
+  it("保存済み食事明細のカロリー/PFCと品数を合計する", () => {
+    const entries = [
+      {
+        id: "entry-1",
+        user_id: "user-1",
+        log_date: "2026-06-14",
+        meal_type: "meal_1",
+        title: null,
+        note: null,
+        created_at: "2026-06-14T00:00:00Z",
+        updated_at: "2026-06-14T00:00:00Z",
+        items: [
+          {
+            id: "item-1",
+            user_id: "user-1",
+            meal_entry_id: "entry-1",
+            item_order: 0,
+            source_type: "food_master",
+            source_name: "chicken",
+            food_name: "chicken",
+            amount_g: 100,
+            calories_kcal: 165,
+            protein_g: 31,
+            fat_g: 4,
+            carbs_g: 0,
+            calories_per_100g: 165,
+            protein_per_100g: 31,
+            fat_per_100g: 4,
+            carbs_per_100g: 0,
+            created_at: "2026-06-14T00:00:00Z",
+            updated_at: "2026-06-14T00:00:00Z",
+          },
+          {
+            id: "item-2",
+            user_id: "user-1",
+            meal_entry_id: "entry-1",
+            item_order: 1,
+            source_type: "temp",
+            source_name: "外食メニュー",
+            food_name: "外食メニュー",
+            amount_g: null,
+            calories_kcal: 500,
+            protein_g: 20,
+            fat_g: 15,
+            carbs_g: 60,
+            calories_per_100g: null,
+            protein_per_100g: null,
+            fat_per_100g: null,
+            carbs_per_100g: null,
+            created_at: "2026-06-14T00:00:00Z",
+            updated_at: "2026-06-14T00:00:00Z",
+          },
+        ],
+      },
+    ];
+
+    expect(calcMealEntriesTotals(entries)).toEqual({
+      calories: 665,
+      protein: 51,
+      fat: 19,
+      carbs: 60,
+      itemCount: 2,
+    });
+  });
+
+  it("明細がない場合は0を返す", () => {
+    expect(calcMealEntriesTotals(undefined)).toEqual({
+      calories: 0,
+      protein: 0,
+      fat: 0,
+      carbs: 0,
+      itemCount: 0,
+    });
   });
 });
 

--- a/src/components/meal/MealLogger.tsx
+++ b/src/components/meal/MealLogger.tsx
@@ -910,6 +910,16 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
               {isActive && (
                 <div className="flex flex-col gap-3 border-t border-slate-100 px-3 py-3 dark:border-slate-700">
                   <div>
+                    <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-slate-400">食品追加</p>
+                    <FoodPicker onAdd={addFood} onAddSet={addFromMenu} onAddTemp={addTempFood} />
+                  </div>
+                  {cartItems.length > 0 && (
+                    <div>
+                      <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-slate-400">カート</p>
+                      <Cart items={cartItems} onChange={setCartItems} />
+                    </div>
+                  )}
+                  <div>
                     <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-slate-400">保存済み</p>
                     <SavedMeals
                       entries={mealEntries === undefined ? undefined : entriesForType}
@@ -920,13 +930,6 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
                       }}
                     />
                   </div>
-                  <FoodPicker onAdd={addFood} onAddSet={addFromMenu} onAddTemp={addTempFood} />
-                  {cartItems.length > 0 && (
-                    <div>
-                      <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-slate-400">カート</p>
-                      <Cart items={cartItems} onChange={setCartItems} />
-                    </div>
-                  )}
                   <div className="rounded-lg bg-blue-50 px-3 py-2 text-xs text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">
                     <span className="font-semibold">MEAL小計:</span>{" "}
                     {formatNutritionValue(displayedMealTotals.calories)} kcal / P {formatNutritionValue(displayedMealTotals.protein)}g F {formatNutritionValue(displayedMealTotals.fat)}g C {formatNutritionValue(displayedMealTotals.carbs)}g

--- a/src/components/meal/MealLogger.tsx
+++ b/src/components/meal/MealLogger.tsx
@@ -1,17 +1,17 @@
 "use client";
 
 import { useState, useMemo, useEffect, useRef } from "react";
-import { Loader2, PenLine, X, Undo2, ChevronDown, Plus } from "lucide-react";
+import { Loader2, PenLine, X, Undo2, ChevronDown } from "lucide-react";
 import { Toast } from "@/components/ui/Toast";
 import { saveDailyLog } from "@/app/actions/saveDailyLog";
 import { addMealEntry } from "@/app/actions/mealEntries";
 import { FoodPicker } from "./FoodPicker";
-import { Cart } from "./Cart";
+import { Cart, calcCartTotals } from "./Cart";
 import type { CartItem, TempFoodItem } from "./Cart";
 import { SavedMeals } from "./SavedMeals";
 import { MEAL_TYPE_LABELS, MEAL_TYPES } from "@/lib/domain/meals";
 import type { SaveMealItemInput } from "@/lib/domain/mealEntryPayload";
-import type { FoodMaster, DailyLog, MealType } from "@/lib/supabase/types";
+import type { FoodMaster, DailyLog, MealEntryWithItems, MealType } from "@/lib/supabase/types";
 import { toJstDateStr } from "@/lib/utils/date";
 import {
   type DayTag,
@@ -155,6 +155,70 @@ export function buildNoteSaveValue(
   return note;
 }
 
+export type NutritionTotals = {
+  calories: number;
+  protein: number;
+  fat: number;
+  carbs: number;
+  itemCount: number;
+};
+
+const emptyNutritionTotals = (): NutritionTotals => ({
+  calories: 0,
+  protein: 0,
+  fat: 0,
+  carbs: 0,
+  itemCount: 0,
+});
+
+export function calcMealEntriesTotals(entries: MealEntryWithItems[] | undefined): NutritionTotals {
+  return (entries ?? []).reduce<NutritionTotals>((entryAcc, entry) => {
+    return entry.items.reduce<NutritionTotals>(
+      (itemAcc, item) => ({
+        calories: itemAcc.calories + (item.calories_kcal ?? 0),
+        protein: itemAcc.protein + (item.protein_g ?? 0),
+        fat: itemAcc.fat + (item.fat_g ?? 0),
+        carbs: itemAcc.carbs + (item.carbs_g ?? 0),
+        itemCount: itemAcc.itemCount + 1,
+      }),
+      entryAcc
+    );
+  }, emptyNutritionTotals());
+}
+
+function calcDailyLogTotals(log: DailyLog | null): NutritionTotals {
+  if (!log) return emptyNutritionTotals();
+  return {
+    calories: log.calories ?? 0,
+    protein: log.protein ?? 0,
+    fat: log.fat ?? 0,
+    carbs: log.carbs ?? 0,
+    itemCount: 0,
+  };
+}
+
+function addNutritionTotals(left: NutritionTotals, right: NutritionTotals): NutritionTotals {
+  return {
+    calories: left.calories + right.calories,
+    protein: left.protein + right.protein,
+    fat: left.fat + right.fat,
+    carbs: left.carbs + right.carbs,
+    itemCount: left.itemCount + right.itemCount,
+  };
+}
+
+function cartTotalsToNutrition(cartItems: CartItem[]): NutritionTotals {
+  const totals = calcCartTotals(cartItems);
+  return {
+    ...totals,
+    itemCount: cartItems.length,
+  };
+}
+
+function formatNutritionValue(value: number): string {
+  return Number.isInteger(value) ? value.toLocaleString() : value.toLocaleString(undefined, { maximumFractionDigits: 1 });
+}
+
 interface MealLoggerProps {
   sidebar?: boolean; // サイドバーモード: 常時展開・縦レイアウト
   /** サイドバーモード時のみ有効。false にすると内部ヘッダー行を非表示にする */
@@ -204,9 +268,8 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
   const [workMode, setWorkMode] = useState<WorkMode | null>(null);
   const [workModeTouched, setWorkModeTouched] = useState(false);
 
-  // 食品を追加セクションの開閉状態（初期: 非表示）
-  const [foodPickerOpen, setFoodPickerOpen] = useState(false);
-  const [mealType, setMealType] = useState<MealType>("meal_1");
+  // MEAL アコーディオンの開閉状態（null = 初期表示・日付変更後・保存後は全て閉じる）
+  const [activeMealType, setActiveMealType] = useState<MealType | null>(null);
 
   const cachedDailyLog = useMemo(
     () => logs?.find((l) => l.log_date === date) ?? null,
@@ -243,7 +306,7 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
     // カートは「これから追加する食事」なので日付変更時にリセット
     setCartItems([]);
     setCartEverHadItems(false);
-    setMealType("meal_1");
+    setActiveMealType(null);
 
     if (existingLog) {
       // 既存値をフォームへ表示（touched は立てない）
@@ -396,6 +459,12 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
     setCartItems((prev) => [...prev, { kind: "temp" as const, food }]);
   }
 
+  function toggleMealAccordion(type: MealType) {
+    setCartItems([]);
+    setCartEverHadItems(false);
+    setActiveMealType((prev) => (prev === type ? null : type));
+  }
+
   async function handleSave() {
     // 二重送信ガード: saving 中は呼び出し元（ボタン以外の経路含む）からの再起動を防ぐ
     if (status === "saving") return;
@@ -446,9 +515,16 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
       }
 
       if (mealItemsToSave.length > 0) {
+        if (!activeMealType) {
+          setErrorMessage("追加先のMEALを開いてから保存してください");
+          setStatus("error");
+          setTimeout(() => { setStatus("idle"); setErrorMessage(""); }, 5000);
+          return;
+        }
+
         const result = await addMealEntry({
           log_date: date,
-          meal_type: mealType,
+          meal_type: activeMealType,
           items: mealItemsToSave,
         });
 
@@ -479,7 +555,7 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
       setTrainingTypeTouched(false);
       setWorkMode(null);
       setWorkModeTouched(false);
-      setMealType("meal_1");
+      setActiveMealType(null);
       // SWR キャッシュを更新して次回 hydrate に最新ログを反映させる
       void mutateLogs();
       void mutateMealEntries();
@@ -501,6 +577,30 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
     note, noteTouched, touchedTags,
     hadBowelMovementTouched, trainingTypeTouched, workModeTouched,
   });
+
+  const mealEntriesByType = useMemo(() => {
+    const map = new Map<MealType, MealEntryWithItems[]>();
+    for (const type of MEAL_TYPES) {
+      map.set(type, (mealEntries ?? []).filter((entry) => entry.meal_type === type));
+    }
+    return map;
+  }, [mealEntries]);
+
+  const savedDailyTotals = useMemo(() => calcMealEntriesTotals(mealEntries), [mealEntries]);
+  const cartTotals = useMemo(() => cartTotalsToNutrition(cartItems), [cartItems]);
+  const legacyDailyTotals = calcDailyLogTotals(hydratedLog);
+  const dailyTotalsBase = savedDailyTotals.itemCount > 0 ? savedDailyTotals : legacyDailyTotals;
+  const displayedDailyTotals = cartItems.length > 0
+    ? addNutritionTotals(dailyTotalsBase, cartTotals)
+    : dailyTotalsBase;
+  const isLegacyDailyTotals =
+    savedDailyTotals.itemCount === 0 &&
+    hydratedLog !== null &&
+    (hydratedLog.calories !== null ||
+      hydratedLog.protein !== null ||
+      hydratedLog.fat !== null ||
+      hydratedLog.carbs !== null);
+  const includesDraftCartTotals = cartItems.length > 0;
 
   const inputCls =
     "w-full min-w-0 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2.5 text-sm text-slate-800 outline-none transition-colors focus:border-blue-400 focus:bg-white focus:ring-2 focus:ring-blue-100 placeholder:text-slate-400 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus:bg-slate-800 dark:focus:border-blue-500 dark:focus:ring-blue-900/40";
@@ -629,26 +729,6 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
         </div>
       </div>
 
-      {/* 保存済み食事明細 */}
-      <div className="min-w-0">
-        <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">保存済み食事</p>
-        <SavedMeals
-          entries={mealEntries}
-          isLoading={isMealEntriesLoading}
-          onChanged={() => {
-            void mutateMealEntries();
-            void mutateLogs();
-          }}
-        />
-        {!isMealEntriesLoading && mealEntries?.length === 0 && hydratedLog && (hydratedLog.calories !== null || hydratedLog.protein !== null) && (
-          <div className="mt-2 rounded-xl border border-amber-100 bg-amber-50 px-3 py-2 text-xs text-amber-700 dark:border-amber-700/40 dark:bg-amber-900/20 dark:text-amber-400">
-            <span className="font-semibold">記録済みマクロ:</span>{" "}
-            <span>{hydratedLog.calories ?? 0} kcal / P {hydratedLog.protein ?? 0}g F {hydratedLog.fat ?? 0}g C {hydratedLog.carbs ?? 0}g</span>
-            <div className="mt-0.5 text-amber-600">明細はまだ作成されていません。</div>
-          </div>
-        )}
-      </div>
-
       {/* 特殊日タグ (is_cheat_day / is_refeed_day / is_eating_out / is_travel_day) */}
       <div className="min-w-0">
         <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">特殊日</p>
@@ -742,67 +822,120 @@ export function MealLogger({ sidebar = false, showHeader = true, onSaveSuccess }
         </div>
       </div>
 
-      {/* 食品を追加（開閉式） */}
+      {/* 1日のカロリー/PFCサマリー */}
+      <div className="min-w-0 rounded-xl border border-slate-100 bg-slate-50 px-3 py-3 dark:border-slate-700 dark:bg-slate-800/60">
+        <div className="mb-2 flex items-center justify-between gap-2">
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">1日のサマリー</p>
+          {(isLegacyDailyTotals || includesDraftCartTotals) && (
+            <span className="rounded-full bg-white px-2 py-0.5 text-[10px] font-semibold text-slate-400 dark:bg-slate-900 dark:text-slate-500">
+              {includesDraftCartTotals ? "入力中含む" : "既存マクロ"}
+            </span>
+          )}
+        </div>
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+          <div className="rounded-lg bg-white px-3 py-2 dark:bg-slate-900">
+            <p className="text-[10px] font-semibold uppercase tracking-wide text-slate-400">カロリー</p>
+            <p className="mt-1 text-lg font-semibold text-slate-800 dark:text-slate-100">
+              {formatNutritionValue(displayedDailyTotals.calories)}
+              <span className="ml-1 text-xs font-medium text-slate-400">kcal</span>
+            </p>
+          </div>
+          <div className="rounded-lg bg-white px-3 py-2 dark:bg-slate-900">
+            <p className="text-[10px] font-semibold uppercase tracking-wide text-slate-400">P</p>
+            <p className="mt-1 text-lg font-semibold text-slate-800 dark:text-slate-100">
+              {formatNutritionValue(displayedDailyTotals.protein)}
+              <span className="ml-1 text-xs font-medium text-slate-400">g</span>
+            </p>
+          </div>
+          <div className="rounded-lg bg-white px-3 py-2 dark:bg-slate-900">
+            <p className="text-[10px] font-semibold uppercase tracking-wide text-slate-400">F</p>
+            <p className="mt-1 text-lg font-semibold text-slate-800 dark:text-slate-100">
+              {formatNutritionValue(displayedDailyTotals.fat)}
+              <span className="ml-1 text-xs font-medium text-slate-400">g</span>
+            </p>
+          </div>
+          <div className="rounded-lg bg-white px-3 py-2 dark:bg-slate-900">
+            <p className="text-[10px] font-semibold uppercase tracking-wide text-slate-400">C</p>
+            <p className="mt-1 text-lg font-semibold text-slate-800 dark:text-slate-100">
+              {formatNutritionValue(displayedDailyTotals.carbs)}
+              <span className="ml-1 text-xs font-medium text-slate-400">g</span>
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* MEAL 1〜4 / Other アコーディオン */}
       <div className="flex flex-col gap-2">
-        <button
-          type="button"
-          onClick={() => setFoodPickerOpen((v) => !v)}
-          className="flex w-full items-center justify-between rounded-xl border border-dashed border-slate-200 bg-slate-50 px-3 py-2.5 transition-colors hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-800/60 dark:hover:bg-slate-700/60"
-        >
-          <span className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-            <Plus size={13} />
-            食品を追加
-            {cartItems.length > 0 && !foodPickerOpen && (
-              <span className="ml-1 rounded-full bg-blue-100 px-1.5 py-0.5 text-[10px] font-semibold text-blue-600 dark:bg-blue-900/40 dark:text-blue-400">
-                {cartItems.length}品
-              </span>
-            )}
-          </span>
-          <ChevronDown
-            size={15}
-            className={`text-slate-400 transition-transform duration-200 dark:text-slate-500 ${foodPickerOpen ? "rotate-180" : ""}`}
-          />
-        </button>
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">食事</p>
+        {MEAL_TYPES.map((type) => {
+          const entriesForType = mealEntriesByType.get(type) ?? [];
+          const savedMealTotals = calcMealEntriesTotals(entriesForType);
+          const isActive = activeMealType === type;
+          const isMealEntriesPending = isMealEntriesLoading && mealEntries === undefined;
+          const displayedMealTotals = isActive && cartItems.length > 0
+            ? addNutritionTotals(savedMealTotals, cartTotals)
+            : savedMealTotals;
 
-        {foodPickerOpen && (
-          <div className="flex flex-col gap-3">
-            <div>
-              <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-slate-400">追加先</p>
-              <div className="grid grid-cols-5 gap-1.5">
-                {MEAL_TYPES.map((type) => (
-                  <button
-                    key={type}
-                    type="button"
-                    aria-pressed={mealType === type}
-                    onClick={() => setMealType(type)}
-                    className={`rounded-lg border px-2 py-2 text-xs font-semibold transition-colors ${
-                      mealType === type
-                        ? "border-blue-500 bg-blue-600 text-white"
-                        : "border-slate-200 bg-white text-slate-500 hover:border-slate-300 hover:bg-slate-100 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
-                    }`}
-                  >
+          return (
+            <div key={type} className="overflow-hidden rounded-xl border border-slate-100 bg-white dark:border-slate-700 dark:bg-slate-900">
+              <button
+                type="button"
+                onClick={() => toggleMealAccordion(type)}
+                aria-expanded={isActive}
+                className="flex w-full items-center justify-between gap-3 px-3 py-3 text-left transition-colors hover:bg-slate-50 dark:hover:bg-slate-800"
+              >
+                <span className="min-w-0">
+                  <span className="block text-sm font-semibold text-slate-800 dark:text-slate-100">
                     {MEAL_TYPE_LABELS[type]}
-                  </button>
-                ))}
-              </div>
-            </div>
-            <FoodPicker onAdd={addFood} onAddSet={addFromMenu} onAddTemp={addTempFood} />
-            {cartItems.length > 0 && (
-              <div>
-                <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-slate-400">カート</p>
-                <Cart items={cartItems} onChange={setCartItems} />
-              </div>
-            )}
-          </div>
-        )}
+                  </span>
+                  <span className="mt-0.5 block text-xs text-slate-400">
+                    {isMealEntriesPending
+                      ? "読み込み中..."
+                      : displayedMealTotals.itemCount > 0
+                      ? `${displayedMealTotals.itemCount}品 / ${formatNutritionValue(displayedMealTotals.calories)} kcal`
+                      : "食品なし"}
+                  </span>
+                </span>
+                <span className="flex shrink-0 items-center gap-2 text-xs text-slate-400">
+                  <span className="hidden sm:inline">
+                    P {formatNutritionValue(displayedMealTotals.protein)}g / F {formatNutritionValue(displayedMealTotals.fat)}g / C {formatNutritionValue(displayedMealTotals.carbs)}g
+                  </span>
+                  <ChevronDown
+                    size={16}
+                    className={`transition-transform duration-200 ${isActive ? "rotate-180" : ""}`}
+                  />
+                </span>
+              </button>
 
-        {/* カート（閉じているときも品数があれば表示） */}
-        {!foodPickerOpen && cartItems.length > 0 && (
-          <div>
-            <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-slate-400">カート</p>
-            <Cart items={cartItems} onChange={setCartItems} />
-          </div>
-        )}
+              {isActive && (
+                <div className="flex flex-col gap-3 border-t border-slate-100 px-3 py-3 dark:border-slate-700">
+                  <div>
+                    <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-slate-400">保存済み</p>
+                    <SavedMeals
+                      entries={mealEntries === undefined ? undefined : entriesForType}
+                      isLoading={isMealEntriesLoading}
+                      onChanged={() => {
+                        void mutateMealEntries();
+                        void mutateLogs();
+                      }}
+                    />
+                  </div>
+                  <FoodPicker onAdd={addFood} onAddSet={addFromMenu} onAddTemp={addTempFood} />
+                  {cartItems.length > 0 && (
+                    <div>
+                      <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-slate-400">カート</p>
+                      <Cart items={cartItems} onChange={setCartItems} />
+                    </div>
+                  )}
+                  <div className="rounded-lg bg-blue-50 px-3 py-2 text-xs text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">
+                    <span className="font-semibold">MEAL小計:</span>{" "}
+                    {formatNutritionValue(displayedMealTotals.calories)} kcal / P {formatNutritionValue(displayedMealTotals.protein)}g F {formatNutritionValue(displayedMealTotals.fat)}g C {formatNutritionValue(displayedMealTotals.carbs)}g
+                  </div>
+                </div>
+              )}
+            </div>
+          );
+        })}
       </div>
 
       {/* 保存ボタン */}

--- a/src/components/meal/SavedMeals.tsx
+++ b/src/components/meal/SavedMeals.tsx
@@ -3,8 +3,7 @@
 import { useMemo, useState } from "react";
 import { Save, Trash2 } from "lucide-react";
 import { deleteMealItem, updateMealItem } from "@/app/actions/mealEntries";
-import { MEAL_TYPE_LABELS } from "@/lib/domain/meals";
-import type { MealEntryWithItems, MealItem, MealType } from "@/lib/supabase/types";
+import type { MealEntryWithItems, MealItem } from "@/lib/supabase/types";
 
 type EditState = {
   amount_g: string;
@@ -41,25 +40,13 @@ function parseNullableNonNegative(raw: string): number | null | typeof Number.Na
   return parsed;
 }
 
-function calcEntryTotals(entry: MealEntryWithItems) {
-  return entry.items.reduce(
-    (acc, item) => ({
-      calories: acc.calories + (item.calories_kcal ?? 0),
-      protein: acc.protein + (item.protein_g ?? 0),
-      fat: acc.fat + (item.fat_g ?? 0),
-      carbs: acc.carbs + (item.carbs_g ?? 0),
-    }),
-    { calories: 0, protein: 0, fat: 0, carbs: 0 }
-  );
-}
-
 export function SavedMeals({ entries, isLoading, onChanged }: SavedMealsProps) {
   const [edits, setEdits] = useState<Record<string, EditState>>({});
   const [busyItemId, setBusyItemId] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string>("");
 
-  const visibleEntries = useMemo(
-    () => (entries ?? []).filter((entry) => entry.items.length > 0),
+  const visibleItems = useMemo(
+    () => (entries ?? []).flatMap((entry) => entry.items),
     [entries]
   );
 
@@ -152,8 +139,8 @@ export function SavedMeals({ entries, isLoading, onChanged }: SavedMealsProps) {
     return <p className="py-2 text-sm text-slate-400">保存済みの食事を読み込み中...</p>;
   }
 
-  if (visibleEntries.length === 0) {
-    return <p className="py-2 text-sm text-slate-400">保存済みの食事明細はありません</p>;
+  if (visibleItems.length === 0) {
+    return <p className="py-2 text-sm text-slate-400">食品なし</p>;
   }
 
   return (
@@ -164,124 +151,104 @@ export function SavedMeals({ entries, isLoading, onChanged }: SavedMealsProps) {
         </p>
       )}
 
-      {visibleEntries.map((entry) => {
-        const totals = calcEntryTotals(entry);
-        const mealType = entry.meal_type as MealType;
-        return (
-          <section key={entry.id} className="rounded-xl border border-slate-200 bg-slate-50 p-3 dark:border-slate-700 dark:bg-slate-900/40">
-            <div className="mb-2 flex items-center justify-between gap-2">
-              <div className="min-w-0">
-                <p className="text-sm font-semibold text-slate-700 dark:text-slate-100">
-                  {MEAL_TYPE_LABELS[mealType] ?? entry.meal_type}
-                  {entry.title && <span className="ml-2 text-xs font-normal text-slate-400">{entry.title}</span>}
-                </p>
-                <p className="text-xs text-slate-400">
-                  {Math.round(totals.calories)} kcal / P {Math.round(totals.protein)}g F {Math.round(totals.fat)}g C {Math.round(totals.carbs)}g
-                </p>
+      <ul className="flex flex-col gap-2">
+        {visibleItems.map((item) => {
+          const edit = getEdit(item);
+          const busy = busyItemId === item.id;
+          return (
+            <li key={item.id} className="rounded-lg border border-slate-100 bg-white p-2 dark:border-slate-700 dark:bg-slate-900">
+              <div className="mb-2 flex items-center justify-between gap-2">
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium text-slate-800 dark:text-slate-100">{item.food_name}</p>
+                  <p className="text-xs text-slate-400">
+                    {item.source_type === "legacy_total" ? "既存記録" : item.source_name ?? item.source_type}
+                  </p>
+                </div>
+                <div className="flex shrink-0 items-center gap-1">
+                  <button
+                    type="button"
+                    onClick={() => handleUpdate(item)}
+                    disabled={busy}
+                    aria-label={`${item.food_name}を更新`}
+                    title="明細を更新"
+                    className="rounded-md p-2 text-slate-400 transition-colors hover:bg-blue-50 hover:text-blue-600 disabled:opacity-50 dark:hover:bg-blue-900/30 dark:hover:text-blue-300"
+                  >
+                    <Save size={15} />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleDelete(item)}
+                    disabled={busy}
+                    aria-label={`${item.food_name}を削除`}
+                    title="明細を削除"
+                    className="rounded-md p-2 text-slate-400 transition-colors hover:bg-rose-50 hover:text-rose-600 disabled:opacity-50 dark:hover:bg-rose-900/30 dark:hover:text-rose-300"
+                  >
+                    <Trash2 size={15} />
+                  </button>
+                </div>
               </div>
-            </div>
 
-            <ul className="flex flex-col gap-2">
-              {entry.items.map((item) => {
-                const edit = getEdit(item);
-                const busy = busyItemId === item.id;
-                return (
-                  <li key={item.id} className="rounded-lg border border-slate-100 bg-white p-2 dark:border-slate-700 dark:bg-slate-900">
-                    <div className="mb-2 flex items-center justify-between gap-2">
-                      <div className="min-w-0">
-                        <p className="truncate text-sm font-medium text-slate-800 dark:text-slate-100">{item.food_name}</p>
-                        <p className="text-xs text-slate-400">
-                          {item.source_type === "legacy_total" ? "既存記録" : item.source_name ?? item.source_type}
-                        </p>
-                      </div>
-                      <div className="flex shrink-0 items-center gap-1">
-                        <button
-                          type="button"
-                          onClick={() => handleUpdate(item)}
-                          disabled={busy}
-                          aria-label={`${item.food_name}を更新`}
-                          title="明細を更新"
-                          className="rounded-md p-2 text-slate-400 transition-colors hover:bg-blue-50 hover:text-blue-600 disabled:opacity-50 dark:hover:bg-blue-900/30 dark:hover:text-blue-300"
-                        >
-                          <Save size={15} />
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => handleDelete(item)}
-                          disabled={busy}
-                          aria-label={`${item.food_name}を削除`}
-                          title="明細を削除"
-                          className="rounded-md p-2 text-slate-400 transition-colors hover:bg-rose-50 hover:text-rose-600 disabled:opacity-50 dark:hover:bg-rose-900/30 dark:hover:text-rose-300"
-                        >
-                          <Trash2 size={15} />
-                        </button>
-                      </div>
-                    </div>
-
-                    <div className="grid grid-cols-5 gap-1.5">
-                      <label className="min-w-0">
-                        <span className="mb-1 block text-[10px] text-slate-400">g</span>
-                        <input
-                          type="number"
-                          inputMode="decimal"
-                          min={0}
-                          value={edit.amount_g}
-                          onChange={(e) => setEditField(item, "amount_g", e.target.value)}
-                          className={inputCls}
-                        />
-                      </label>
-                      <label className="min-w-0">
-                        <span className="mb-1 block text-[10px] text-slate-400">kcal</span>
-                        <input
-                          type="number"
-                          inputMode="decimal"
-                          min={0}
-                          value={edit.calories_kcal}
-                          onChange={(e) => setEditField(item, "calories_kcal", e.target.value)}
-                          className={inputCls}
-                        />
-                      </label>
-                      <label className="min-w-0">
-                        <span className="mb-1 block text-[10px] text-slate-400">P</span>
-                        <input
-                          type="number"
-                          inputMode="decimal"
-                          min={0}
-                          value={edit.protein_g}
-                          onChange={(e) => setEditField(item, "protein_g", e.target.value)}
-                          className={inputCls}
-                        />
-                      </label>
-                      <label className="min-w-0">
-                        <span className="mb-1 block text-[10px] text-slate-400">F</span>
-                        <input
-                          type="number"
-                          inputMode="decimal"
-                          min={0}
-                          value={edit.fat_g}
-                          onChange={(e) => setEditField(item, "fat_g", e.target.value)}
-                          className={inputCls}
-                        />
-                      </label>
-                      <label className="min-w-0">
-                        <span className="mb-1 block text-[10px] text-slate-400">C</span>
-                        <input
-                          type="number"
-                          inputMode="decimal"
-                          min={0}
-                          value={edit.carbs_g}
-                          onChange={(e) => setEditField(item, "carbs_g", e.target.value)}
-                          className={inputCls}
-                        />
-                      </label>
-                    </div>
-                  </li>
-                );
-              })}
-            </ul>
-          </section>
-        );
-      })}
+              <div className="grid grid-cols-5 gap-1.5">
+                <label className="min-w-0">
+                  <span className="mb-1 block text-[10px] text-slate-400">g</span>
+                  <input
+                    type="number"
+                    inputMode="decimal"
+                    min={0}
+                    value={edit.amount_g}
+                    onChange={(e) => setEditField(item, "amount_g", e.target.value)}
+                    className={inputCls}
+                  />
+                </label>
+                <label className="min-w-0">
+                  <span className="mb-1 block text-[10px] text-slate-400">kcal</span>
+                  <input
+                    type="number"
+                    inputMode="decimal"
+                    min={0}
+                    value={edit.calories_kcal}
+                    onChange={(e) => setEditField(item, "calories_kcal", e.target.value)}
+                    className={inputCls}
+                  />
+                </label>
+                <label className="min-w-0">
+                  <span className="mb-1 block text-[10px] text-slate-400">P</span>
+                  <input
+                    type="number"
+                    inputMode="decimal"
+                    min={0}
+                    value={edit.protein_g}
+                    onChange={(e) => setEditField(item, "protein_g", e.target.value)}
+                    className={inputCls}
+                  />
+                </label>
+                <label className="min-w-0">
+                  <span className="mb-1 block text-[10px] text-slate-400">F</span>
+                  <input
+                    type="number"
+                    inputMode="decimal"
+                    min={0}
+                    value={edit.fat_g}
+                    onChange={(e) => setEditField(item, "fat_g", e.target.value)}
+                    className={inputCls}
+                  />
+                </label>
+                <label className="min-w-0">
+                  <span className="mb-1 block text-[10px] text-slate-400">C</span>
+                  <input
+                    type="number"
+                    inputMode="decimal"
+                    min={0}
+                    value={edit.carbs_g}
+                    onChange={(e) => setEditField(item, "carbs_g", e.target.value)}
+                    className={inputCls}
+                  />
+                </label>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
     </div>
   );
 }

--- a/src/components/meal/SavedMeals.tsx
+++ b/src/components/meal/SavedMeals.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { Save, Trash2 } from "lucide-react";
+import { RefreshCw, Trash2 } from "lucide-react";
 import { deleteMealItem, updateMealItem } from "@/app/actions/mealEntries";
 import type { MealEntryWithItems, MealItem } from "@/lib/supabase/types";
 
@@ -38,6 +38,23 @@ function parseNullableNonNegative(raw: string): number | null | typeof Number.Na
   const parsed = Number(raw);
   if (!Number.isFinite(parsed) || parsed < 0) return Number.NaN;
   return parsed;
+}
+
+function getSourceLabel(item: MealItem): string | null {
+  if (item.source_name && item.source_name !== item.food_name) return item.source_name;
+
+  switch (item.source_type) {
+    case "legacy_total":
+      return "既存記録";
+    case "temp":
+      return "一時食品";
+    case "manual":
+      return "手入力";
+    case "menu_master":
+      return "メニュー";
+    default:
+      return null;
+  }
 }
 
 export function SavedMeals({ entries, isLoading, onChanged }: SavedMealsProps) {
@@ -155,14 +172,13 @@ export function SavedMeals({ entries, isLoading, onChanged }: SavedMealsProps) {
         {visibleItems.map((item) => {
           const edit = getEdit(item);
           const busy = busyItemId === item.id;
+          const sourceLabel = getSourceLabel(item);
           return (
             <li key={item.id} className="rounded-lg border border-slate-100 bg-white p-2 dark:border-slate-700 dark:bg-slate-900">
               <div className="mb-2 flex items-center justify-between gap-2">
                 <div className="min-w-0">
                   <p className="truncate text-sm font-medium text-slate-800 dark:text-slate-100">{item.food_name}</p>
-                  <p className="text-xs text-slate-400">
-                    {item.source_type === "legacy_total" ? "既存記録" : item.source_name ?? item.source_type}
-                  </p>
+                  {sourceLabel && <p className="text-xs text-slate-400">{sourceLabel}</p>}
                 </div>
                 <div className="flex shrink-0 items-center gap-1">
                   <button
@@ -173,7 +189,7 @@ export function SavedMeals({ entries, isLoading, onChanged }: SavedMealsProps) {
                     title="明細を更新"
                     className="rounded-md p-2 text-slate-400 transition-colors hover:bg-blue-50 hover:text-blue-600 disabled:opacity-50 dark:hover:bg-blue-900/30 dark:hover:text-blue-300"
                   >
-                    <Save size={15} />
+                    <RefreshCw size={15} className={busy ? "animate-spin" : ""} />
                   </button>
                   <button
                     type="button"

--- a/src/lib/domain/meals.test.ts
+++ b/src/lib/domain/meals.test.ts
@@ -1,0 +1,14 @@
+import { MEAL_TYPE_LABELS, MEAL_TYPES } from "./meals";
+
+describe("meal labels", () => {
+  it("MEAL 1〜4 / Other の表示ラベルを返す", () => {
+    expect(MEAL_TYPES).toEqual(["meal_1", "meal_2", "meal_3", "meal_4", "other"]);
+    expect(MEAL_TYPE_LABELS).toEqual({
+      meal_1: "MEAL 1",
+      meal_2: "MEAL 2",
+      meal_3: "MEAL 3",
+      meal_4: "MEAL 4",
+      other: "Other",
+    });
+  });
+});

--- a/src/lib/domain/meals.ts
+++ b/src/lib/domain/meals.ts
@@ -3,11 +3,11 @@ import type { MealType } from "@/lib/supabase/types";
 export const MEAL_TYPES = ["meal_1", "meal_2", "meal_3", "meal_4", "other"] as const satisfies readonly MealType[];
 
 export const MEAL_TYPE_LABELS: Record<MealType, string> = {
-  meal_1: "食事1",
-  meal_2: "食事2",
-  meal_3: "食事3",
-  meal_4: "食事4",
-  other: "その他",
+  meal_1: "MEAL 1",
+  meal_2: "MEAL 2",
+  meal_3: "MEAL 3",
+  meal_4: "MEAL 4",
+  other: "Other",
 };
 
 export function isMealType(value: string): value is MealType {


### PR DESCRIPTION
## 概要
食事ログ入力UIを、既存アプリの日本語寄りUIに合わせつつ MEAL 1〜4 / Other の縦並びアコーディオン構成へ変更します。

## 変更内容
- 食事区分ラベルを `MEAL 1` / `MEAL 2` / `MEAL 3` / `MEAL 4` / `Other` に変更
- MealLogger 内の表示順を以下に整理
  - 日付・体重・メモ
  - 特殊日・コンディション・トレーニング・仕事モード
  - 1日のカロリー/PFCサマリー
  - MEAL 1〜4 / Other の縦並びアコーディオン
  - 保存ボタン
- 初期表示・日付変更後・保存後は全 MEAL を閉じる状態に変更
- 各 MEAL 内で保存済み食品、食品追加、カート、MEAL小計を表示
- 食品がない空表示を `食品なし` に統一
- MEALラベルと食事明細合計計算のテストを追加

## 判断理由
- 追加先を横並びボタンで選ぶ方式ではなく、開いている MEAL を追加先にすることで、入力対象が明確になります。
- 日次サマリーは保存済み明細を基本にし、明細がない既存ログでは `daily_logs` のカロリー/PFCをフォールバック表示します。
- DBスキーマと `meal_type` の値は #728 の設計を維持し、今回はUI/UX改善に限定します。

## 検証結果
- `npm test -- --runTestsByPath src/components/meal/MealLogger.test.ts src/lib/domain/meals.test.ts`
- `npm run lint`
- `npm run build`

## 補足
- このPRは #729（食事明細ログ実装）の上に積む差分です。#729 マージ後に base を `main` へ変更してください。

Closes #730