### PR TITLE
[codex] 食事ログのカートを合計カロリー降順で表示

### DIFF
--- a/src/components/meal/Cart.test.ts
+++ b/src/components/meal/Cart.test.ts
@@ -1,4 +1,14 @@
-import { normalizeGrams } from "./Cart";
+import { normalizeGrams, sortCartItemsByCalories } from "./Cart";
+import type { CartItem } from "./Cart";
+import type { FoodMaster } from "@/lib/supabase/types";
+
+function regularItem(name: string, calories: number, grams: number): CartItem {
+  return {
+    kind: "regular",
+    food: { name, calories, protein: 0, fat: 0, carbs: 0 } as FoodMaster,
+    grams,
+  };
+}
 
 describe("normalizeGrams", () => {
   // ── 空文字 / 不正入力 → fallback に戻す ───────────────────────────────────
@@ -67,5 +77,57 @@ describe("normalizeGrams", () => {
 
   it("全消し後に未入力のまま blur した場合は元の値に戻る", () => {
     expect(normalizeGrams("", 100)).toBe(100);
+  });
+});
+
+describe("sortCartItemsByCalories", () => {
+  it("数量・量を反映した合計カロリーの降順で並べる", () => {
+    const items: CartItem[] = [
+      regularItem("低カロリー食品", 100, 100),
+      regularItem("高カロリー食品", 200, 250),
+      { kind: "temp", food: { tempId: "temp-1", name: "一時食品", grams: 200, calories: 400, protein: 0, fat: 0, carbs: 0 } },
+      regularItem("中カロリー食品", 150, 200),
+    ];
+
+    expect(sortCartItemsByCalories(items).map((item) => item.food.name)).toEqual([
+      "高カロリー食品",
+      "一時食品",
+      "中カロリー食品",
+      "低カロリー食品",
+    ]);
+    expect(items.map((item) => item.food.name)).toEqual([
+      "低カロリー食品",
+      "高カロリー食品",
+      "一時食品",
+      "中カロリー食品",
+    ]);
+  });
+
+  it("量の変更後の合計カロリーに応じて並び順を更新する", () => {
+    const before = [
+      regularItem("食品A", 200, 100),
+      regularItem("食品B", 150, 100),
+    ];
+    const after = [
+      regularItem("食品A", 200, 50),
+      regularItem("食品B", 150, 100),
+    ];
+
+    expect(sortCartItemsByCalories(before).map((item) => item.food.name)).toEqual(["食品A", "食品B"]);
+    expect(sortCartItemsByCalories(after).map((item) => item.food.name)).toEqual(["食品B", "食品A"]);
+  });
+
+  it("合計カロリーが同じ商品は元のカート順を維持する", () => {
+    const items = [
+      regularItem("先に追加した食品", 200, 100),
+      { kind: "temp" as const, food: { tempId: "temp-1", name: "次に追加した食品", grams: 100, calories: 200, protein: 0, fat: 0, carbs: 0 } },
+      regularItem("低カロリー食品", 100, 100),
+    ];
+
+    expect(sortCartItemsByCalories(items).map((item) => item.food.name)).toEqual([
+      "先に追加した食品",
+      "次に追加した食品",
+      "低カロリー食品",
+    ]);
   });
 });

--- a/src/components/meal/Cart.tsx
+++ b/src/components/meal/Cart.tsx
@@ -38,6 +38,31 @@ function calcNutrient(food: FoodMaster, grams: number, key: keyof Pick<FoodMaste
   return Math.round(((food[key] ?? 0) * grams) / 100);
 }
 
+export function calcCartItemCalories(item: CartItem): number {
+  if (item.kind === "regular") {
+    return calcNutrient(item.food, item.grams, "calories");
+  }
+  return item.food.calories;
+}
+
+interface IndexedCartItem {
+  item: CartItem;
+  index: number;
+}
+
+function sortCartItemEntriesByCalories(items: CartItem[]): IndexedCartItem[] {
+  return items
+    .map((item, index) => ({ item, index }))
+    .sort((a, b) => {
+      const calorieDifference = calcCartItemCalories(b.item) - calcCartItemCalories(a.item);
+      return calorieDifference || a.index - b.index;
+    });
+}
+
+export function sortCartItemsByCalories(items: CartItem[]): CartItem[] {
+  return sortCartItemEntriesByCalories(items).map(({ item }) => item);
+}
+
 export function calcCartTotals(items: CartItem[]) {
   return items.reduce(
     (acc, item) => {
@@ -81,6 +106,7 @@ export function normalizeGrams(raw: string, fallback: number): number {
 
 export function Cart({ items, onChange }: CartProps) {
   const totals = calcCartTotals(items);
+  const sortedItems = sortCartItemEntriesByCalories(items);
 
   // 編集中の grams を string で一時保持する（food.name → string）。
   // キーに index ではなく food.name（通常食品は cart 内で一意）を使うことで、
@@ -135,7 +161,7 @@ export function Cart({ items, onChange }: CartProps) {
   return (
     <div className="flex flex-col gap-3">
       <ul className="flex flex-col gap-2">
-        {items.map((item, i) => {
+        {sortedItems.map(({ item, index }) => {
           if (item.kind === "regular") {
             return (
               <li key={`regular-${item.food.name}`} className="flex items-center gap-2 rounded-lg border border-gray-100 bg-white px-3 py-2 dark:border-slate-700 dark:bg-slate-900">
@@ -156,13 +182,13 @@ export function Cart({ items, onChange }: CartProps) {
                     max={9999}
                     value={item.food.name in editingGrams ? editingGrams[item.food.name] : item.grams}
                     onChange={(e) => handleGramsChange(item.food.name, e.target.value)}
-                    onBlur={() => handleGramsBlur(i, item.food.name)}
+                    onBlur={() => handleGramsBlur(index, item.food.name)}
                     className="w-20 rounded border border-gray-200 px-2 py-2.5 text-right text-sm outline-none focus:border-blue-400 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
                   />
                   <span className="text-xs text-gray-400">g</span>
                 </div>
                 <button
-                  onClick={() => remove(i)}
+                  onClick={() => remove(index)}
                   className="ml-1 p-2 text-gray-300 hover:text-rose-500 dark:text-slate-600 dark:hover:text-rose-400"
                   aria-label="削除"
                 >
@@ -188,7 +214,7 @@ export function Cart({ items, onChange }: CartProps) {
                   </p>
                 </div>
                 <button
-                  onClick={() => remove(i)}
+                  onClick={() => remove(index)}
                   className="ml-1 p-2 text-gray-300 hover:text-rose-500 dark:text-slate-600 dark:hover:text-rose-400"
                   aria-label="削除"
                 >


### PR DESCRIPTION
## 概要
食事ログのカートを、数量・量を反映した商品ごとの合計カロリーが高い順に表示します。

## 変更内容
- 通常食品は100gあたりのカロリーと入力量で表示順を判定
- カートの表示時だけを安定ソートし、保存用の配列順は維持
- グラム編集・削除では元の配列インデックスを使い、既存の操作を維持
- 降順表示、量変更後の再ソート、同値時の順序維持をテスト

## 判断理由
食事全体への影響が大きい商品を上部に表示しつつ、保存データやカート合計値への影響を避けるため、表示用の並び替えに限定しています。

## 検証結果
- npm test -- Cart.test.ts
- npm run lint -- src/components/meal/Cart.tsx src/components/meal/Cart.test.ts
- git diff --check

Closes #736